### PR TITLE
Improve training fitness graph: tighter layout and robust high highlights

### DIFF
--- a/apps/src/ui/TrainingActiveView.cpp
+++ b/apps/src/ui/TrainingActiveView.cpp
@@ -478,10 +478,13 @@ void TrainingActiveView::createActiveUI(int displayWidth, int displayHeight)
         TimeSeriesPlotWidget::Config{
             .title = "Robust Evaluated",
             .lineColor = lv_color_hex(0xFFDD66),
+            .highlightColor = lv_color_hex(0xFF4FA3),
             .defaultMinY = 0.0f,
             .defaultMaxY = 1.0f,
             .valueScale = 100.0f,
             .autoScaleY = true,
+            .showHighlights = true,
+            .highlightMarkerSizePx = 8,
         });
 
     clearFitnessPlots();
@@ -956,10 +959,11 @@ void TrainingActiveView::updateProgress(const Api::EvolutionProgress& progress)
     }
 }
 
-void TrainingActiveView::updateFitnessPlots(const std::vector<float>& robustFitnessSeries)
+void TrainingActiveView::updateFitnessPlots(
+    const std::vector<float>& robustFitnessSeries, const std::vector<uint8_t>& robustHighMask)
 {
     if (bestFitnessPlot_) {
-        bestFitnessPlot_->setSamples(robustFitnessSeries);
+        bestFitnessPlot_->setSamplesWithHighlights(robustFitnessSeries, robustHighMask);
     }
     if (fitnessPlotsPanel_) {
         lv_obj_invalidate(fitnessPlotsPanel_);

--- a/apps/src/ui/TrainingActiveView.h
+++ b/apps/src/ui/TrainingActiveView.h
@@ -46,7 +46,8 @@ public:
     ~TrainingActiveView();
 
     void updateProgress(const Api::EvolutionProgress& progress);
-    void updateFitnessPlots(const std::vector<float>& robustFitnessSeries);
+    void updateFitnessPlots(
+        const std::vector<float>& robustFitnessSeries, const std::vector<uint8_t>& robustHighMask);
     void clearFitnessPlots();
     void updateAnimations();
 

--- a/apps/src/ui/state-machine/states/TrainingActive.h
+++ b/apps/src/ui/state-machine/states/TrainingActive.h
@@ -52,7 +52,10 @@ struct TrainingActive {
     bool hasTrainingSpec_ = false;
     std::optional<Starfield::Snapshot> starfieldSnapshot_;
     bool trainingPaused_ = false;
+    bool hasPlottedRobustBestFitness_ = false;
+    float plottedRobustBestFitness_ = 0.0f;
     std::vector<float> plotBestSeries_;
+    std::vector<uint8_t> plotBestSeriesRobustHighMask_;
     uint64_t lastPlottedRobustEvaluationCount_ = 0;
     int lastPlottedCompletedGeneration_ = -1;
     uint64_t progressEventCount_ = 0;

--- a/apps/src/ui/widgets/TimeSeriesPlotWidget.h
+++ b/apps/src/ui/widgets/TimeSeriesPlotWidget.h
@@ -13,15 +13,18 @@ public:
     struct Config {
         std::string title;
         lv_color_t lineColor = lv_color_hex(0x88AACC);
+        lv_color_t highlightColor = lv_color_hex(0xFF4FA3);
         float defaultMinY = 0.0f;
         float defaultMaxY = 1.0f;
         float valueScale = 100.0f;
         bool autoScaleY = true;
         bool hideZeroValuePoints = false;
+        bool showHighlights = false;
         bool showYAxisRangeLabels = true;
         lv_chart_type_t chartType = LV_CHART_TYPE_LINE;
         int32_t barGroupGapPx = -1;
         int32_t barSeriesGapPx = -1;
+        int32_t highlightMarkerSizePx = 7;
         uint32_t minPointCount = 2;
     };
 
@@ -33,10 +36,14 @@ public:
     void setBottomLabels(const std::string& left, const std::string& right);
     void clearBottomLabels();
     void setSamples(const std::vector<float>& samples);
+    void setSamplesWithHighlights(
+        const std::vector<float>& samples, const std::vector<uint8_t>& highlightMask);
 
     lv_obj_t* getContainer() const;
 
 private:
+    void setSamplesInternal(
+        const std::vector<float>& samples, const std::vector<uint8_t>* highlightMask);
     int32_t toChartValue(float value) const;
     int32_t measureYAxisLabelTextWidth(const char* text) const;
     void setYAxisRange(float minValue, float maxValue);
@@ -49,11 +56,13 @@ private:
     lv_obj_t* container_ = nullptr;
     lv_obj_t* titleLabel_ = nullptr;
     lv_obj_t* chart_ = nullptr;
+    lv_obj_t* highlightChart_ = nullptr;
     lv_obj_t* yAxisMaxLabel_ = nullptr;
     lv_obj_t* yAxisMinLabel_ = nullptr;
     lv_obj_t* bottomLabelsRow_ = nullptr;
     lv_obj_t* bottomLeftLabel_ = nullptr;
     lv_obj_t* bottomRightLabel_ = nullptr;
+    lv_chart_series_t* highlightSeries_ = nullptr;
     lv_chart_series_t* series_ = nullptr;
     std::vector<int32_t> chartValues_;
     uint32_t minPointCount_ = 2;


### PR DESCRIPTION
## Summary

- Tighten y-axis label width to fit actual text content rather than using a fixed wide gutter, with dynamic resizing as labels grow.
- Align bar chart baseline by removing bottom padding that caused a gap between bars and the axis.
- Overlay a second transparent chart on the fitness plot to render pink circular markers at each new all-time robust evaluation high, making it easy to spot progress milestones at a glance.

## Test plan

- [ ] Run a training session and confirm the fitness plot y-axis labels are no longer over-padded on the left.
- [ ] Confirm bar charts (if any) have bars flush to the baseline.
- [ ] Confirm pink highlight dots appear on the fitness plot whenever a new robust best fitness is achieved.
- [ ] Confirm highlight dots do not appear for non-robust (generation-only) samples.
- [ ] Confirm highlight state resets correctly when a new evolution session begins.