### PR TITLE
Fix x86 UI fullscreen deployment

### DIFF
--- a/apps/src/ui/main.cpp
+++ b/apps/src/ui/main.cpp
@@ -150,6 +150,8 @@ int main(int argc, char** argv)
         parser, "width", "Set window width (default: 1200)", { 'W', "width" }, 1200);
     args::ValueFlag<int> window_height(
         parser, "height", "Set window height (default: 1200)", { 'H', "height" }, 1200);
+    args::Flag fullscreen(parser, "fullscreen", "Start in fullscreen mode", { "fullscreen" });
+    args::Flag maximize(parser, "maximize", "Start in maximized mode", { "maximize" });
     args::ValueFlag<int> max_steps(
         parser,
         "steps",
@@ -242,6 +244,8 @@ int main(int argc, char** argv)
     if (window_width) settings.window_width = args::get(window_width);
     if (window_height) settings.window_height = args::get(window_height);
     if (max_steps) settings.max_steps = args::get(max_steps);
+    if (fullscreen) settings.fullscreen = true;
+    if (maximize) settings.maximize = true;
 
     /* Initialize LVGL. */
     lv_init();

--- a/yocto/meta-dirtsim/recipes-dirtsim/dirtsim/files/dirtsim-ui-x86.service
+++ b/yocto/meta-dirtsim/recipes-dirtsim/dirtsim/files/dirtsim-ui-x86.service
@@ -13,7 +13,7 @@ Environment=DIRTSIM_X11_IDLE_TIMEOUT_SECONDS=21600
 # Start X server and dirtsim-ui directly — no display manager needed.
 # X runs on vt7, leaving vt1-6 free for interactive login.
 # Apply a long display sleep timeout before launching the UI.
-ExecStart=/usr/bin/xinit /bin/sh -lc 'if command -v xset >/dev/null 2>&1; then xset s "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}"; xset dpms "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}"; fi; exec /usr/bin/dirtsim-ui --connect localhost:8080' -- :0 vt7 -keeptty -noreset -nolisten tcp
+ExecStart=/usr/bin/xinit /bin/sh -lc 'if command -v xset >/dev/null 2>&1; then xset s "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}"; xset dpms "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}" "${DIRTSIM_X11_IDLE_TIMEOUT_SECONDS}"; fi; exec /usr/bin/dirtsim-ui --fullscreen --connect localhost:8080' -- :0 vt7 -keeptty -noreset -nolisten tcp
 Restart=no
 
 # Hardware access for X server, GPU, and input devices.


### PR DESCRIPTION
## Summary
- Add `--fullscreen` / `--maximize` flags to `dirtsim-ui`
- On X11, use screen resolution when fullscreen/maximize is requested
- Start x86 systemd `dirtsim-ui` unit with `--fullscreen`
- In x86 fast deploy, copy updated systemd units and daemon-reload

## Test plan
- [x] Deploy to x86 target and verify UI launches fullscreen
- [x] Verify `--maximize` flag works independently
- [x] Confirm fast deploy copies systemd units and reloads daemon