### PR TITLE
Make StartMenu auto-run user-toggleable

### DIFF
--- a/apps/src/server/UserSettings.h
+++ b/apps/src/server/UserSettings.h
@@ -20,12 +20,13 @@ struct UserSettings {
     int volumePercent = 20;
     Scenario::EnumType defaultScenario = Scenario::EnumType::Sandbox;
     StartMenuIdleAction startMenuIdleAction = StartMenuIdleAction::ClockScenario;
+    bool startMenuAutoRun = false;
     TrainingSpec trainingSpec;
     EvolutionConfig evolutionConfig;
     MutationConfig mutationConfig;
     TrainingResumePolicy trainingResumePolicy = TrainingResumePolicy::WarmFromBest;
 
-    using serialize = zpp::bits::members<8>;
+    using serialize = zpp::bits::members<9>;
 };
 
 void from_json(const nlohmann::json& j, UserSettings& settings);

--- a/apps/src/server/tests/UserSettings_test.cpp
+++ b/apps/src/server/tests/UserSettings_test.cpp
@@ -36,12 +36,14 @@ TEST(UserSettingsTest, MissingFileLoadsDefaultsAndWritesFile)
     EXPECT_EQ(inMemory.timezoneIndex, 2);
     EXPECT_EQ(inMemory.volumePercent, 20);
     EXPECT_EQ(inMemory.defaultScenario, Scenario::EnumType::Sandbox);
+    EXPECT_FALSE(inMemory.startMenuAutoRun);
     EXPECT_EQ(inMemory.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 
     const UserSettings fromDisk = readUserSettingsFromDisk(settingsPath);
     EXPECT_EQ(fromDisk.timezoneIndex, 2);
     EXPECT_EQ(fromDisk.volumePercent, 20);
     EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Sandbox);
+    EXPECT_FALSE(fromDisk.startMenuAutoRun);
     EXPECT_EQ(fromDisk.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 }
 
@@ -59,6 +61,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
                 .volumePercent = 999,
                 .defaultScenario = Scenario::EnumType::Clock,
                 .startMenuIdleAction = StartMenuIdleAction::ClockScenario,
+                .startMenuAutoRun = true,
                 .trainingSpec = {},
                 .evolutionConfig = {},
                 .mutationConfig = {},
@@ -77,6 +80,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(response.value().settings.timezoneIndex, 0);
     EXPECT_EQ(response.value().settings.volumePercent, 100);
     EXPECT_EQ(response.value().settings.defaultScenario, Scenario::EnumType::Clock);
+    EXPECT_TRUE(response.value().settings.startMenuAutoRun);
     EXPECT_EQ(response.value().settings.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 
     const std::filesystem::path settingsPath = fixture.testDataDir / "user_settings.json";
@@ -84,6 +88,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(fromDisk.timezoneIndex, 0);
     EXPECT_EQ(fromDisk.volumePercent, 100);
     EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Clock);
+    EXPECT_TRUE(fromDisk.startMenuAutoRun);
     EXPECT_EQ(fromDisk.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 }
 
@@ -98,6 +103,7 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
                 .volumePercent = 65,
                 .defaultScenario = Scenario::EnumType::Clock,
                 .startMenuIdleAction = StartMenuIdleAction::ClockScenario,
+                .startMenuAutoRun = true,
                 .trainingSpec = {},
                 .evolutionConfig = {},
                 .mutationConfig = {},
@@ -122,6 +128,7 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
     EXPECT_EQ(response.value().settings.timezoneIndex, 2);
     EXPECT_EQ(response.value().settings.volumePercent, 20);
     EXPECT_EQ(response.value().settings.defaultScenario, Scenario::EnumType::Sandbox);
+    EXPECT_FALSE(response.value().settings.startMenuAutoRun);
     EXPECT_EQ(response.value().settings.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 
     const std::filesystem::path settingsPath = fixture.testDataDir / "user_settings.json";
@@ -129,5 +136,6 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
     EXPECT_EQ(fromDisk.timezoneIndex, 2);
     EXPECT_EQ(fromDisk.volumePercent, 20);
     EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Sandbox);
+    EXPECT_FALSE(fromDisk.startMenuAutoRun);
     EXPECT_EQ(fromDisk.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
 }

--- a/apps/src/ui/controls/StartMenuSettingsPanel.cpp
+++ b/apps/src/ui/controls/StartMenuSettingsPanel.cpp
@@ -161,6 +161,17 @@ void StartMenuSettingsPanel::createMainView(lv_obj_t* view)
                               .callback(onIdleActionChanged, this)
                               .buildOrLog();
 
+    autoRunToggle_ = LVGLBuilder::actionButton(view)
+                         .text("Auto-Run on Startup")
+                         .mode(LVGLBuilder::ActionMode::Toggle)
+                         .checked(settings_.startMenuAutoRun)
+                         .width(LV_PCT(95))
+                         .height(LVGLBuilder::Style::ACTION_SIZE)
+                         .layoutRow()
+                         .alignLeft()
+                         .callback(onAutoRunChanged, this)
+                         .buildOrLog();
+
     defaultScenarioButton_ = LVGLBuilder::actionButton(view)
                                  .text("Default Scenario")
                                  .icon(LV_SYMBOL_RIGHT)
@@ -309,6 +320,7 @@ void StartMenuSettingsPanel::applySettings(const DirtSim::UserSettings& settings
 
     updateTimezoneButtonText();
     updateDefaultScenarioButtonText();
+    updateAutoRunToggle();
     updateIdleActionDropdown();
     updateResetButtonEnabled();
 
@@ -392,6 +404,31 @@ void StartMenuSettingsPanel::updateIdleActionDropdown()
 
     const auto index = static_cast<uint16_t>(settings_.startMenuIdleAction);
     LVGLBuilder::ActionDropdownBuilder::setSelected(idleActionDropdown_, index);
+}
+
+void StartMenuSettingsPanel::updateAutoRunToggle()
+{
+    if (!autoRunToggle_) {
+        return;
+    }
+
+    LVGLBuilder::ActionButtonBuilder::setChecked(autoRunToggle_, settings_.startMenuAutoRun);
+}
+
+void StartMenuSettingsPanel::onAutoRunChanged(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->autoRunToggle_) {
+        return;
+    }
+
+    if (self->updatingUi_) {
+        return;
+    }
+
+    self->settings_.startMenuAutoRun =
+        LVGLBuilder::ActionButtonBuilder::isChecked(self->autoRunToggle_);
+    self->sendSettingsUpdate();
 }
 
 void StartMenuSettingsPanel::onIdleActionChanged(lv_event_t* e)

--- a/apps/src/ui/controls/StartMenuSettingsPanel.h
+++ b/apps/src/ui/controls/StartMenuSettingsPanel.h
@@ -36,6 +36,7 @@ private:
     void updateResetButtonEnabled();
     void updateTimezoneButtonText();
 
+    static void onAutoRunChanged(lv_event_t* e);
     static void onBackToMainClicked(lv_event_t* e);
     static void onDefaultScenarioButtonClicked(lv_event_t* e);
     static void onDefaultScenarioSelected(lv_event_t* e);
@@ -46,8 +47,10 @@ private:
     static void onVolumeChanged(lv_event_t* e);
 
     static void onIdleActionChanged(lv_event_t* e);
+    void updateAutoRunToggle();
     void updateIdleActionDropdown();
 
+    lv_obj_t* autoRunToggle_ = nullptr;
     lv_obj_t* container_ = nullptr;
     lv_obj_t* defaultScenarioButton_ = nullptr;
     lv_obj_t* idleActionDropdown_ = nullptr;

--- a/apps/src/ui/state-machine/StateMachine.cpp
+++ b/apps/src/ui/state-machine/StateMachine.cpp
@@ -89,6 +89,16 @@ FractalAnimator& StateMachine::getFractalAnimator()
     return *fractalAnimator_.get();
 }
 
+bool StateMachine::consumeStartupAutoRun()
+{
+    if (startupAutoRunConsumed_) {
+        return false;
+    }
+
+    startupAutoRunConsumed_ = true;
+    return serverUserSettings_.startMenuAutoRun;
+}
+
 void StateMachine::setupWebSocketService()
 {
     LOG_INFO(Network, "Setting up WebSocketService command handlers...");

--- a/apps/src/ui/state-machine/StateMachine.h
+++ b/apps/src/ui/state-machine/StateMachine.h
@@ -108,6 +108,8 @@ public:
         return uiConfig ? *uiConfig : defaultConfig;
     }
 
+    bool consumeStartupAutoRun();
+
 private:
     static constexpr uint32_t AutoShrinkTimeoutMs = 10000;
     static constexpr uint32_t StartMenuIdleClockTimeoutMs = 60000;
@@ -124,6 +126,7 @@ private:
     UserSettingsManager* userSettingsManager_ = nullptr;
     DirtSim::UserSettings serverUserSettings_{};
     bool startMenuIdleClockTriggered_ = false;
+    bool startupAutoRunConsumed_ = false;
     int synthVolumePercent_ = 20;
     bool audioVolumeWarningLogged_ = false;
 

--- a/apps/src/ui/state-machine/states/StartMenu.h
+++ b/apps/src/ui/state-machine/states/StartMenu.h
@@ -42,7 +42,8 @@ private:
     static void onDisplayResized(lv_event_t* e);
     static void onTouchEvent(lv_event_t* e);
     void updateInfoPanelVisibility(RailMode mode);
-    Any startSimulation(StateMachine& sm, std::optional<Scenario::EnumType> scenarioId);
+    Any startSimulation(
+        StateMachine& sm, std::optional<Scenario::EnumType> scenarioId, bool startupAutoRun);
 
     StateMachine* sm_ = nullptr;                       // State machine reference for callbacks.
     std::unique_ptr<SparklingDuckButton> startButton_; // Animated start button.
@@ -53,6 +54,7 @@ private:
     lv_obj_t* infoLabel_ = nullptr;                         // Fractal info label.
     int updateFrameCount_ = 0;                              // Frame counter for periodic logging.
     int labelUpdateCounter_ = 0; // Frame counter for label updates (~1/sec).
+    bool startupAutoRunPending_ = false;
 };
 
 } // namespace State


### PR DESCRIPTION
## Summary
- add `startMenuAutoRun` to server-backed `UserSettings` so startup auto-run is a user setting
- add an "Auto-Run on Startup" toggle to the Start Menu settings panel
- wire StartMenu startup flow to consume the new setting once per UI process
- keep idle-timeout action logic separate (Clock/None/Training)
- update `UserSettings` tests for defaults, persistence, and reset behavior

## Validation
- `cd apps && make test ARGS='--gtest_filter=UserSettingsTest.*'`
- `cd apps && ./build-debug/bin/dirtsim-tests --gtest_filter=StateTrainingTest.ConnectWaitsForServerConnectedEventBeforeStartMenuTransition`
- `cd /home/data/workspace/dirtsim && DIRTSIM_SSH_STRICT=false ./update.sh --target garden.local --fast`
- manual validation on `garden.local` (user confirmed behavior is good)
