### PR TITLE
Add per-core CPU plot to active training view

### DIFF
--- a/apps/src/core/SystemMetrics.h
+++ b/apps/src/core/SystemMetrics.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 namespace DirtSim {
 
@@ -9,10 +10,11 @@ namespace DirtSim {
 class SystemMetrics {
 public:
     struct Metrics {
-        double cpu_percent = 0.0;     // CPU usage as percentage (0-100).
-        double memory_percent = 0.0;  // Memory usage as percentage (0-100).
-        uint64_t memory_used_kb = 0;  // Memory used in KB.
-        uint64_t memory_total_kb = 0; // Total memory in KB.
+        double cpu_percent = 0.0;                 // CPU usage as percentage (0-100).
+        std::vector<double> cpu_percent_per_core; // Per-core CPU usage percentages (0-100).
+        double memory_percent = 0.0;              // Memory usage as percentage (0-100).
+        uint64_t memory_used_kb = 0;              // Memory used in KB.
+        uint64_t memory_total_kb = 0;             // Total memory in KB.
     };
 
     SystemMetrics();
@@ -37,9 +39,10 @@ private:
         uint64_t total() const;
     };
 
-    CpuSnapshot readCpuSnapshot();
+    void readCpuSnapshots(CpuSnapshot& totalSnapshot, std::vector<CpuSnapshot>& coreSnapshots);
 
     CpuSnapshot prev_cpu_;
+    std::vector<CpuSnapshot> prev_cpu_per_core_;
     bool has_prev_snapshot_ = false;
 };
 

--- a/apps/src/server/api/EvolutionProgress.h
+++ b/apps/src/server/api/EvolutionProgress.h
@@ -30,13 +30,14 @@ struct EvolutionProgress {
     std::vector<uint32_t> lastGenerationFitnessHistogram;
     std::string bestThisGenSource = "none";
     GenomeId bestGenomeId{};
-    double totalTrainingSeconds = 0.0; // Real-world seconds since training started.
-    double currentSimTime = 0.0;       // Sim time for current individual.
-    double cumulativeSimTime = 0.0;    // Total sim time across all individuals.
-    double speedupFactor = 0.0;        // Sim time / real time.
-    double etaSeconds = 0.0;           // Estimated time remaining.
-    int activeParallelism = 0;         // Current allowed concurrency (background + main).
-    double cpuPercent = 0.0;           // Latest system CPU measurement.
+    double totalTrainingSeconds = 0.0;     // Real-world seconds since training started.
+    double currentSimTime = 0.0;           // Sim time for current individual.
+    double cumulativeSimTime = 0.0;        // Total sim time across all individuals.
+    double speedupFactor = 0.0;            // Sim time / real time.
+    double etaSeconds = 0.0;               // Estimated time remaining.
+    int activeParallelism = 0;             // Current allowed concurrency (background + main).
+    double cpuPercent = 0.0;               // Latest system CPU measurement.
+    std::vector<double> cpuPercentPerCore; // Latest per-core CPU measurements.
 
     // Breeding telemetry from the most recent offspring generation step.
     double lastBreedingPerturbationsAvg = 0.0;
@@ -62,7 +63,7 @@ struct EvolutionProgress {
     nlohmann::json toJson() const;
     static constexpr const char* name() { return "EvolutionProgress"; }
 
-    using serialize = zpp::bits::members<39>;
+    using serialize = zpp::bits::members<40>;
 };
 
 } // namespace Api

--- a/apps/src/server/states/Evolution.cpp
+++ b/apps/src/server/states/Evolution.cpp
@@ -400,13 +400,13 @@ void Evolution::onEnter(StateMachine& dsm)
     evolutionConfig.maxParallelEvaluations = resolveParallelEvaluations(
         evolutionConfig.maxParallelEvaluations, static_cast<int>(population.size()));
 
-    // Initialize CPU auto-tuning.
-    if (evolutionConfig.targetCpuPercent > 0) {
-        cpuMetrics_ = std::make_unique<SystemMetrics>();
-        cpuSamples_.clear();
-        lastCpuSampleTime_ = {};
-        cpuMetrics_->get(); // Prime the delta with an initial reading.
-    }
+    // Initialize CPU telemetry.
+    cpuMetrics_ = std::make_unique<SystemMetrics>();
+    cpuSamples_.clear();
+    lastCpuPercent_ = 0.0;
+    lastCpuPercentPerCore_.clear();
+    lastCpuSampleTime_ = {};
+    cpuMetrics_->get(); // Prime the delta with an initial reading.
 
     startWorkers(dsm);
     queueGenerationTasks();
@@ -418,6 +418,8 @@ void Evolution::onExit(StateMachine& dsm)
     stopWorkers();
     cpuMetrics_.reset();
     cpuSamples_.clear();
+    lastCpuPercent_ = 0.0;
+    lastCpuPercentPerCore_.clear();
     storeBestGenome(dsm);
 }
 
@@ -438,7 +440,12 @@ std::optional<Any> Evolution::tick(StateMachine& dsm)
         if (lastCpuSampleTime_ == std::chrono::steady_clock::time_point{}
             || now - lastCpuSampleTime_ >= kCpuSampleInterval) {
             lastCpuSampleTime_ = now;
-            cpuSamples_.push_back(cpuMetrics_->get().cpu_percent);
+            const auto metrics = cpuMetrics_->get();
+            lastCpuPercent_ = metrics.cpu_percent;
+            lastCpuPercentPerCore_ = metrics.cpu_percent_per_core;
+            if (evolutionConfig.targetCpuPercent > 0) {
+                cpuSamples_.push_back(metrics.cpu_percent);
+            }
         }
     }
 
@@ -1470,12 +1477,9 @@ void Evolution::broadcastProgress(StateMachine& dsm)
 
     // Compute CPU auto-tune fields.
     int activeParallelism = evolutionConfig.maxParallelEvaluations;
-    double latestCpu = 0.0;
+    double latestCpu = lastCpuPercent_;
     if (workerState_) {
         activeParallelism = workerState_->allowedConcurrency.load() + 1; // +1 for main thread.
-    }
-    if (!cpuSamples_.empty()) {
-        latestCpu = cpuSamples_.back();
     }
 
     const size_t totalGenomeCount = dsm.getGenomeRepository().count();
@@ -1507,6 +1511,7 @@ void Evolution::broadcastProgress(StateMachine& dsm)
         .etaSeconds = eta,
         .activeParallelism = activeParallelism,
         .cpuPercent = latestCpu,
+        .cpuPercentPerCore = lastCpuPercentPerCore_,
         .lastBreedingPerturbationsAvg = lastBreedingPerturbationsAvg_,
         .lastBreedingResetsAvg = lastBreedingResetsAvg_,
         .lastBreedingWeightChangesAvg = lastBreedingWeightChangesAvg_,

--- a/apps/src/server/states/Evolution.h
+++ b/apps/src/server/states/Evolution.h
@@ -176,6 +176,8 @@ struct Evolution {
     // CPU auto-tuning.
     std::unique_ptr<SystemMetrics> cpuMetrics_;
     std::vector<double> cpuSamples_;
+    double lastCpuPercent_ = 0.0;
+    std::vector<double> lastCpuPercentPerCore_;
     std::chrono::steady_clock::time_point lastCpuSampleTime_{};
 
     void onEnter(StateMachine& dsm);

--- a/apps/src/ui/TrainingActiveView.h
+++ b/apps/src/ui/TrainingActiveView.h
@@ -69,6 +69,7 @@ public:
     Starfield::Snapshot captureStarfieldSnapshot() const;
 
 private:
+    static std::vector<float> buildCpuCoreSeries(const Api::EvolutionProgress& progress);
     static std::vector<float> buildDistributionSeries(const Api::EvolutionProgress& progress);
 
     void createUI();
@@ -128,6 +129,7 @@ private:
 
     std::unique_ptr<CellRenderer> renderer_;
     std::unique_ptr<CellRenderer> bestRenderer_;
+    std::unique_ptr<TimeSeriesPlotWidget> cpuCorePlot_;
     std::unique_ptr<Starfield> starfield_;
     std::unique_ptr<TimeSeriesPlotWidget> bestFitnessPlot_;
     std::unique_ptr<TimeSeriesPlotWidget> lastGenerationDistributionPlot_;

--- a/apps/src/ui/docs/src/screens/training-active.md
+++ b/apps/src/ui/docs/src/screens/training-active.md
@@ -8,10 +8,10 @@
 | [Stop Training]  |  | Time: 1055.5s  Sim: 0.0s  Speed: 1362.4x  ETA: --  CPU: 54%      |  | Episodes: 824 / 5000   |
 | [Pause]          |  | This Gen: 2.64  All Time: 2.64 (Gen 0)                            |  | Novelty: 0.48          |
 |                  |  |                                                                  |  | Plateau: 12 generations|
-|                  |  |   Current                          Best                          |  | ETA: 2h 14m            |
-|                  |  |  +----------------------+      +----------------------+          |  |                        |
-|                  |  |  |                      |      |                      |          |  |                        |
-|                  |  |  |                      |      |                      |          |  |                        |
+| +------------+   |  |   Current                          Best                          |  | ETA: 2h 14m            |
+| |  _CPU--    |   |  |  +----------------------+      +----------------------+          |  |                        |
+| |--|    |____|   |  |  |                      |      |                      |          |  |                        |
+| +------------+   |  |  |                      |      |                      |          |  |                        |
 |                  |  |  +----------------------+      +----------------------+          |  |                        |
 |                  |  |                                                                  |  | Last update: 0.5s ago  |
 |                  |  |   Fitness Insights                                               |  |                        |
@@ -23,7 +23,7 @@
 +------------------+  +------------------------------------------------------------------+  +------------------------+
 ```
 
-Full-screen training view. Icon rail hidden. The center section mirrors current and best cards, while the right panel is reserved for long-term progress stats.
+Full-screen training view. Icon rail hidden. The left stream column includes controls plus a per-core CPU bar chart, while the center section mirrors current and best cards and the right panel is reserved for long-term progress stats.
 
 ## States
 


### PR DESCRIPTION
## Summary
- Extend `SystemMetrics` to collect per-core CPU usage from `/proc/stat` alongside the existing aggregate metric
- Wire per-core data through `EvolutionProgress` API to the UI
- Add a per-core CPU bar chart (`TimeSeriesPlotWidget` in bar mode) to the stream panel in `TrainingActiveView`
- Always initialize CPU telemetry (not just when auto-tuning is enabled), so the UI always has fresh data

## Test plan
- [ ] Verify per-core CPU bars render correctly on the training active screen during an evolution run
- [ ] Confirm aggregate CPU percentage label still works as before
- [ ] Check that CPU auto-tuning behavior is unchanged when `targetCpuPercent > 0`
- [ ] Verify clean startup/shutdown with no metric-related crashes or leaks