### PR TITLE
Duck training: DuckTraining scenario + UserSettingsPatch

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -396,6 +396,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/clock_scenario/RainEvent.cpp
     src/core/scenarios/clock_scenario/StormManager.cpp
     src/core/scenarios/DamBreakScenario.cpp
+    src/core/scenarios/DuckTrainingScenario.cpp
     src/core/scenarios/EmptyScenario.cpp
     src/core/scenarios/GooseTestScenario.cpp
     src/core/scenarios/LightsScenario.cpp
@@ -437,6 +438,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/organisms/TreeCommandProcessor.cpp
     src/core/organisms/TreeSensoryData.cpp
     src/core/organisms/brains/Genome.cpp
+    src/core/organisms/brains/DuckNeuralNetBrain.cpp
     src/core/organisms/brains/NeuralNetBrain.cpp
     src/core/organisms/brains/RuleBasedBrain.cpp
     src/core/organisms/brains/RuleBased2Brain.cpp

--- a/apps/src/cli/CommandDispatcher.cpp
+++ b/apps/src/cli/CommandDispatcher.cpp
@@ -74,6 +74,7 @@ CommandDispatcher::CommandDispatcher()
     registerCommand<Api::StatusGet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TimerStatsGet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::UserSettingsGet::Cwc>(serverHandlers_, serverExampleHandlers_);
+    registerCommand<Api::UserSettingsPatch::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::UserSettingsReset::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::UserSettingsSet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TrainingResultDiscard::Cwc>(serverHandlers_, serverExampleHandlers_);

--- a/apps/src/cli/README.md
+++ b/apps/src/cli/README.md
@@ -72,6 +72,11 @@ Send commands to the server, UI, audio, or os-manager:
 ./build-debug/bin/cli server Reset
 ./build-debug/bin/cli server Exit
 
+# User settings (patch updates only specified fields)
+./build-debug/bin/cli server UserSettingsGet
+./build-debug/bin/cli server UserSettingsPatch '{"trainingSpec":{"scenarioId":"DuckTraining","organismType":"DUCK","population":[]}}'
+./build-debug/bin/cli server UserSettingsPatch '{"trainingSpec":{"scenarioId":"TreeGermination","organismType":"TREE","population":[]}}'
+
 # UI commands
 ./build-debug/bin/cli ui SimPause
 ./build-debug/bin/cli ui SimStop
@@ -382,6 +387,25 @@ Run evolution training with JSON configuration:
   },
   "scenarioId": "TreeGermination",
   "organismType": "TREE",
+  "resumePolicy": "WarmFromBest",
+  "population": [
+    {
+      "brainKind": "NeuralNet",
+      "count": 20,
+      "randomCount": 20
+    }
+  ]
+}'
+
+# Train ducks with the clock-style obstacle course
+./build-debug/bin/cli train '{
+  "evolution": {
+    "maxGenerations": 10,
+    "populationSize": 20,
+    "tournamentSize": 3
+  },
+  "scenarioId": "DuckTraining",
+  "organismType": "DUCK",
   "resumePolicy": "WarmFromBest",
   "population": [
     {

--- a/apps/src/core/ScenarioConfig.cpp
+++ b/apps/src/core/ScenarioConfig.cpp
@@ -31,6 +31,8 @@ ScenarioConfig makeDefaultConfig(Scenario::EnumType id)
             return Config::TreeGermination{};
         case Scenario::EnumType::WaterEqualization:
             return Config::WaterEqualization{};
+        case Scenario::EnumType::DuckTraining:
+            return Config::DuckTraining{};
     }
     return Config::Empty{};
 }

--- a/apps/src/core/ScenarioConfig.h
+++ b/apps/src/core/ScenarioConfig.h
@@ -4,6 +4,7 @@
 #include "core/scenarios/BenchmarkConfig.h"
 #include "core/scenarios/ClockConfig.h"
 #include "core/scenarios/DamBreakConfig.h"
+#include "core/scenarios/DuckTrainingConfig.h"
 #include "core/scenarios/EmptyConfig.h"
 #include "core/scenarios/GooseTestConfig.h"
 #include "core/scenarios/LightsConfig.h"
@@ -26,7 +27,8 @@ using ScenarioConfig = std::variant<
     Config::Raining,
     Config::Sandbox,
     Config::TreeGermination,
-    Config::WaterEqualization>;
+    Config::WaterEqualization,
+    Config::DuckTraining>;
 
 // Map variant index to Scenario::EnumType enum (must stay in sync with variant order).
 Scenario::EnumType getScenarioId(const ScenarioConfig& config);

--- a/apps/src/core/ScenarioId.h
+++ b/apps/src/core/ScenarioId.h
@@ -24,6 +24,7 @@ enum class EnumType : uint8_t {
     Sandbox,
     TreeGermination,
     WaterEqualization,
+    DuckTraining,
 };
 
 std::string toString(EnumType id);

--- a/apps/src/core/organisms/brains/DuckNeuralNetBrain.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetBrain.cpp
@@ -1,0 +1,251 @@
+#include "DuckNeuralNetBrain.h"
+
+#include "WeightType.h"
+#include "core/Assert.h"
+#include "core/organisms/Duck.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace DirtSim {
+
+namespace {
+
+constexpr int GRID_SIZE = DuckSensoryData::GRID_SIZE;
+constexpr int NUM_MATERIALS = DuckSensoryData::NUM_MATERIALS;
+
+constexpr int INPUT_HISTOGRAM_SIZE = GRID_SIZE * GRID_SIZE * NUM_MATERIALS;
+constexpr int INPUT_SIZE = INPUT_HISTOGRAM_SIZE + 4;
+constexpr int HIDDEN_SIZE = 32;
+constexpr int OUTPUT_SIZE = 2;
+
+constexpr int W_IH_SIZE = INPUT_SIZE * HIDDEN_SIZE;
+constexpr int B_H_SIZE = HIDDEN_SIZE;
+constexpr int W_HO_SIZE = HIDDEN_SIZE * OUTPUT_SIZE;
+constexpr int B_O_SIZE = OUTPUT_SIZE;
+constexpr int TOTAL_WEIGHTS = W_IH_SIZE + B_H_SIZE + W_HO_SIZE + B_O_SIZE;
+
+WeightType relu(WeightType x)
+{
+    return std::max(static_cast<WeightType>(0.0f), x);
+}
+
+} // namespace
+
+struct DuckNeuralNetBrain::Impl {
+    std::vector<WeightType> w_ih;
+    std::vector<WeightType> b_h;
+    std::vector<WeightType> w_ho;
+    std::vector<WeightType> b_o;
+    std::vector<WeightType> input_buffer;
+    std::vector<WeightType> hidden_buffer;
+    std::vector<WeightType> output_buffer;
+
+    Impl()
+        : w_ih(W_IH_SIZE, 0.0f),
+          b_h(B_H_SIZE, 0.0f),
+          w_ho(W_HO_SIZE, 0.0f),
+          b_o(B_O_SIZE, 0.0f),
+          input_buffer(INPUT_SIZE, 0.0f),
+          hidden_buffer(HIDDEN_SIZE, 0.0f),
+          output_buffer(OUTPUT_SIZE, 0.0f)
+    {}
+
+    void loadFromGenome(const Genome& genome)
+    {
+        DIRTSIM_ASSERT(
+            genome.weights.size() == TOTAL_WEIGHTS,
+            "DuckNeuralNetBrain: Genome weight count mismatch");
+
+        int idx = 0;
+        for (int i = 0; i < W_IH_SIZE; ++i) {
+            w_ih[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < B_H_SIZE; ++i) {
+            b_h[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < W_HO_SIZE; ++i) {
+            w_ho[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < B_O_SIZE; ++i) {
+            b_o[i] = genome.weights[idx++];
+        }
+    }
+
+    Genome toGenome() const
+    {
+        Genome genome(static_cast<size_t>(TOTAL_WEIGHTS));
+        int idx = 0;
+
+        for (int i = 0; i < W_IH_SIZE; ++i) {
+            genome.weights[idx++] = w_ih[i];
+        }
+        for (int i = 0; i < B_H_SIZE; ++i) {
+            genome.weights[idx++] = b_h[i];
+        }
+        for (int i = 0; i < W_HO_SIZE; ++i) {
+            genome.weights[idx++] = w_ho[i];
+        }
+        for (int i = 0; i < B_O_SIZE; ++i) {
+            genome.weights[idx++] = b_o[i];
+        }
+
+        return genome;
+    }
+
+    const std::vector<WeightType>& flattenSensoryData(const DuckSensoryData& sensory)
+    {
+        int index = 0;
+
+        for (int y = 0; y < GRID_SIZE; ++y) {
+            for (int x = 0; x < GRID_SIZE; ++x) {
+                for (int material = 0; material < NUM_MATERIALS; ++material) {
+                    input_buffer[index++] =
+                        static_cast<WeightType>(sensory.material_histograms[y][x][material]);
+                }
+            }
+        }
+
+        input_buffer[index++] = static_cast<WeightType>(sensory.velocity.x / 10.0);
+        input_buffer[index++] = static_cast<WeightType>(sensory.velocity.y / 10.0);
+        input_buffer[index++] =
+            sensory.on_ground ? static_cast<WeightType>(1.0f) : static_cast<WeightType>(0.0f);
+        input_buffer[index++] = static_cast<WeightType>(sensory.facing_x);
+
+        DIRTSIM_ASSERT(index == INPUT_SIZE, "DuckNeuralNetBrain: Input size mismatch");
+
+        return input_buffer;
+    }
+
+    const std::vector<WeightType>& forward(const std::vector<WeightType>& input)
+    {
+        std::copy(b_h.begin(), b_h.end(), hidden_buffer.begin());
+        for (int i = 0; i < INPUT_SIZE; ++i) {
+            const WeightType input_value = input[i];
+            if (input_value == 0.0f) {
+                continue;
+            }
+            const WeightType* weights = &w_ih[i * HIDDEN_SIZE];
+            for (int h = 0; h < HIDDEN_SIZE; ++h) {
+                hidden_buffer[h] += input_value * weights[h];
+            }
+        }
+        for (int h = 0; h < HIDDEN_SIZE; ++h) {
+            hidden_buffer[h] = relu(hidden_buffer[h]);
+        }
+
+        std::copy(b_o.begin(), b_o.end(), output_buffer.begin());
+        for (int h = 0; h < HIDDEN_SIZE; ++h) {
+            const WeightType hidden_value = hidden_buffer[h];
+            const WeightType* weights = &w_ho[h * OUTPUT_SIZE];
+            for (int o = 0; o < OUTPUT_SIZE; ++o) {
+                output_buffer[o] += hidden_value * weights[o];
+            }
+        }
+
+        return output_buffer;
+    }
+};
+
+DuckNeuralNetBrain::DuckNeuralNetBrain() : impl_(std::make_unique<Impl>())
+{
+    std::mt19937 rng(std::random_device{}());
+    const Genome genome = randomGenome(rng);
+    impl_->loadFromGenome(genome);
+}
+
+DuckNeuralNetBrain::DuckNeuralNetBrain(const Genome& genome) : impl_(std::make_unique<Impl>())
+{
+    impl_->loadFromGenome(genome);
+}
+
+DuckNeuralNetBrain::DuckNeuralNetBrain(uint32_t seed) : impl_(std::make_unique<Impl>())
+{
+    std::mt19937 rng(seed);
+    const Genome genome = randomGenome(rng);
+    impl_->loadFromGenome(genome);
+}
+
+DuckNeuralNetBrain::~DuckNeuralNetBrain() = default;
+
+void DuckNeuralNetBrain::think(Duck& duck, const DuckSensoryData& sensory, double deltaTime)
+{
+    decisionTimerSeconds_ += deltaTime;
+    if (decisionTimerSeconds_ >= kDecisionIntervalSeconds) {
+        decisionTimerSeconds_ = 0.0;
+
+        const auto& input = impl_->flattenSensoryData(sensory);
+        const auto& output = impl_->forward(input);
+
+        lastMoveX_ = static_cast<float>(std::tanh(output[0]));
+        jumpLatch_ = output[1] > 0.0f;
+    }
+
+    bool should_jump = false;
+    if (jumpLatch_ && sensory.on_ground) {
+        should_jump = true;
+        jumpLatch_ = false;
+    }
+
+    duck.setInput({ .move = { lastMoveX_, 0.0f }, .jump = should_jump });
+
+    if (should_jump) {
+        current_action_ = DuckAction::JUMP;
+        return;
+    }
+
+    if (std::abs(lastMoveX_) < 0.2f) {
+        current_action_ = DuckAction::WAIT;
+        return;
+    }
+
+    current_action_ = lastMoveX_ < 0.0f ? DuckAction::RUN_LEFT : DuckAction::RUN_RIGHT;
+}
+
+Genome DuckNeuralNetBrain::getGenome() const
+{
+    return impl_->toGenome();
+}
+
+void DuckNeuralNetBrain::setGenome(const Genome& genome)
+{
+    impl_->loadFromGenome(genome);
+}
+
+Genome DuckNeuralNetBrain::randomGenome(std::mt19937& rng)
+{
+    Genome genome(static_cast<size_t>(TOTAL_WEIGHTS));
+
+    const WeightType ih_stddev = std::sqrt(2.0f / (INPUT_SIZE + HIDDEN_SIZE));
+    const WeightType ho_stddev = std::sqrt(2.0f / (HIDDEN_SIZE + OUTPUT_SIZE));
+
+    std::normal_distribution<WeightType> ih_dist(0.0f, ih_stddev);
+    std::normal_distribution<WeightType> ho_dist(0.0f, ho_stddev);
+
+    int idx = 0;
+    for (int i = 0; i < W_IH_SIZE; ++i) {
+        genome.weights[idx++] = ih_dist(rng);
+    }
+    for (int i = 0; i < B_H_SIZE; ++i) {
+        genome.weights[idx++] = 0.0f;
+    }
+    for (int i = 0; i < W_HO_SIZE; ++i) {
+        genome.weights[idx++] = ho_dist(rng);
+    }
+    for (int i = 0; i < B_O_SIZE; ++i) {
+        genome.weights[idx++] = 0.0f;
+    }
+
+    DIRTSIM_ASSERT(idx == TOTAL_WEIGHTS, "DuckNeuralNetBrain: Generated genome size mismatch");
+
+    return genome;
+}
+
+bool DuckNeuralNetBrain::isGenomeCompatible(const Genome& genome)
+{
+    return genome.weights.size() == static_cast<size_t>(TOTAL_WEIGHTS);
+}
+
+} // namespace DirtSim

--- a/apps/src/core/organisms/brains/DuckNeuralNetBrain.h
+++ b/apps/src/core/organisms/brains/DuckNeuralNetBrain.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "core/organisms/DuckBrain.h"
+#include "core/organisms/brains/Genome.h"
+
+#include <memory>
+#include <random>
+
+namespace DirtSim {
+
+class Duck;
+
+class DuckNeuralNetBrain : public DuckBrain {
+public:
+    DuckNeuralNetBrain();
+    explicit DuckNeuralNetBrain(const Genome& genome);
+    explicit DuckNeuralNetBrain(uint32_t seed);
+    ~DuckNeuralNetBrain() override;
+
+    void think(Duck& duck, const DuckSensoryData& sensory, double deltaTime) override;
+
+    Genome getGenome() const;
+    void setGenome(const Genome& genome);
+
+    static Genome randomGenome(std::mt19937& rng);
+    static bool isGenomeCompatible(const Genome& genome);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+
+    double decisionTimerSeconds_ = 0.0;
+    float lastMoveX_ = 0.0f;
+    bool jumpLatch_ = false;
+
+    static constexpr double kDecisionIntervalSeconds = 0.05;
+};
+
+} // namespace DirtSim

--- a/apps/src/core/organisms/brains/Genome.cpp
+++ b/apps/src/core/organisms/brains/Genome.cpp
@@ -23,6 +23,9 @@ constexpr int TOTAL_WEIGHTS = W_IH_SIZE + B_H_SIZE + W_HO_SIZE + B_O_SIZE;
 Genome::Genome() : weights(TOTAL_WEIGHTS, 0.0f)
 {}
 
+Genome::Genome(size_t weightCount) : weights(weightCount, 0.0f)
+{}
+
 Genome Genome::random(std::mt19937& rng)
 {
     Genome g;

--- a/apps/src/core/organisms/brains/Genome.h
+++ b/apps/src/core/organisms/brains/Genome.h
@@ -14,6 +14,7 @@ struct Genome {
     std::vector<WeightType> weights;
 
     Genome();
+    explicit Genome(size_t weightCount);
 
     static Genome random(std::mt19937& rng);
     static Genome constant(WeightType value);

--- a/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
+++ b/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include "core/organisms/OrganismType.h"
+#include "core/organisms/brains/Genome.h"
 
 #include <functional>
+#include <random>
 #include <string>
 #include <unordered_map>
 
 namespace DirtSim {
 
 class World;
-struct Genome;
 
 namespace TrainingBrainKind {
 inline constexpr const char* NeuralNet = "NeuralNet";
@@ -46,6 +47,8 @@ struct BrainRegistryEntry {
     bool requiresGenome = false;
     bool allowsMutation = false;
     std::function<OrganismId(World& world, uint32_t x, uint32_t y, const Genome* genome)> spawn;
+    std::function<Genome(std::mt19937& rng)> createRandomGenome;
+    std::function<bool(const Genome& genome)> isGenomeCompatible;
 };
 
 class TrainingBrainRegistry {

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -9,6 +9,7 @@
 #include "core/organisms/Tree.h"
 #include "core/scenarios/Scenario.h"
 #include "core/scenarios/ScenarioRegistry.h"
+#include <algorithm>
 #include <limits>
 #include <optional>
 
@@ -285,7 +286,22 @@ void TrainingRunner::spawnEvaluationOrganism()
     DIRTSIM_ASSERT(world_, "TrainingRunner: World must exist before spawn");
     DIRTSIM_ASSERT(scenario_, "TrainingRunner: Scenario must exist before spawn");
 
-    const Vector2i spawnCell = findSpawnCell(*world_);
+    Vector2i spawnCell{ 0, 0 };
+    const WorldData& data = world_->getData();
+    if (trainingSpec_.organismType == OrganismType::DUCK
+        && individual_.scenarioId == Scenario::EnumType::DuckTraining) {
+        Vector2i candidate{ 1, std::max(1, data.height - 2) };
+        if (data.inBounds(candidate.x, candidate.y) && data.at(candidate.x, candidate.y).isAir()
+            && !world_->getOrganismManager().hasOrganism(candidate)) {
+            spawnCell = candidate;
+        }
+        else {
+            spawnCell = findSpawnCell(*world_);
+        }
+    }
+    else {
+        spawnCell = findSpawnCell(*world_);
+    }
 
     const std::string variant = individual_.brain.brainVariant.value_or("");
     const BrainRegistryEntry* entry =

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -488,6 +488,8 @@ TEST_F(TrainingRunnerTest, UsesConfiguredBrainRegistry)
                     return world.getOrganismManager().createTree(
                         world, x, y, std::make_unique<TestTreeBrain>(&decided));
                 },
+            .createRandomGenome = nullptr,
+            .isGenomeCompatible = nullptr,
         });
 
     TrainingRunner::Config runnerConfig{ .brainRegistry = registry };
@@ -543,6 +545,11 @@ TEST_F(TrainingRunnerTest, TreeScenarioBrainHarness)
                             return world.getOrganismManager().createTree(
                                 world, x, y, std::move(brain));
                         },
+                    .createRandomGenome = [](std::mt19937& rng) { return Genome::random(rng); },
+                    .isGenomeCompatible =
+                        [](const Genome& genome) {
+                            return genome.weights.size() == Genome::EXPECTED_WEIGHT_COUNT;
+                        },
                 });
         }
         else if (brainCase.brainKind == TrainingBrainKind::RuleBased) {
@@ -561,6 +568,8 @@ TEST_F(TrainingRunnerTest, TreeScenarioBrainHarness)
                             return world.getOrganismManager().createTree(
                                 world, x, y, std::move(brain));
                         },
+                    .createRandomGenome = nullptr,
+                    .isGenomeCompatible = nullptr,
                 });
         }
         else if (brainCase.brainKind == TrainingBrainKind::RuleBased2) {
@@ -579,6 +588,8 @@ TEST_F(TrainingRunnerTest, TreeScenarioBrainHarness)
                             return world.getOrganismManager().createTree(
                                 world, x, y, std::move(brain));
                         },
+                    .createRandomGenome = nullptr,
+                    .isGenomeCompatible = nullptr,
                 });
         }
 
@@ -729,6 +740,8 @@ TEST_F(TrainingRunnerTest, TopCommandSignaturesAreTop20AndTieBreakBySignature)
                         std::make_unique<RecordingTreeBrain>(std::move(baseBrain), &issued);
                     return world.getOrganismManager().createTree(world, x, y, std::move(brain));
                 },
+            .createRandomGenome = nullptr,
+            .isGenomeCompatible = nullptr,
         });
 
     TrainingRunner::Individual individual;
@@ -794,6 +807,8 @@ TEST_F(TrainingRunnerTest, CommandOutcomeSignaturesUseDecisionAnchorWhenTreeMove
                     auto brain = std::make_unique<TestTreeBrain>(nullptr);
                     return world.getOrganismManager().createTree(world, x, y, std::move(brain));
                 },
+            .createRandomGenome = nullptr,
+            .isGenomeCompatible = nullptr,
         });
 
     TrainingRunner::Individual individual;

--- a/apps/src/core/scenarios/DuckTrainingConfig.h
+++ b/apps/src/core/scenarios/DuckTrainingConfig.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <zpp_bits.h>
+
+namespace DirtSim::Config {
+
+struct DuckTraining {
+    uint32_t obstacleSeed = 1337;
+    uint8_t obstacleCount = 3;
+
+    using serialize = zpp::bits::members<2>;
+};
+
+} // namespace DirtSim::Config

--- a/apps/src/core/scenarios/DuckTrainingScenario.cpp
+++ b/apps/src/core/scenarios/DuckTrainingScenario.cpp
@@ -1,0 +1,183 @@
+#include "DuckTrainingScenario.h"
+
+#include "core/Cell.h"
+#include "core/ColorNames.h"
+#include "core/LightManager.h"
+#include "core/LightTypes.h"
+#include "core/World.h"
+#include "core/WorldData.h"
+
+#include <algorithm>
+#include <spdlog/spdlog.h>
+
+namespace DirtSim {
+
+namespace {
+
+constexpr uint8_t kMaxObstacleCount = 3;
+
+} // namespace
+
+DuckTrainingScenario::DuckTrainingScenario() : rng_(std::random_device{}())
+{
+    metadata_.name = "Duck Training";
+    metadata_.description = "Obstacle course based on the clock duck event";
+    metadata_.category = "training";
+    metadata_.requiredWidth = 60;
+    metadata_.requiredHeight = 16;
+}
+
+const ScenarioMetadata& DuckTrainingScenario::getMetadata() const
+{
+    return metadata_;
+}
+
+ScenarioConfig DuckTrainingScenario::getConfig() const
+{
+    return config_;
+}
+
+void DuckTrainingScenario::setConfig(const ScenarioConfig& newConfig, World& world)
+{
+    if (!std::holds_alternative<Config::DuckTraining>(newConfig)) {
+        spdlog::error("DuckTrainingScenario: Invalid config type provided");
+        return;
+    }
+
+    config_ = std::get<Config::DuckTraining>(newConfig);
+    config_.obstacleCount =
+        std::clamp(config_.obstacleCount, static_cast<uint8_t>(0), kMaxObstacleCount);
+
+    rebuildWorld(world);
+}
+
+void DuckTrainingScenario::setup(World& world)
+{
+    spdlog::info("DuckTrainingScenario::setup - building obstacle course");
+    rebuildWorld(world);
+}
+
+void DuckTrainingScenario::reset(World& world)
+{
+    spdlog::info("DuckTrainingScenario::reset");
+    rebuildWorld(world);
+}
+
+void DuckTrainingScenario::tick(World& world, double /*deltaTime*/)
+{
+    redrawWalls(world);
+}
+
+void DuckTrainingScenario::rebuildWorld(World& world)
+{
+    WorldData& data = world.getData();
+
+    world.getLightManager().clear();
+
+    for (int y = 0; y < data.height; ++y) {
+        for (int x = 0; x < data.width; ++x) {
+            data.at(x, y) = Cell();
+        }
+    }
+
+    rng_.seed(config_.obstacleSeed);
+    obstacleManager_.clearAll(world);
+    spawnObstacles(world);
+    redrawWalls(world);
+
+    world.getLightManager().addLight(
+        PointLight{ .position = Vector2d{ static_cast<double>(data.width - 2), 2.0 },
+                    .color = ColorNames::torchOrange(),
+                    .intensity = 0.15f,
+                    .radius = 15.0f,
+                    .attenuation = 0.05f });
+
+    world.getLightManager().addLight(
+        PointLight{ .position = Vector2d{ 2.0, 2.0 },
+                    .color = ColorNames::torchOrange(),
+                    .intensity = 0.15f,
+                    .radius = 15.0f,
+                    .attenuation = 0.05f });
+}
+
+void DuckTrainingScenario::spawnObstacles(World& world)
+{
+    const uint8_t desired = std::min(config_.obstacleCount, kMaxObstacleCount);
+    uint8_t spawned = 0;
+    int attempts = 0;
+    while (spawned < desired && attempts < 50) {
+        attempts++;
+        if (obstacleManager_.spawnObstacle(world, rng_, uniformDist_)) {
+            spawned++;
+        }
+    }
+
+    spdlog::info("DuckTrainingScenario: Spawned {}/{} obstacles", spawned, desired);
+}
+
+std::vector<DuckTrainingScenario::WallSpec> DuckTrainingScenario::generateWallSpecs(
+    const WorldData& data) const
+{
+    int16_t width = data.width;
+    int16_t height = data.height;
+
+    std::vector<WallSpec> walls;
+    walls.reserve(2 * (width + height) + 20);
+
+    for (int16_t x = 0; x < width; ++x) {
+        walls.push_back({ x, 0, Material::EnumType::Wood });
+    }
+
+    for (int16_t x = 0; x < width; ++x) {
+        if (obstacleManager_.isPitAt(static_cast<uint32_t>(x))) {
+            continue;
+        }
+        walls.push_back({ x, static_cast<int16_t>(height - 1), Material::EnumType::Dirt });
+    }
+
+    for (int16_t y = 0; y < height; ++y) {
+        walls.push_back({ 0, y, Material::EnumType::Wood });
+    }
+
+    for (int16_t y = 0; y < height; ++y) {
+        walls.push_back({ static_cast<int16_t>(width - 1), y, Material::EnumType::Wood });
+    }
+
+    if (height > 2) {
+        for (int16_t x = 0; x < width; ++x) {
+            if (obstacleManager_.isHurdleAt(static_cast<uint32_t>(x))) {
+                walls.push_back({ x, static_cast<int16_t>(height - 2), Material::EnumType::Wall });
+            }
+        }
+    }
+
+    return walls;
+}
+
+void DuckTrainingScenario::applyWalls(World& world, const std::vector<WallSpec>& walls)
+{
+    for (const auto& wall : walls) {
+        world.replaceMaterialAtCell({ wall.x, wall.y }, Material::EnumType::Wall);
+        world.getData().at(wall.x, wall.y).render_as = static_cast<int8_t>(wall.renderAs);
+    }
+}
+
+void DuckTrainingScenario::redrawWalls(World& world)
+{
+    const WorldData& data = world.getData();
+    const std::vector<WallSpec> walls = generateWallSpecs(data);
+    applyWalls(world, walls);
+
+    const int16_t height = data.height;
+    for (int16_t x = 0; x < data.width; ++x) {
+        if (!obstacleManager_.isPitAt(static_cast<uint32_t>(x))) {
+            continue;
+        }
+        Cell& cell = world.getData().at(x, height - 1);
+        if (cell.material_type == Material::EnumType::Wall) {
+            cell = Cell();
+        }
+    }
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/DuckTrainingScenario.h
+++ b/apps/src/core/scenarios/DuckTrainingScenario.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "DuckTrainingConfig.h"
+#include "clock_scenario/ObstacleManager.h"
+#include "core/ScenarioConfig.h"
+#include "core/scenarios/Scenario.h"
+
+#include <random>
+#include <vector>
+
+namespace DirtSim {
+
+class World;
+struct WorldData;
+
+class DuckTrainingScenario : public ScenarioRunner {
+public:
+    DuckTrainingScenario();
+
+    const ScenarioMetadata& getMetadata() const override;
+    ScenarioConfig getConfig() const override;
+    void setConfig(const ScenarioConfig& newConfig, World& world) override;
+    void setup(World& world) override;
+    void reset(World& world) override;
+    void tick(World& world, double deltaTime) override;
+
+private:
+    struct WallSpec {
+        int16_t x = 0;
+        int16_t y = 0;
+        Material::EnumType renderAs = Material::EnumType::Wall;
+    };
+
+    ScenarioMetadata metadata_;
+    Config::DuckTraining config_;
+    ObstacleManager obstacleManager_;
+
+    std::mt19937 rng_;
+    std::uniform_real_distribution<double> uniformDist_{ 0.0, 1.0 };
+
+    void rebuildWorld(World& world);
+    void spawnObstacles(World& world);
+
+    std::vector<WallSpec> generateWallSpecs(const WorldData& data) const;
+    void applyWalls(World& world, const std::vector<WallSpec>& walls);
+    void redrawWalls(World& world);
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/ScenarioRegistry.cpp
+++ b/apps/src/core/scenarios/ScenarioRegistry.cpp
@@ -5,6 +5,7 @@
 #include "core/scenarios/BenchmarkScenario.h"
 #include "core/scenarios/ClockScenario.h"
 #include "core/scenarios/DamBreakScenario.h"
+#include "core/scenarios/DuckTrainingScenario.h"
 #include "core/scenarios/EmptyScenario.h"
 #include "core/scenarios/GooseTestScenario.h"
 #include "core/scenarios/LightsScenario.h"
@@ -70,6 +71,11 @@ ScenarioRegistry ScenarioRegistry::createDefault(GenomeRepository& genomeReposit
     registry.registerScenario(
         Scenario::EnumType::WaterEqualization, WaterEqualizationScenario{}.getMetadata(), []() {
             return std::make_unique<WaterEqualizationScenario>();
+        });
+
+    registry.registerScenario(
+        Scenario::EnumType::DuckTraining, DuckTrainingScenario{}.getMetadata(), []() {
+            return std::make_unique<DuckTrainingScenario>();
         });
 
     return registry;

--- a/apps/src/server/Event.h
+++ b/apps/src/server/Event.h
@@ -39,6 +39,7 @@
 #include "api/TrainingResultSet.h"
 #include "api/TrainingStreamConfigSet.h"
 #include "api/UserSettingsGet.h"
+#include "api/UserSettingsPatch.h"
 #include "api/UserSettingsReset.h"
 #include "api/UserSettingsSet.h"
 #include "api/WorldResize.h"
@@ -454,6 +455,7 @@ public:
         DirtSim::Api::StatusGet::Cwc,
         DirtSim::Api::TimerStatsGet::Cwc,
         DirtSim::Api::UserSettingsGet::Cwc,
+        DirtSim::Api::UserSettingsPatch::Cwc,
         DirtSim::Api::UserSettingsReset::Cwc,
         DirtSim::Api::UserSettingsSet::Cwc,
         DirtSim::Api::TrainingResultDiscard::Cwc,

--- a/apps/src/server/api/ApiCommand.h
+++ b/apps/src/server/api/ApiCommand.h
@@ -42,6 +42,7 @@
 #include "TrainingResultSet.h"
 #include "TrainingStreamConfigSet.h"
 #include "UserSettingsGet.h"
+#include "UserSettingsPatch.h"
 #include "UserSettingsReset.h"
 #include "UserSettingsSet.h"
 #include "WebSocketAccessSet.h"
@@ -108,6 +109,7 @@ using ApiCommand = std::variant<
     Api::TimerStatsGet::Command,
     Api::TrainingBestSnapshotGet::Command,
     Api::UserSettingsGet::Command,
+    Api::UserSettingsPatch::Command,
     Api::UserSettingsReset::Command,
     Api::UserSettingsSet::Command,
     Api::TrainingResultDiscard::Command,

--- a/apps/src/server/api/UserSettingsPatch.h
+++ b/apps/src/server/api/UserSettingsPatch.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "ApiError.h"
+#include "ApiMacros.h"
+#include "core/CommandWithCallback.h"
+#include "core/Result.h"
+#include "server/UserSettings.h"
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace Api {
+namespace UserSettingsPatch {
+
+DEFINE_API_NAME(UserSettingsPatch);
+
+struct Okay;
+
+struct Command {
+    std::optional<int> timezoneIndex = std::nullopt;
+    std::optional<int> volumePercent = std::nullopt;
+    std::optional<Scenario::EnumType> defaultScenario = std::nullopt;
+    std::optional<StartMenuIdleAction> startMenuIdleAction = std::nullopt;
+    std::optional<bool> startMenuAutoRun = std::nullopt;
+    std::optional<TrainingSpec> trainingSpec = std::nullopt;
+    std::optional<EvolutionConfig> evolutionConfig = std::nullopt;
+    std::optional<MutationConfig> mutationConfig = std::nullopt;
+    std::optional<TrainingResumePolicy> trainingResumePolicy = std::nullopt;
+
+    API_COMMAND();
+    API_JSON_SERIALIZABLE(Command);
+
+    bool isEmpty() const
+    {
+        return !timezoneIndex.has_value() && !volumePercent.has_value()
+            && !defaultScenario.has_value() && !startMenuIdleAction.has_value()
+            && !startMenuAutoRun.has_value() && !trainingSpec.has_value()
+            && !evolutionConfig.has_value() && !mutationConfig.has_value()
+            && !trainingResumePolicy.has_value();
+    }
+
+    using serialize = zpp::bits::members<9>;
+};
+
+struct Okay {
+    UserSettings settings;
+
+    API_COMMAND_NAME();
+    API_JSON_SERIALIZABLE(Okay);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+using Response = Result<Okay, ApiError>;
+using Cwc = CommandWithCallback<Command, Response>;
+
+} // namespace UserSettingsPatch
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/network/CommandDeserializerJson.cpp
+++ b/apps/src/server/network/CommandDeserializerJson.cpp
@@ -32,6 +32,7 @@
 #include "server/api/TrainingResultSet.h"
 #include "server/api/TrainingStreamConfigSet.h"
 #include "server/api/UserSettingsGet.h"
+#include "server/api/UserSettingsPatch.h"
 #include "server/api/UserSettingsReset.h"
 #include "server/api/UserSettingsSet.h"
 #include "server/api/WebUiAccessSet.h"
@@ -150,6 +151,10 @@ Result<ApiCommand, ApiError> CommandDeserializerJson::deserialize(const std::str
         }
         else if (commandName == Api::UserSettingsGet::Command::name()) {
             return Result<ApiCommand, ApiError>::okay(Api::UserSettingsGet::Command::fromJson(cmd));
+        }
+        else if (commandName == Api::UserSettingsPatch::Command::name()) {
+            return Result<ApiCommand, ApiError>::okay(
+                Api::UserSettingsPatch::Command::fromJson(cmd));
         }
         else if (commandName == Api::UserSettingsReset::Command::name()) {
             return Result<ApiCommand, ApiError>::okay(

--- a/apps/src/server/states/Evolution.cpp
+++ b/apps/src/server/states/Evolution.cpp
@@ -435,11 +435,14 @@ void Evolution::initializePopulation(StateMachine& dsm)
             }
 
             for (int i = 0; i < spec.randomCount; ++i) {
+                DIRTSIM_ASSERT(
+                    entry->createRandomGenome,
+                    "Evolution: createRandomGenome must be set for genome brains");
                 population.push_back(
                     Individual{ .brainKind = spec.brainKind,
                                 .brainVariant = spec.brainVariant,
                                 .scenarioId = spec.scenarioId,
-                                .genome = Genome::random(rng),
+                                .genome = entry->createRandomGenome(rng),
                                 .allowsMutation = entry->allowsMutation });
                 populationOrigins.push_back(IndividualOrigin::Seed);
             }

--- a/apps/src/server/states/Idle.cpp
+++ b/apps/src/server/states/Idle.cpp
@@ -88,7 +88,8 @@ std::optional<ApiError> validateTrainingConfig(
                 defaultSpec.randomCount = defaultSpec.count;
                 break;
             case OrganismType::DUCK:
-                defaultSpec.brainKind = TrainingBrainKind::Random;
+                defaultSpec.brainKind = TrainingBrainKind::NeuralNet;
+                defaultSpec.randomCount = defaultSpec.count;
                 break;
             case OrganismType::GOOSE:
                 defaultSpec.brainKind = TrainingBrainKind::Random;
@@ -165,6 +166,16 @@ std::optional<ApiError> validateTrainingConfig(
                 }
                 if (!repo.exists(id)) {
                     return ApiError("Seed genome not found: " + id.toShortString());
+                }
+                if (entry->isGenomeCompatible) {
+                    auto genome = repo.get(id);
+                    if (!genome.has_value()) {
+                        return ApiError("Seed genome not found: " + id.toShortString());
+                    }
+                    if (!entry->isGenomeCompatible(genome.value())) {
+                        return ApiError(
+                            "Seed genome incompatible with brain kind: " + spec.brainKind);
+                    }
                 }
             }
         }

--- a/apps/src/ui/TrainingIdleView.cpp
+++ b/apps/src/ui/TrainingIdleView.cpp
@@ -345,6 +345,8 @@ void TrainingIdleView::addGenomeToTraining(const GenomeId& genomeId, Scenario::E
                 spec.brainKind = TrainingBrainKind::NeuralNet;
                 break;
             case OrganismType::DUCK:
+                spec.brainKind = TrainingBrainKind::NeuralNet;
+                break;
             case OrganismType::GOOSE:
                 spec.brainKind = TrainingBrainKind::Random;
                 break;

--- a/apps/src/ui/controls/EvolutionConfigPanel.cpp
+++ b/apps/src/ui/controls/EvolutionConfigPanel.cpp
@@ -305,7 +305,7 @@ void EvolutionConfigPanel::onPopulationChanged(lv_event_t* e)
                 entry.brainKind = TrainingBrainKind::NeuralNet;
                 break;
             case OrganismType::DUCK:
-                entry.brainKind = TrainingBrainKind::Random;
+                entry.brainKind = TrainingBrainKind::NeuralNet;
                 break;
             case OrganismType::GOOSE:
                 entry.brainKind = TrainingBrainKind::Random;

--- a/apps/src/ui/controls/StartMenuSettingsPanel.h
+++ b/apps/src/ui/controls/StartMenuSettingsPanel.h
@@ -42,6 +42,7 @@ private:
     static void onDefaultScenarioSelected(lv_event_t* e);
     static void onResetConfirmToggled(lv_event_t* e);
     static void onResetClicked(lv_event_t* e);
+    static void onTrainingTargetChanged(lv_event_t* e);
     static void onTimezoneButtonClicked(lv_event_t* e);
     static void onTimezoneSelected(lv_event_t* e);
     static void onVolumeChanged(lv_event_t* e);
@@ -49,6 +50,7 @@ private:
     static void onIdleActionChanged(lv_event_t* e);
     void updateAutoRunToggle();
     void updateIdleActionDropdown();
+    void updateTrainingTargetDropdown();
 
     lv_obj_t* autoRunToggle_ = nullptr;
     lv_obj_t* container_ = nullptr;
@@ -56,6 +58,7 @@ private:
     lv_obj_t* idleActionDropdown_ = nullptr;
     lv_obj_t* resetButton_ = nullptr;
     lv_obj_t* resetConfirmCheckbox_ = nullptr;
+    lv_obj_t* trainingTargetDropdown_ = nullptr;
     lv_obj_t* timezoneButton_ = nullptr;
     lv_obj_t* volumeStepper_ = nullptr;
     Network::WebSocketServiceInterface* wsService_ = nullptr;

--- a/apps/src/ui/controls/TrainingPopulationPanel.cpp
+++ b/apps/src/ui/controls/TrainingPopulationPanel.cpp
@@ -37,6 +37,7 @@ std::vector<TrainingPopulationPanel::BrainOption> getBrainOptions(OrganismType o
             };
         case OrganismType::DUCK:
             return {
+                { TrainingBrainKind::NeuralNet, true },
                 { TrainingBrainKind::Random, false },
                 { TrainingBrainKind::WallBouncing, false },
                 { TrainingBrainKind::DuckBrain2, false },
@@ -104,11 +105,17 @@ TrainingPopulationPanel::TrainingPopulationPanel(
       trainingSpec_(trainingSpec)
 {
     scenarioOptions_ = {
-        Scenario::EnumType::Benchmark,       Scenario::EnumType::Clock,
-        Scenario::EnumType::DamBreak,        Scenario::EnumType::Empty,
-        Scenario::EnumType::GooseTest,       Scenario::EnumType::Lights,
-        Scenario::EnumType::Raining,         Scenario::EnumType::Sandbox,
-        Scenario::EnumType::TreeGermination, Scenario::EnumType::WaterEqualization,
+        Scenario::EnumType::Benchmark,
+        Scenario::EnumType::Clock,
+        Scenario::EnumType::DamBreak,
+        Scenario::EnumType::Empty,
+        Scenario::EnumType::DuckTraining,
+        Scenario::EnumType::GooseTest,
+        Scenario::EnumType::Lights,
+        Scenario::EnumType::Raining,
+        Scenario::EnumType::Sandbox,
+        Scenario::EnumType::TreeGermination,
+        Scenario::EnumType::WaterEqualization,
     };
     scenarioLabels_.reserve(scenarioOptions_.size());
     for (const auto& scenarioId : scenarioOptions_) {
@@ -608,6 +615,16 @@ void TrainingPopulationPanel::refreshFromSpec()
     }
 
     for (auto& spec : trainingSpec_.population) {
+        if (brainRequiresGenome_ && spec.seedGenomes.empty() && spec.randomCount == 0
+            && spec.count > 0) {
+            spec.randomCount = spec.count;
+        }
+        else if (
+            !brainRequiresGenome_ && spec.count == 0
+            && (!spec.seedGenomes.empty() || spec.randomCount > 0)) {
+            spec.count = static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
+        }
+
         spec.brainKind = brainKind_;
         spec.brainVariant.reset();
         if (!brainRequiresGenome_) {

--- a/apps/src/ui/state-machine/states/TrainingActive.cpp
+++ b/apps/src/ui/state-machine/states/TrainingActive.cpp
@@ -73,7 +73,7 @@ void beginEvolutionSession(TrainingActive& state, StateMachine& sm)
     state.plotBestSeries_.clear();
 
     state.plotBestSeries_.push_back(0.0f);
-  
+
     state.lastFitnessInsightsGeneration_ = -1;
     state.trainingPaused_ = false;
     state.progressEventCount_ = 0;
@@ -259,7 +259,6 @@ State::Any TrainingActive::onEvent(const EvolutionProgressReceivedEvent& evt, St
             const size_t pruneCount = plotBestSeries_.size() - plotRefreshPointCount;
             plotBestSeries_.erase(plotBestSeries_.begin(), plotBestSeries_.begin() + pruneCount);
         }
-
 
         view_->updateFitnessPlots(plotBestSeries_);
     }


### PR DESCRIPTION
Adds duck evolution training support:

- New `DuckNeuralNetBrain` + per-brain genome sizing/compat checks in the training registry.
- New `DuckTraining` scenario (clock-style obstacle course) wired through core/server/UI/CLI.
- Start Menu setting to pick long-term trainer target (trees vs ducks).
- New `UserSettingsPatch` API so CLI can update trainer settings without clobbering unrelated fields.

Tests: `cd apps && make test`