### PR TITLE
Update fitness insights per generation

### DIFF
--- a/apps/src/ui/state-machine/states/TrainingActive.h
+++ b/apps/src/ui/state-machine/states/TrainingActive.h
@@ -54,9 +54,9 @@ struct TrainingActive {
     TrainingFitnessHistory fitnessHistory_{};
     std::vector<float> plotDistributionSeries_;
     std::vector<float> plotBestSeries_;
+    int lastFitnessInsightsGeneration_ = -1;
     uint64_t progressEventCount_ = 0;
     uint64_t renderMessageCount_ = 0;
-    std::chrono::steady_clock::time_point lastPlotUpdate_;
     std::chrono::steady_clock::time_point lastRenderRateLog_;
     uint64_t uiLoopCount_ = 0;
     std::chrono::steady_clock::time_point lastUiLoopLog_;


### PR DESCRIPTION
Training Active: make the Fitness Insights 'Best' chart update once per generation (when EvolutionProgress.lastCompletedGeneration advances), instead of repainting on every progress tick.

Tests: cd apps && make test ARGS='--gtest_filter=StateTrainingTest.TrainingFitnessHistory*'