### PR TITLE
Fix manual bandwidth selection and incidental beacon rendering

### DIFF
--- a/apps/design_docs/nes-heuristic-search.md
+++ b/apps/design_docs/nes-heuristic-search.md
@@ -1,0 +1,485 @@
+# NES Heuristic Search Option Catalog
+
+Brainstorming doc for using heuristic search as a gameplay and visualization mechanism for NES
+games, starting with Super Mario Bros. 1.
+
+This document is intentionally an option inventory, not a recommendation document. The current
+goal is to gather plausible design directions and organize them by topic. Choosing between them is
+future work.
+
+## Topics
+
+- Current Constraints And Observations
+- State Representation And Transpositions
+- Action And Segment Representation
+- Planner Families
+- Objectives, State Evaluation, And Search-Control Heuristics
+- Automatic Landmarks And Segment Discovery
+- Geometry And Terrain Extraction
+- Context-Conditioned Action Libraries
+- Neural Network Roles
+- Shared Semantics Between Training And Search
+- Multi-Game Search Architecture
+- Evaluation And Benchmarks
+- Visualization Options
+- Topic Summary
+
+## Current Constraints And Observations
+
+- SMB1 remains a strong first target because it is highly deterministic and already has useful RAM
+  extraction for progress, life state, powerup state, motion, and nearby enemies.
+- `absoluteX` remains the dominant progress signal for SMB. Secondary signals may still be useful as
+  tie-breakers or mode-specific preferences.
+- NES training is already app-headless in the DirtSim sense. A separate option is to build a more
+  specialized search runner that captures only the data the search actually needs.
+- PPU emulation still dominates a large share of runtime cost, even after major optimization.
+- Human labeling effort is intended to be minimal or zero. Automatic landmarks and automatic
+  obstacle discovery are therefore more aligned with the current constraints than hand-authored
+  level markup.
+- The current NN is not yet proven beyond 1-1, which makes it more natural to treat as optional
+  support than as a required core component for the first round of design exploration.
+
+## State Representation And Transpositions
+
+### Canonical Search State Options
+
+- `Exact emulator state.` Use a full savestate as the canonical state for correctness and exact
+  transposition reuse.
+- `RAM-derived state.` Hash a selected subset of SMB RAM fields such as world, level, `absoluteX`,
+  screen-space position, velocity, life state, power state, and enemy slots.
+- `Hybrid state.` Use exact state for correctness and transpositions, and compute a separate coarse
+  feature state for heuristics, bucketing, and pruning.
+
+### Transposition Table Options
+
+- `Pure duplicate suppression.` If the same state has already been seen at equal or lower cost, drop
+  the new visit.
+- `Best-known arrival cost.` Store the best frame count or path cost that reached each state and
+  only revisit if the new path is cheaper.
+- `State plus option context.` Treat the same emulator state as distinct if the path history or
+  segment context matters for debugging, visualization, or commitment policy.
+- `Approximate transpositions.` Merge not only exact matches but also states that appear
+  effectively equivalent under a coarse feature representation.
+
+### Dominance And Bucket-Pruning Options
+
+- `No dominance pruning.` Only use exact transpositions and leave approximate pruning for later.
+- `Strict dominance.` Within a coarse bucket, drop a state if another state is better on all key
+  dimensions.
+- `Frontier-first dominance.` Prefer the state that has better frontier progress and lower elapsed
+  time, with motion and survival signals as tie-breakers.
+- `K-best per bucket.` Keep a small number of diverse high-quality states instead of a single
+  winner.
+
+## Action And Segment Representation
+
+### Action Representation Options
+
+- `Fixed hold macros.` Hold a button mask such as `Right+B` for a fixed number of frames.
+- `Press/release event sequences.` Search directly over input press and release timings.
+- `Parameterized motion primitives.` Use actions such as `run_right(duration)`,
+  `run_jump(hold_frames)`, or `turnaround_jump(duration_before_jump, hold_frames)`.
+- `Semantic options.` Use higher-level maneuver families such as `clear_gap`, `land_on_pipe`, or
+  `flag_finish`.
+- `Closed-loop options.` Use options whose stop condition is state-based rather than frame-based,
+  such as `hold_right_until_grounded`.
+
+### Segment Representation Options
+
+- `Fixed-length segments.` Plan over a fixed number of future frames.
+- `Variable-length segments.` Let segment duration depend on context or candidate policy.
+- `Condition-terminated segments.` End segments on conditions such as grounded landing, death,
+  transition, or frontier gain.
+- `Landmark-terminated segments.` Plan from one anchor to the next rather than over a fixed time
+  window.
+- `Two-stage segments.` Use a coarse segment first and refine the timing near the end.
+
+### Coarse-To-Fine Options
+
+- `Coarse action search plus fine timing refinement.` Search over maneuver families first, then
+  refine press and release timing.
+- `Short-horizon event search near hazards.` Use a richer action language only in contexts that
+  actually need it.
+- `Option library plus segment optimizer.` Search over a compact action library and let a local
+  optimizer tune its parameters.
+
+## Planner Families
+
+### State-Space Planner Options
+
+- `Best-first graph search.` Expand the most promising state next using a heuristic and exact
+  transpositions.
+- `A* or weighted A*.` Treat SMB as a cost-plus-heuristic graph search problem, with weighted A*
+  favored if speed matters more than optimality guarantees.
+- `Beam search.` Keep only the top-N states at each depth.
+- `MCTS.` Explore a search tree adaptively and allocate effort toward promising branches.
+
+### Sequence-Optimization Options
+
+- `Rolling Horizon Evolutionary Algorithm.` Evolve short input sequences from the current root
+  state.
+- `Cross-Entropy Method (CEM).` Sample many candidate sequences, keep the elites, and bias the next
+  sampling round toward them.
+- `Model Predictive Path Integral (MPPI).` Start from a current best segment plan, perturb it many
+  times, and shift it toward the higher-scoring perturbations.
+- `Random or elite shooting.` Sample many sequences and keep only the best, with little or no model
+  update between rounds.
+
+### Hierarchical And Hybrid Planner Options
+
+- `Landmark graph search plus local optimizer.` Search over anchors globally and optimize each local
+  segment separately.
+- `Beam search plus timing refinement.` Use beam search to identify promising maneuver families and
+  refine timing only for survivors.
+- `MCTS plus policy prior.` Use a policy model to bias action ordering or rollout behavior.
+- `NN baseline plus planner challenger.` Let the NN and planner attempt the same segment and choose
+  the better result.
+
+## Objectives, State Evaluation, And Search-Control Heuristics
+
+### Top-Level Objective Options
+
+- `Pure frontier objective.` Maximize best `absoluteX` reached.
+- `Frontier plus time.` Prefer reaching the same frontier sooner in game frames.
+- `Landmark completion objective.` Treat reaching the next anchor safely as the main goal.
+- `Robustness objective.` Prefer plans with larger success margins or more stable post-segment
+  states.
+- `Mode-specific objective.` Keep frontier dominant but vary tie-breakers for speedrun, safety, or
+  powerup-preserving modes.
+
+### State-Evaluation Options
+
+- `Best-frontier evaluation.` Score states using best frontier reached so far, not only current
+  position.
+- `Velocity-aware evaluation.` Use speed and motion quality as tie-breakers for future promise.
+- `Landing-quality evaluation.` Prefer stable grounded states over awkward airborne states at
+  similar progress.
+- `Recovery-potential evaluation.` Distinguish controlled survival from states that are alive but
+  nearly doomed.
+- `Hazard-margin evaluation.` Prefer plans that clear pits, enemies, or stairs with more margin.
+- `Phase-specific evaluation.` Use different tie-breakers depending on flat ground, jump arcs,
+  hazard approach, or level transitions.
+- `Learned value estimate.` Later option: use a learned evaluator to estimate future promise.
+
+### Search-Control Heuristic Options
+
+- `Action ordering.` Expand the most sensible actions first.
+- `Branch suppression.` Limit branching on safe flat ground.
+- `Hazard-triggered branching.` Increase branching near pits, enemy clusters, transitions, and
+  hotspots.
+- `Adaptive horizon.` Use short lookahead in easy regions and deeper lookahead in timing-critical
+  regions.
+- `Dominance pruning.` Use coarse feature dominance to shrink the search space.
+- `K-best per bucket.` Preserve some diversity instead of collapsing early to one local style.
+- `Novelty or diversity bonus.` Intentionally keep some structurally different candidates alive.
+- `Optimistic bounds.` Use a rough upper bound on future progress to stop exploring hopeless
+  states.
+
+## Automatic Landmarks And Segment Discovery
+
+### Landmark Options
+
+- `Progress landmarks.` Use fixed `absoluteX` buckets, screen buckets, or half-screen progress
+  intervals.
+- `Hard RAM-transition landmarks.` Trigger anchors on pipe entry, vine climb, level transition,
+  powerup transition, and similar explicit state changes.
+- `Safe-anchor landmarks.` Detect grounded, stable, post-hazard states that are good segment roots.
+- `Failure-cluster landmarks.` Discover hotspots by clustering deaths, stalls, or severe slowdowns
+  from many baseline runs.
+- `Trajectory landmarks.` Reuse automatically detected jump launches, landings, recoveries, and
+  other motion events as anchor candidates.
+- `Geometry-derived landmarks.` Infer anchors from terrain or level structure once geometry
+  extraction exists.
+
+### Failure-Cluster Options
+
+- `Death clusters.` Cluster repeated deaths by frontier position.
+- `Stall clusters.` Cluster repeated no-progress or low-progress regions.
+- `Velocity-collapse clusters.` Detect locations where policies repeatedly lose momentum.
+- `Transition-failure clusters.` Detect recurring misses of pipe entry, staircase timing, and other
+  special segments.
+- `Mixed-policy hotspot map.` Combine failures from the NN, simple scripted baselines, and shallow
+  planners to find general difficulty regions rather than only model-specific weaknesses.
+
+### Motion-Context Landmark Options
+
+- `Jump launch landmarks.` Detect grounded-to-airborne transitions caused by deliberate jump input.
+- `Landing landmarks.` Detect stable airborne-to-grounded transitions after successful jumps.
+- `Fall landmarks.` Distinguish airborne states caused by falling off support from intentional jump
+  arcs.
+- `Recovery landmarks.` Detect when Mario regains stable control after an unstable phase.
+
+The jump-versus-fall distinction is especially valuable because it adds meaningful context without
+manual level labeling.
+
+## Geometry And Terrain Extraction
+
+### Extraction Source Options
+
+- `PPU or nametable extraction.` Expose internal PPU background state and derive terrain from it.
+- `SMB-specific RAM extraction.` Reverse-engineer SMB's own level or object data structures and
+  decode terrain from game memory.
+- `Palette or video extraction.` Infer terrain from palette-index or RGB frames.
+- `Hybrid extraction.` Combine geometry from PPU or RAM with actor state from existing SMB RAM
+  extraction and hotspot information from observed failures.
+
+### Derived Geometry Products
+
+- `Support map.` Estimate where stable ground exists ahead of Mario.
+- `Gap and ledge map.` Detect likely pits, drops, and unsafe empty spans.
+- `Obstacle-class tags.` Label segments as likely pit, enemy cluster, pipe, stairs, flag finish,
+  or tunnel-like constraints.
+- `Safe-ground candidates.` Detect likely anchor regions without full semantic labeling.
+
+### Scope-Control Options
+
+- `Failure-guided geometry mining.` Only extract and classify terrain around already discovered
+  hotspots.
+- `Coarse structure only.` Start with walkable versus non-walkable support and avoid rich
+  semantics.
+- `Full semantic extraction later.` Leave richer object and tile understanding as a later layer.
+
+## Context-Conditioned Action Libraries
+
+### Conditioning Signal Options
+
+- `Flat versus hazard-nearby.` Split between easy and hard contexts.
+- `Grounded versus airborne.` Use different option families depending on support state.
+- `Jumped versus fell.` Distinguish intentional airborne motion from failure airborne motion.
+- `Enemy-pressure aware.` Use nearby enemy state to widen or narrow the action set.
+- `Transition-state aware.` Use pipe, vine, powerup, and level-transition phases as special
+  contexts.
+- `Geometry-aware.` Later option: use terrain-derived segment classes to choose action families.
+
+### Context-Specific Option Families
+
+- `Safe flat ground library.` Mostly preserve speed and move right.
+- `Hazard-approach library.` Expand jump timing and maneuver variants.
+- `Intentional jump library.` Search over jump-hold duration and steering while airborne.
+- `Fall recovery library.` Use a smaller set focused on salvage rather than normal traversal.
+- `Enemy-cluster library.` Include enemy-specific hops, timing variants, and speed control.
+- `Transition library.` Use special options for pipes, vines, stairs, and flag sequences.
+
+### Structural Options
+
+- `Single universal action library.` Same option set everywhere.
+- `Context-conditioned library.` Switch option families based on runtime context.
+- `Hierarchical option grammar.` Let context determine which maneuver families are even legal to
+  consider next.
+
+## Neural Network Roles
+
+At the current stage, the NN fits more naturally as optional support than as a required planning
+component.
+
+### Near-Term NN Roles
+
+- `Baseline comparator.` Let the NN attempt the same segment and compare it directly with planner
+  output.
+- `Easy-stretch autopilot.` Use the NN only on already-solved or low-risk regions.
+- `Candidate generator.` Let the NN propose candidate segment plans for search to refine or defeat.
+
+### Later NN Roles
+
+- `Action-ordering prior.` Use the NN to rank candidate options before search expands them.
+- `Rollout policy.` Use the NN inside MCTS or other tree search instead of random rollouts.
+- `Value estimator.` Use the NN to estimate state promise without directly controlling the game.
+- `Training target consumer.` Distill successful search results into a faster reactive NN policy.
+
+## Shared Semantics Between Training And Search
+
+The current NES design already suggests a reusable pattern:
+
+- extract game-specific RAM state
+- convert it into a typed per-game state
+- evaluate that state using per-game logic
+
+For heuristic search, an important design question is how much of that should be shared directly
+with training.
+
+### Shared-Layer Options
+
+- `Shared extractor only.` Training and search both use the same per-game RAM extractor, but have
+  separate evaluation and planning logic.
+- `Shared extractor and evaluator.` Training and search both use the same typed state extraction and
+  the same evaluation logic.
+- `Shared semantics package.` Training and search share a per-game package containing extraction,
+  terminal detection, progress logic, event detection, and evaluation updates.
+- `Separate training and search semantics.` Keep the current training-oriented adapter path and build
+  a distinct search-oriented semantics layer later.
+
+### Reusable Shared Components
+
+- `MemorySnapshot -> typed game state.`
+- `typed game state -> evaluation or progress update.`
+- `terminal detection.`
+- `motion-context event detection.` Examples include jump launch, fall, landing, and recovery.
+- `setup-state detection.` Examples include title, waiting, gameplay, transition, and failure
+  phases.
+
+### Evaluator-State Options
+
+If search wants to reuse the exact same evaluation semantics as training, search nodes may need to
+carry evaluator state in addition to emulator state.
+
+- `Emulator state only.` The evaluator is recomputed or simplified from scratch at each state.
+- `Emulator state plus evaluator state.` Each search node carries the extra evaluator bookkeeping
+  needed for exact agreement with training semantics.
+- `Derived evaluator summary.` Carry a reduced evaluator state such as best frontier, frames since
+  progress, and accumulated reward totals instead of a full evaluator object.
+
+### Setup-Script And Bootstrapping Options
+
+Setup scripts are useful not only for training but also for search bootstrapping.
+
+- `Shared setup script.` Use the same scripted setup path to reach a canonical gameplay start state
+  before either training or search begins.
+- `Search-specific root setup.` Allow search to start from a different scripted or saved root than
+  training if a segment-specific start state is needed.
+- `Power-on canonical root.` Always reproduce the same full boot path from power-on.
+- `Saved-root canonical root.` Store specific search roots after setup and start search from those
+  directly.
+
+### Search-Specific Additions On Top Of Shared Semantics
+
+- `action library.`
+- `landmark detection and segment policy.`
+- `transposition keys.`
+- `dominance and pruning rules.`
+- `search-specific heuristics and budget allocation.`
+
+## Multi-Game Search Architecture
+
+The current per-game RAM extractor pattern invites a broader question: what would it mean for a
+heuristic searcher to work across many supported NES games?
+
+### Genericity Options
+
+- `Framework-general.` Use one shared planner core, but require a per-game search adapter.
+- `Extractor-general.` Treat the existence of a RAM extractor as the main prerequisite for search.
+- `Semantics-general.` Require per-game extraction plus progress, terminal, and action semantics.
+- `Fully generic.` Try to make search work on any supported ROM with minimal game-specific logic.
+
+### Per-Game Search Adapter Options
+
+A future search adapter could be lighter and more planner-oriented than the current training
+adapter.
+
+- `Reuse current NesGameAdapter directly.` Extend the existing adapter interface to serve both
+  training and search.
+- `Introduce a search-specific adapter.` Create a new per-game search interface focused on state
+  extraction, objective semantics, landmarks, and action libraries.
+- `Split semantics from orchestration.` Factor extraction and evaluation into reusable per-game
+  semantics while keeping training-control and search-control layers separate.
+
+### Minimal Per-Game Search Contract Options
+
+- `typed state extraction.`
+- `terminal detection.`
+- `progress or objective update.`
+- `optional landmark and event detection.`
+- `optional action library or option grammar.`
+- `optional exact and coarse state keys for transpositions and pruning.`
+
+### Support-Tier Options
+
+- `Tier 1: Searchable.` The game provides typed extraction, terminal detection, a progress
+  objective, and a basic action library.
+- `Tier 2: Segment-aware.` The game also provides landmarks, motion-context events, and richer
+  heuristics.
+- `Tier 3: Rich visualization.` The game also provides geometry extraction, hotspot overlays, and
+  segment classification.
+
+## Evaluation And Benchmarks
+
+### Primary Outcome Metrics
+
+- `Next-landmark solve rate.` Measure how often a planner reaches the next anchor from a fixed root
+  state.
+- `Wall-clock time to first success.` Important for interactive use and watchability.
+- `Wall-clock time to best-known segment.` Useful for anytime planners.
+- `Frontier gained per second.` Useful when no segment success is found.
+- `End-to-end level progress.` Coarse but still useful later.
+
+### Search-Efficiency Metrics
+
+- `Nodes expanded or sequences evaluated.`
+- `Unique exact states reached.`
+- `Transposition hit rate.`
+- `Dominance-prune rate.`
+- `Effective search depth reached.`
+- `Budget spent in hotspot regions versus easy regions.`
+
+### Quality Metrics
+
+- `Plan robustness.` Sensitivity to small timing perturbations or slight root-state variation.
+- `Landing quality or stability.` Whether the end state is easy to continue from.
+- `Margin of success.` Barely clearing an obstacle versus clearing it comfortably.
+- `Replay cleanliness or watchability.` Subjective but still relevant for the visualization goal.
+
+### Benchmark Granularity Options
+
+- `Micro-benchmarks.` Single hotspot or single segment from a fixed root state.
+- `Meso-benchmarks.` Small chains of consecutive segments.
+- `Macro-benchmarks.` Full-level or multi-level play.
+
+### Comparison Set Options
+
+- `Simple scripted baseline.`
+- `NN-only baseline.`
+- `Beam-search baseline.`
+- `Best-first graph-search baseline.`
+- `CEM baseline.`
+- `RHEA baseline.`
+- `MCTS baseline.`
+
+## Visualization Options
+
+One design axis for visualization is whether it emphasizes truthful search artifacts or more
+decorative presentation layers that may obscure what the algorithm is actually doing.
+
+### Low-Cost Visualization Options
+
+- `Level-progress strip.` Show current frontier, hotspots, deaths, stalls, anchors, and solved
+  regions along a horizontal progress axis.
+- `Failure histogram.` Show density of repeated failures or stalls by frontier position.
+- `Segment status panel.` Show current root, current target anchor, current best candidate, and
+  elapsed search time.
+- `Trajectory overlay on simplified map.` Draw attempted and successful paths over a lightweight
+  representation of the level.
+
+### Comparison Visualization Options
+
+- `Planner versus NN on the same root and target.`
+- `Planner versus planner on the same segment.`
+- `Baseline versus refined search on the same hotspot.`
+
+### Developer-Facing Diagnostic Options
+
+- `Transposition hit visualization.`
+- `Dominance-prune counters and trends.`
+- `Bucket occupancy and diversity loss.`
+- `Search-budget allocation across hotspots and easy regions.`
+
+### Richer Later Visualization Options
+
+- `Ghost trajectories over a frozen game frame.`
+- `Multi-viewport candidate comparisons.`
+- `Rewind-and-compare playback of competing segment solutions.`
+
+## Topic Summary
+
+The major topic buckets gathered so far are:
+
+- state representation, transpositions, and dominance pruning
+- action representation and segment structure
+- planner families, including graph search, beam search, MCTS, RHEA, CEM, and MPPI
+- objectives, evaluation functions, and search-control heuristics
+- automatic landmarks, especially failure-cluster and motion-context landmarks
+- geometry and terrain extraction with minimal manual labeling
+- context-conditioned action libraries
+- optional NN roles now and later
+- evaluation and benchmark design
+- truthful and low-cost visualization options
+
+Future work can narrow these options into a concrete plan.

--- a/apps/src/os-manager/OperatingSystemManager.cpp
+++ b/apps/src/os-manager/OperatingSystemManager.cpp
@@ -409,7 +409,8 @@ OsApi::ScannerSnapshotGet::Okay toApiScannerSnapshotOkay(
 {
     OsApi::ScannerSnapshotGet::Okay okay;
     okay.active = active;
-    okay.config = snapshot.config;
+    okay.requestedConfig = snapshot.requestedConfig;
+    okay.appliedConfig = snapshot.appliedConfig;
     okay.currentTuning = snapshot.currentTuning;
 
     const auto now = std::chrono::steady_clock::now();
@@ -435,8 +436,8 @@ OsApi::ScannerSnapshotGet::Okay toApiScannerSnapshotOkay(
     else if (!lastError.empty()) {
         okay.detail = lastError;
     }
-    else if (active && okay.config.mode == ScannerConfigMode::Manual) {
-        const auto& manualConfig = okay.config.manualConfig;
+    else if (active && okay.appliedConfig.mode == ScannerConfigMode::Manual) {
+        const auto& manualConfig = okay.appliedConfig.manualConfig;
         okay.detail = "Listening " + scannerBandLabel(manualConfig.band) + " "
             + scannerManualTargetShortLabel(
                           manualConfig.band, manualConfig.widthMhz, manualConfig.targetChannel)

--- a/apps/src/os-manager/ScannerTypes.h
+++ b/apps/src/os-manager/ScannerTypes.h
@@ -202,6 +202,12 @@ struct ScannerTuning {
     using serialize = zpp::bits::members<4>;
 };
 
+inline bool operator==(const ScannerTuning& lhs, const ScannerTuning& rhs)
+{
+    return lhs.band == rhs.band && lhs.primaryChannel == rhs.primaryChannel
+        && lhs.widthMhz == rhs.widthMhz && lhs.centerChannel == rhs.centerChannel;
+}
+
 inline std::vector<int> scannerBandPrimaryChannels(const ScannerBand band)
 {
     switch (band) {
@@ -278,6 +284,11 @@ struct ScannerAutoConfig {
     using serialize = zpp::bits::members<2>;
 };
 
+inline bool operator==(const ScannerAutoConfig& lhs, const ScannerAutoConfig& rhs)
+{
+    return lhs.band == rhs.band && lhs.widthMhz == rhs.widthMhz;
+}
+
 struct ScannerManualConfig {
     ScannerBand band = ScannerBand::Band5Ghz;
     int widthMhz = 20;
@@ -286,6 +297,12 @@ struct ScannerManualConfig {
     using serialize = zpp::bits::members<3>;
 };
 
+inline bool operator==(const ScannerManualConfig& lhs, const ScannerManualConfig& rhs)
+{
+    return lhs.band == rhs.band && lhs.widthMhz == rhs.widthMhz
+        && lhs.targetChannel == rhs.targetChannel;
+}
+
 struct ScannerConfig {
     ScannerConfigMode mode = ScannerConfigMode::Auto;
     ScannerAutoConfig autoConfig;
@@ -293,6 +310,12 @@ struct ScannerConfig {
 
     using serialize = zpp::bits::members<3>;
 };
+
+inline bool operator==(const ScannerConfig& lhs, const ScannerConfig& rhs)
+{
+    return lhs.mode == rhs.mode && lhs.autoConfig == rhs.autoConfig
+        && lhs.manualConfig == rhs.manualConfig;
+}
 
 inline void to_json(nlohmann::json& j, const ScannerTuning& tuning)
 {

--- a/apps/src/os-manager/api/ScannerSnapshotGet.h
+++ b/apps/src/os-manager/api/ScannerSnapshotGet.h
@@ -53,7 +53,8 @@ struct Command {
 
 struct Okay {
     bool active = false;
-    OsManager::ScannerConfig config = OsManager::scannerDefaultConfig();
+    OsManager::ScannerConfig requestedConfig = OsManager::scannerDefaultConfig();
+    OsManager::ScannerConfig appliedConfig = OsManager::scannerDefaultConfig();
     std::optional<OsManager::ScannerTuning> currentTuning;
     std::string detail;
     std::vector<ObservedRadioInfo> radios;
@@ -61,7 +62,7 @@ struct Okay {
     API_COMMAND_NAME();
     API_JSON_SERIALIZABLE(Okay);
 
-    using serialize = zpp::bits::members<5>;
+    using serialize = zpp::bits::members<6>;
 };
 
 API_STANDARD_TYPES();

--- a/apps/src/os-manager/network/AdaptiveScanPlanner.cpp
+++ b/apps/src/os-manager/network/AdaptiveScanPlanner.cpp
@@ -17,12 +17,6 @@ bool scannerTuningMatchesConfig(const ScannerTuning& tuning, const ScannerAutoCo
     return tuning.band == config.band && tuning.widthMhz == config.widthMhz;
 }
 
-bool scannerTuningsEqual(const ScannerTuning& a, const ScannerTuning& b)
-{
-    return a.band == b.band && a.primaryChannel == b.primaryChannel && a.widthMhz == b.widthMhz
-        && a.centerChannel == b.centerChannel;
-}
-
 ScannerTuning makeScannerTuning(
     const ScannerBand band,
     const int primaryChannel,
@@ -39,23 +33,29 @@ ScannerTuning makeScannerTuning(
 
 std::vector<ScannerTuning> supportedScannerTunings()
 {
-    std::vector<ScannerTuning> tunings;
-    tunings.reserve(48);
+    const auto band24Channels = scannerBandPrimaryChannels(ScannerBand::Band24Ghz);
+    const auto band5Channels = scannerBandPrimaryChannels(ScannerBand::Band5Ghz);
+    const auto band5Centers40 = scannerManualTargetChannels(ScannerBand::Band5Ghz, kWidth40Mhz);
+    const auto band5Centers80 = scannerManualTargetChannels(ScannerBand::Band5Ghz, kWidth80Mhz);
 
-    for (const int channel : scannerBandPrimaryChannels(ScannerBand::Band24Ghz)) {
+    std::vector<ScannerTuning> tunings;
+    tunings.reserve(
+        band24Channels.size() + band5Channels.size() + band5Centers40.size()
+        + band5Centers80.size());
+
+    for (const int channel : band24Channels) {
         tunings.push_back(
             makeScannerTuning(ScannerBand::Band24Ghz, channel, kWidth20Mhz, std::nullopt));
     }
 
-    for (const int channel : scannerBandPrimaryChannels(ScannerBand::Band5Ghz)) {
+    for (const int channel : band5Channels) {
         tunings.push_back(
             makeScannerTuning(ScannerBand::Band5Ghz, channel, kWidth20Mhz, std::nullopt));
     }
 
     // For 40/80 MHz, one tuning per center channel. All primary channels within a center
     // cover the same band, so stepping through them individually is redundant.
-    for (const int centerChannel :
-         scannerManualTargetChannels(ScannerBand::Band5Ghz, kWidth40Mhz)) {
+    for (const int centerChannel : band5Centers40) {
         const auto coveredChannels = scannerTuningCoveredPrimaryChannels(
             ScannerTuning{
                 .band = ScannerBand::Band5Ghz,
@@ -69,8 +69,7 @@ std::vector<ScannerTuning> supportedScannerTunings()
         }
     }
 
-    for (const int centerChannel :
-         scannerManualTargetChannels(ScannerBand::Band5Ghz, kWidth80Mhz)) {
+    for (const int centerChannel : band5Centers80) {
         const auto coveredChannels = scannerTuningCoveredPrimaryChannels(
             ScannerTuning{
                 .band = ScannerBand::Band5Ghz,
@@ -129,7 +128,7 @@ struct AdaptiveScanPlanner::Impl {
     {
         const auto it = std::find_if(
             tuningStates.begin(), tuningStates.end(), [&tuning](const TuningState& state) {
-                return scannerTuningsEqual(state.tuning, tuning);
+                return state.tuning == tuning;
             });
         return *it;
     }
@@ -138,7 +137,7 @@ struct AdaptiveScanPlanner::Impl {
     {
         const auto it = std::find_if(
             tuningStates.begin(), tuningStates.end(), [&tuning](const TuningState& state) {
-                return scannerTuningsEqual(state.tuning, tuning);
+                return state.tuning == tuning;
             });
         return *it;
     }
@@ -251,7 +250,7 @@ struct AdaptiveScanPlanner::Impl {
         const auto candidates = focusCandidates();
         const auto it =
             std::find_if(candidates.begin(), candidates.end(), [&tuning](const TuningState* state) {
-                return scannerTuningsEqual(state->tuning, tuning);
+                return state->tuning == tuning;
             });
         if (it == candidates.end()) {
             nextTrackingIndex = 0;

--- a/apps/src/os-manager/network/AdaptiveScanPlanner.cpp
+++ b/apps/src/os-manager/network/AdaptiveScanPlanner.cpp
@@ -40,7 +40,7 @@ ScannerTuning makeScannerTuning(
 std::vector<ScannerTuning> supportedScannerTunings()
 {
     std::vector<ScannerTuning> tunings;
-    tunings.reserve(84);
+    tunings.reserve(48);
 
     for (const int channel : scannerBandPrimaryChannels(ScannerBand::Band24Ghz)) {
         tunings.push_back(
@@ -52,6 +52,8 @@ std::vector<ScannerTuning> supportedScannerTunings()
             makeScannerTuning(ScannerBand::Band5Ghz, channel, kWidth20Mhz, std::nullopt));
     }
 
+    // For 40/80 MHz, one tuning per center channel. All primary channels within a center
+    // cover the same band, so stepping through them individually is redundant.
     for (const int centerChannel :
          scannerManualTargetChannels(ScannerBand::Band5Ghz, kWidth40Mhz)) {
         const auto coveredChannels = scannerTuningCoveredPrimaryChannels(
@@ -61,9 +63,9 @@ std::vector<ScannerTuning> supportedScannerTunings()
                 .widthMhz = kWidth40Mhz,
                 .centerChannel = centerChannel,
             });
-        for (const int primaryChannel : coveredChannels) {
+        if (!coveredChannels.empty()) {
             tunings.push_back(makeScannerTuning(
-                ScannerBand::Band5Ghz, primaryChannel, kWidth40Mhz, centerChannel));
+                ScannerBand::Band5Ghz, coveredChannels.front(), kWidth40Mhz, centerChannel));
         }
     }
 
@@ -76,9 +78,9 @@ std::vector<ScannerTuning> supportedScannerTunings()
                 .widthMhz = kWidth80Mhz,
                 .centerChannel = centerChannel,
             });
-        for (const int primaryChannel : coveredChannels) {
+        if (!coveredChannels.empty()) {
             tunings.push_back(makeScannerTuning(
-                ScannerBand::Band5Ghz, primaryChannel, kWidth80Mhz, centerChannel));
+                ScannerBand::Band5Ghz, coveredChannels.front(), kWidth80Mhz, centerChannel));
         }
     }
 

--- a/apps/src/os-manager/network/ScannerService.cpp
+++ b/apps/src/os-manager/network/ScannerService.cpp
@@ -163,12 +163,6 @@ std::optional<int> frequencyToChannel(int freqMhz)
     return std::nullopt;
 }
 
-bool scannerTuningsEqual(const ScannerTuning& lhs, const ScannerTuning& rhs)
-{
-    return lhs.band == rhs.band && lhs.primaryChannel == rhs.primaryChannel
-        && lhs.widthMhz == rhs.widthMhz && lhs.centerChannel == rhs.centerChannel;
-}
-
 struct RadiotapInfo {
     uint16_t headerLength = 0;
     std::optional<int> signalDbm;
@@ -1176,8 +1170,8 @@ void ScannerService::threadMain()
             previousTuning = currentTuning_;
         }
 
-        const bool tuningChanged = !previousTuning.has_value()
-            || !scannerTuningsEqual(previousTuning.value(), step.tuning);
+        const bool tuningChanged =
+            !previousTuning.has_value() || !(previousTuning.value() == step.tuning);
         if (tuningChanged) {
             const auto setChannelResult = setChannel(step.tuning);
             if (setChannelResult.isError()) {
@@ -1203,15 +1197,13 @@ void ScannerService::threadMain()
 
             // Drain stale packets from the previous dwell so they are not
             // attributed to the new tuning.
+            int fd = -1;
             {
-                int fd = -1;
-                {
-                    std::lock_guard<std::mutex> lock(mutex_);
-                    fd = socketFd_;
-                }
-                if (fd >= 0) {
-                    drainPendingPackets(fd, buffer);
-                }
+                std::lock_guard<std::mutex> lock(mutex_);
+                fd = socketFd_;
+            }
+            if (fd >= 0) {
+                drainPendingPackets(fd, buffer);
             }
 
             if (manualMode) {

--- a/apps/src/os-manager/network/ScannerService.cpp
+++ b/apps/src/os-manager/network/ScannerService.cpp
@@ -621,7 +621,7 @@ Result<std::monostate, std::string> ScannerService::start()
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        activeConfig_ = requestedConfig_;
+        appliedConfig_ = requestedConfig_;
         currentTuning_.reset();
         lastError_.clear();
         manualReadbackExpectedChanspec_.reset();
@@ -660,7 +660,7 @@ void ScannerService::stop()
     int fd = -1;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        activeConfig_ = requestedConfig_;
+        appliedConfig_ = requestedConfig_;
         fd = socketFd_;
         socketFd_ = -1;
         currentTuning_.reset();
@@ -695,7 +695,8 @@ ScannerService::Snapshot ScannerService::snapshot(uint64_t maxAgeMs, size_t maxR
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        snapshot.config = activeConfig_;
+        snapshot.requestedConfig = requestedConfig_;
+        snapshot.appliedConfig = appliedConfig_;
         snapshot.currentTuning = currentTuning_;
         snapshot.radios.reserve(radiosByBssid_.size());
         for (const auto& [bssid, state] : radiosByBssid_) {
@@ -812,7 +813,7 @@ Result<std::monostate, std::string> ScannerService::setConfig(const ScannerConfi
         std::lock_guard<std::mutex> lock(mutex_);
         requestedConfig_ = config;
         if (!running_ || !currentTuning_.has_value()) {
-            activeConfig_ = config;
+            appliedConfig_ = config;
         }
     }
     return Result<std::monostate, std::string>::okay(std::monostate{});
@@ -1221,7 +1222,7 @@ void ScannerService::threadMain()
         {
             std::lock_guard<std::mutex> lock(mutex_);
             if (stepConfig.has_value()) {
-                activeConfig_ = stepConfig.value();
+                appliedConfig_ = stepConfig.value();
             }
             currentTuning_ = step.tuning;
             lastError_.clear();

--- a/apps/src/os-manager/network/ScannerService.cpp
+++ b/apps/src/os-manager/network/ScannerService.cpp
@@ -30,6 +30,9 @@ constexpr int kMinDwellMs = 100;
 constexpr int kManualDwellMs = 250;
 constexpr int kProbeTimeoutPaddingMs = 5000;
 constexpr auto kIncidentalObservationLogCooldown = std::chrono::seconds(5);
+constexpr auto kManualRetuneDrainWindow = std::chrono::milliseconds(25);
+constexpr auto kManualRetuneReadbackPollInterval = std::chrono::milliseconds(10);
+constexpr auto kManualRetuneReadbackTimeout = std::chrono::milliseconds(150);
 constexpr auto kManualReadbackSampleInterval = std::chrono::milliseconds(100);
 
 enum class ParsedChannelSource { DsParameterSet = 0, HtOperation, Radiotap, Hint };
@@ -160,6 +163,12 @@ std::optional<int> frequencyToChannel(int freqMhz)
     return std::nullopt;
 }
 
+bool scannerTuningsEqual(const ScannerTuning& lhs, const ScannerTuning& rhs)
+{
+    return lhs.band == rhs.band && lhs.primaryChannel == rhs.primaryChannel
+        && lhs.widthMhz == rhs.widthMhz && lhs.centerChannel == rhs.centerChannel;
+}
+
 struct RadiotapInfo {
     uint16_t headerLength = 0;
     std::optional<int> signalDbm;
@@ -175,6 +184,73 @@ ScannerService::ProbeDwell probeDwellFromObservation(const StepObservation& obse
         .strongestSignalDbm = observation.strongestSignalDbm,
         .observedChannels = observation.observedChannels,
     };
+}
+
+Result<std::monostate, std::string> waitForManualReadbackMatch(
+    ScannerChannelController& channelController, const ScannerTuning& tuning)
+{
+    const auto expectedChanspecResult = NexmonChannelProtocol::encodeChanspec(tuning);
+    if (expectedChanspecResult.isError()) {
+        return Result<std::monostate, std::string>::error(expectedChanspecResult.errorValue());
+    }
+
+    const uint32_t expectedChanspec = expectedChanspecResult.value();
+    const auto deadline = std::chrono::steady_clock::now() + kManualRetuneReadbackTimeout;
+    std::optional<uint32_t> lastActualChanspec;
+    std::optional<std::string> lastReadbackError;
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        const auto readbackResult = channelController.readbackChanspec();
+        if (readbackResult.isValue()) {
+            if (readbackResult.value() == expectedChanspec) {
+                return Result<std::monostate, std::string>::okay(std::monostate{});
+            }
+
+            lastActualChanspec = readbackResult.value();
+            lastReadbackError.reset();
+        }
+        else {
+            lastReadbackError = readbackResult.errorValue();
+        }
+
+        std::this_thread::sleep_for(kManualRetuneReadbackPollInterval);
+    }
+
+    std::string error = "Manual tuning readback did not settle to "
+        + NexmonChannelProtocol::describeChanspec(expectedChanspec);
+    if (lastActualChanspec.has_value()) {
+        error +=
+            "; last actual=" + NexmonChannelProtocol::describeChanspec(lastActualChanspec.value());
+    }
+    else if (lastReadbackError.has_value()) {
+        error += "; last readback error=" + lastReadbackError.value();
+    }
+
+    return Result<std::monostate, std::string>::error(error);
+}
+
+void drainPendingPackets(int fd, std::array<uint8_t, 8192>& buffer)
+{
+    const auto deadline = std::chrono::steady_clock::now() + kManualRetuneDrainWindow;
+    while (std::chrono::steady_clock::now() < deadline) {
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+            deadline - std::chrono::steady_clock::now());
+        const int timeoutMs = std::max(0, static_cast<int>(remaining.count()));
+
+        pollfd pfd{};
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+
+        const int pollResult = ::poll(&pfd, 1, timeoutMs);
+        if (pollResult <= 0 || (pfd.revents & POLLIN) == 0) {
+            return;
+        }
+
+        const ssize_t received = ::recvfrom(fd, buffer.data(), buffer.size(), 0, nullptr, nullptr);
+        if (received <= 0) {
+            return;
+        }
+    }
 }
 
 RadiotapInfo parseRadiotap(const uint8_t* data, size_t length)
@@ -545,6 +621,7 @@ Result<std::monostate, std::string> ScannerService::start()
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
+        activeConfig_ = requestedConfig_;
         currentTuning_.reset();
         lastError_.clear();
         manualReadbackExpectedChanspec_.reset();
@@ -583,6 +660,7 @@ void ScannerService::stop()
     int fd = -1;
     {
         std::lock_guard<std::mutex> lock(mutex_);
+        activeConfig_ = requestedConfig_;
         fd = socketFd_;
         socketFd_ = -1;
         currentTuning_.reset();
@@ -617,7 +695,7 @@ ScannerService::Snapshot ScannerService::snapshot(uint64_t maxAgeMs, size_t maxR
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        snapshot.config = requestedConfig_;
+        snapshot.config = activeConfig_;
         snapshot.currentTuning = currentTuning_;
         snapshot.radios.reserve(radiosByBssid_.size());
         for (const auto& [bssid, state] : radiosByBssid_) {
@@ -733,6 +811,9 @@ Result<std::monostate, std::string> ScannerService::setConfig(const ScannerConfi
     {
         std::lock_guard<std::mutex> lock(mutex_);
         requestedConfig_ = config;
+        if (!running_ || !currentTuning_.has_value()) {
+            activeConfig_ = config;
+        }
     }
     return Result<std::monostate, std::string>::okay(std::monostate{});
 }
@@ -1035,6 +1116,7 @@ void ScannerService::threadMain()
         }
 
         ScanStep step;
+        std::optional<ScannerConfig> stepConfig;
         bool manualMode = false;
         if (probe) {
             resetManualReadbackSampler();
@@ -1049,6 +1131,7 @@ void ScannerService::threadMain()
                 std::lock_guard<std::mutex> lock(mutex_);
                 configCopy = requestedConfig_;
             }
+            stepConfig = configCopy;
 
             if (configCopy.mode == ScannerConfigMode::Manual) {
                 manualMode = true;
@@ -1077,30 +1160,74 @@ void ScannerService::threadMain()
             }
         }
 
-        const auto setChannelResult = setChannel(step.tuning);
-        if (setChannelResult.isError()) {
-            {
-                std::lock_guard<std::mutex> lock(mutex_);
-                currentTuning_.reset();
-                lastError_ = "Failed to set channel " + std::to_string(step.tuning.primaryChannel)
-                    + ": " + setChannelResult.errorValue();
+        std::optional<ScannerTuning> previousTuning;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            previousTuning = currentTuning_;
+        }
+
+        const bool tuningChanged = !previousTuning.has_value()
+            || !scannerTuningsEqual(previousTuning.value(), step.tuning);
+        if (tuningChanged) {
+            const auto setChannelResult = setChannel(step.tuning);
+            if (setChannelResult.isError()) {
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    currentTuning_.reset();
+                    lastError_ = "Failed to set channel "
+                        + std::to_string(step.tuning.primaryChannel) + ": "
+                        + setChannelResult.errorValue();
+                }
+                if (probe) {
+                    completeProbe(
+                        probe,
+                        Result<ProbeResult, std::string>::error(
+                            "Failed to set probe tuning "
+                            + std::to_string(step.tuning.primaryChannel) + ": "
+                            + setChannelResult.errorValue()));
+                }
+                notifySnapshotChanged();
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                continue;
             }
-            if (probe) {
-                completeProbe(
-                    probe,
-                    Result<ProbeResult, std::string>::error(
-                        "Failed to set probe tuning " + std::to_string(step.tuning.primaryChannel)
-                        + ": " + setChannelResult.errorValue()));
+
+            if (manualMode) {
+                const auto settleResult =
+                    waitForManualReadbackMatch(*channelController_, step.tuning);
+                if (settleResult.isError()) {
+                    {
+                        std::lock_guard<std::mutex> lock(mutex_);
+                        currentTuning_.reset();
+                        lastError_ = settleResult.errorValue();
+                    }
+                    notifySnapshotChanged();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    continue;
+                }
+
+                resetManualReadbackSampler();
+
+                int fd = -1;
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    fd = socketFd_;
+                }
+                if (fd >= 0) {
+                    drainPendingPackets(fd, buffer);
+                }
             }
-            notifySnapshotChanged();
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            continue;
         }
 
         {
             std::lock_guard<std::mutex> lock(mutex_);
+            if (stepConfig.has_value()) {
+                activeConfig_ = stepConfig.value();
+            }
             currentTuning_ = step.tuning;
             lastError_.clear();
+        }
+        if (manualMode && tuningChanged) {
+            notifySnapshotChanged();
         }
 
         StepObservation observation{

--- a/apps/src/os-manager/network/ScannerService.cpp
+++ b/apps/src/os-manager/network/ScannerService.cpp
@@ -1171,7 +1171,7 @@ void ScannerService::threadMain()
         }
 
         const bool tuningChanged =
-            !previousTuning.has_value() || !(previousTuning.value() == step.tuning);
+            !previousTuning.has_value() || previousTuning.value() != step.tuning;
         if (tuningChanged) {
             const auto setChannelResult = setChannel(step.tuning);
             if (setChannelResult.isError()) {

--- a/apps/src/os-manager/network/ScannerService.cpp
+++ b/apps/src/os-manager/network/ScannerService.cpp
@@ -1042,10 +1042,19 @@ std::optional<ScannerService::PacketObservation> ScannerService::handlePacket(
         state.signalDbm = parsed->signalDbm;
     }
     if (parsed->channel.has_value()) {
+        // If the radio moved to a different channel, reset the latch so it
+        // must be directly confirmed again on the new channel.
+        if (state.channel.has_value() && state.channel.value() != parsed->channel.value()) {
+            state.observationKind = ScannerObservationKind::Incidental;
+        }
         state.channel = parsed->channel;
-        state.observationKind =
-            scannerObservationKindForPrimaryChannel(tuning, parsed->channel.value());
-        if (state.observationKind == ScannerObservationKind::Incidental) {
+        // Once directly confirmed, keep it. Incidental re-observations on other dwells
+        // should not downgrade the classification.
+        const auto kind = scannerObservationKindForPrimaryChannel(tuning, parsed->channel.value());
+        if (state.observationKind != ScannerObservationKind::Direct) {
+            state.observationKind = kind;
+        }
+        if (kind == ScannerObservationKind::Incidental) {
             const bool shouldLog = !state.lastIncidentalLoggedAt.has_value()
                 || now - state.lastIncidentalLoggedAt.value() >= kIncidentalObservationLogCooldown
                 || state.lastIncidentalLoggedChannel != parsed->channel;
@@ -1192,6 +1201,19 @@ void ScannerService::threadMain()
                 continue;
             }
 
+            // Drain stale packets from the previous dwell so they are not
+            // attributed to the new tuning.
+            {
+                int fd = -1;
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    fd = socketFd_;
+                }
+                if (fd >= 0) {
+                    drainPendingPackets(fd, buffer);
+                }
+            }
+
             if (manualMode) {
                 const auto settleResult =
                     waitForManualReadbackMatch(*channelController_, step.tuning);
@@ -1207,15 +1229,6 @@ void ScannerService::threadMain()
                 }
 
                 resetManualReadbackSampler();
-
-                int fd = -1;
-                {
-                    std::lock_guard<std::mutex> lock(mutex_);
-                    fd = socketFd_;
-                }
-                if (fd >= 0) {
-                    drainPendingPackets(fd, buffer);
-                }
             }
         }
 

--- a/apps/src/os-manager/network/ScannerService.h
+++ b/apps/src/os-manager/network/ScannerService.h
@@ -35,7 +35,8 @@ public:
 
     struct Snapshot {
         bool running = false;
-        ScannerConfig config = scannerDefaultConfig();
+        ScannerConfig requestedConfig = scannerDefaultConfig();
+        ScannerConfig appliedConfig = scannerDefaultConfig();
         std::optional<ScannerTuning> currentTuning;
         std::vector<ObservedRadio> radios;
     };
@@ -137,7 +138,7 @@ private:
     std::unordered_map<std::string, std::chrono::steady_clock::time_point>
         probeRequestLoggedAtByKey_;
     std::unordered_map<std::string, RadioState> radiosByBssid_;
-    ScannerConfig activeConfig_ = scannerDefaultConfig();
+    ScannerConfig appliedConfig_ = scannerDefaultConfig();
     std::optional<ScannerTuning> currentTuning_;
     std::string lastError_;
     ScannerConfig requestedConfig_ = scannerDefaultConfig();

--- a/apps/src/os-manager/network/ScannerService.h
+++ b/apps/src/os-manager/network/ScannerService.h
@@ -94,7 +94,7 @@ private:
         std::optional<int> lastIncidentalLoggedChannel;
         std::optional<std::chrono::steady_clock::time_point> lastIncidentalLoggedAt;
         std::chrono::steady_clock::time_point lastSeenAt;
-        ScannerObservationKind observationKind = ScannerObservationKind::Direct;
+        ScannerObservationKind observationKind = ScannerObservationKind::Incidental;
     };
 
     void threadMain();

--- a/apps/src/os-manager/network/ScannerService.h
+++ b/apps/src/os-manager/network/ScannerService.h
@@ -137,6 +137,7 @@ private:
     std::unordered_map<std::string, std::chrono::steady_clock::time_point>
         probeRequestLoggedAtByKey_;
     std::unordered_map<std::string, RadioState> radiosByBssid_;
+    ScannerConfig activeConfig_ = scannerDefaultConfig();
     std::optional<ScannerTuning> currentTuning_;
     std::string lastError_;
     ScannerConfig requestedConfig_ = scannerDefaultConfig();

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
@@ -165,7 +165,7 @@ lv_obj_t* getActionDropdownWidget(lv_obj_t* container)
 
 void setActionDropdownOptions(lv_obj_t* container, const std::string& options)
 {
-    auto* dropdown = getActionDropdownWidget(container);
+    lv_obj_t* dropdown = getActionDropdownWidget(container);
     if (!dropdown) {
         return;
     }
@@ -178,12 +178,12 @@ void styleScannerDropdownPopup(lv_obj_t* container)
     constexpr int popupLineSpace = 28;
     constexpr int popupPadVertical = 28;
 
-    auto* dropdown = getActionDropdownWidget(container);
+    lv_obj_t* dropdown = getActionDropdownWidget(container);
     if (!dropdown) {
         return;
     }
 
-    auto* list = lv_dropdown_get_list(dropdown);
+    lv_obj_t* list = lv_dropdown_get_list(dropdown);
     if (!list) {
         return;
     }
@@ -193,7 +193,7 @@ void styleScannerDropdownPopup(lv_obj_t* container)
     lv_obj_set_style_text_line_space(list, popupLineSpace, LV_PART_MAIN);
     lv_obj_set_style_text_line_space(list, popupLineSpace, LV_PART_SELECTED);
 
-    auto* label = lv_obj_get_child(list, 0);
+    lv_obj_t* label = lv_obj_get_child(list, 0);
     if (label) {
         lv_obj_set_style_text_line_space(label, popupLineSpace, LV_PART_MAIN);
     }
@@ -245,21 +245,6 @@ void normalizeScannerConfig(OsManager::ScannerConfig& config)
     }
 
     config.manualConfig.targetChannel = targetChannels.front();
-}
-
-bool scannerConfigsEqual(const OsManager::ScannerConfig& lhs, const OsManager::ScannerConfig& rhs)
-{
-    return lhs.mode == rhs.mode && lhs.autoConfig.band == rhs.autoConfig.band
-        && lhs.autoConfig.widthMhz == rhs.autoConfig.widthMhz
-        && lhs.manualConfig.band == rhs.manualConfig.band
-        && lhs.manualConfig.widthMhz == rhs.manualConfig.widthMhz
-        && lhs.manualConfig.targetChannel == rhs.manualConfig.targetChannel;
-}
-
-bool scannerTuningsEqual(const OsManager::ScannerTuning& lhs, const OsManager::ScannerTuning& rhs)
-{
-    return lhs.band == rhs.band && lhs.primaryChannel == rhs.primaryChannel
-        && lhs.widthMhz == rhs.widthMhz && lhs.centerChannel == rhs.centerChannel;
 }
 
 std::optional<int> scannerManualPrimaryChannel(const OsManager::ScannerConfig& config)
@@ -2686,16 +2671,6 @@ void NetworkDiagnosticsPanel::clearScannerRadioRows()
     }
 }
 
-bool NetworkDiagnosticsPanel::isScannerConfigRequestInFlight() const
-{
-    if (!asyncState_) {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> lock(asyncState_->mutex);
-    return asyncState_->scannerConfigSetInProgress;
-}
-
 std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerAppliedManualTuning() const
 {
     if (!scannerAppliedConfig_.has_value()
@@ -2738,11 +2713,11 @@ bool NetworkDiagnosticsPanel::isScannerManualRetunePending() const
     }
 
     if (const auto appliedTuning = scannerAppliedManualTuning(); appliedTuning.has_value()) {
-        return !scannerTuningsEqual(appliedTuning.value(), requestedTuning.value());
+        return !(appliedTuning.value() == requestedTuning.value());
     }
 
     if (scannerCurrentTuning_.has_value()) {
-        return !scannerTuningsEqual(scannerCurrentTuning_.value(), requestedTuning.value());
+        return !(scannerCurrentTuning_.value() == requestedTuning.value());
     }
 
     return false;
@@ -2831,7 +2806,7 @@ int NetworkDiagnosticsPanel::scannerSelectedWidthMhz() const
 void NetworkDiagnosticsPanel::applyScannerConfigChange(OsManager::ScannerConfig nextConfig)
 {
     normalizeScannerConfig(nextConfig);
-    if (scannerConfigsEqual(nextConfig, scannerConfig_)) {
+    if (nextConfig == scannerConfig_) {
         updateScannerConfigControls();
         updateScannerControls();
         return;
@@ -4592,7 +4567,7 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerSnapshotStale_ = false;
     scannerAppliedConfig_ = snapshot.appliedConfig;
     if (!scannerConfigSetInProgress_) {
-        const bool configChanged = !scannerConfigsEqual(scannerConfig_, snapshot.requestedConfig);
+        const bool configChanged = !(scannerConfig_ == snapshot.requestedConfig);
         scannerConfig_ = snapshot.requestedConfig;
         if (configChanged) {
             ++scannerConfigRefreshToken_;
@@ -4639,7 +4614,7 @@ void NetworkDiagnosticsPanel::updateScannerConfigControls()
     const ScannerBand selectedBand = scannerConfigBand(scannerConfig_);
     const int selectedWidthMhz = scannerConfigWidthMhz(scannerConfig_);
     const bool controlsEnabled = scannerModeAvailable_ && !scannerActionInProgress_
-        && !scannerStatusUnavailable_ && !scannerConfigSetInProgress_;
+        && !scannerConfigSetInProgress_ && !scannerStatusUnavailable_;
 
     if (scannerBandDropdown_) {
         LVGLBuilder::ActionDropdownBuilder::setSelected(

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
@@ -2713,11 +2713,11 @@ bool NetworkDiagnosticsPanel::isScannerManualRetunePending() const
     }
 
     if (const auto appliedTuning = scannerAppliedManualTuning(); appliedTuning.has_value()) {
-        return !(appliedTuning.value() == requestedTuning.value());
+        return appliedTuning.value() != requestedTuning.value();
     }
 
     if (scannerCurrentTuning_.has_value()) {
-        return !(scannerCurrentTuning_.value() == requestedTuning.value());
+        return scannerCurrentTuning_.value() != requestedTuning.value();
     }
 
     return false;
@@ -4567,7 +4567,7 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerSnapshotStale_ = false;
     scannerAppliedConfig_ = snapshot.appliedConfig;
     if (!scannerConfigSetInProgress_) {
-        const bool configChanged = !(scannerConfig_ == snapshot.requestedConfig);
+        const bool configChanged = scannerConfig_ != snapshot.requestedConfig;
         scannerConfig_ = snapshot.requestedConfig;
         if (configChanged) {
             ++scannerConfigRefreshToken_;
@@ -5029,6 +5029,7 @@ void NetworkDiagnosticsPanel::updateScannerStatusLabel()
             text += "\nWaiting for scanner data.";
         }
         else {
+            // These conditions are not mutually exclusive.
             if (isScannerManualRetunePending()) {
                 text += "\nRetuning to "
                     + scannerManualTargetShortLabel(

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
@@ -1527,7 +1527,8 @@ void NetworkDiagnosticsPanel::startEventStream()
                         Network::deserialize_payload<OsApi::ScannerSnapshotChanged>(payload);
                     ScannerSnapshot snapshot;
                     snapshot.active = changed.snapshot.active;
-                    snapshot.config = changed.snapshot.config;
+                    snapshot.requestedConfig = changed.snapshot.requestedConfig;
+                    snapshot.appliedConfig = changed.snapshot.appliedConfig;
                     snapshot.currentTuning = changed.snapshot.currentTuning;
                     snapshot.detail = changed.snapshot.detail;
                     snapshot.radios.reserve(changed.snapshot.radios.size());
@@ -3867,7 +3868,8 @@ bool NetworkDiagnosticsPanel::startAsyncScannerSnapshot()
                     const auto& okay = response.value().value();
                     ScannerSnapshot snapshot;
                     snapshot.active = okay.active;
-                    snapshot.config = okay.config;
+                    snapshot.requestedConfig = okay.requestedConfig;
+                    snapshot.appliedConfig = okay.appliedConfig;
                     snapshot.currentTuning = okay.currentTuning;
                     snapshot.detail = okay.detail;
                     snapshot.radios.reserve(okay.radios.size());
@@ -4557,7 +4559,11 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerSnapshotErrorMessage_.clear();
     scannerSnapshotStale_ = false;
     if (!scannerConfigSetInProgress_) {
-        scannerConfig_ = snapshot.config;
+        const bool configChanged = !scannerConfigsEqual(scannerConfig_, snapshot.requestedConfig);
+        scannerConfig_ = snapshot.requestedConfig;
+        if (configChanged) {
+            updateScannerConfigControls();
+        }
     }
     if (!snapshot.detail.empty()) {
         scannerModeDetail_ = snapshot.detail;
@@ -4569,6 +4575,7 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
         if (scannerChannelMap_) {
             scannerChannelMap_->clear();
         }
+        updateScannerConfigControls();
         updateScannerStatusLabel();
         updateScannerChannelMap();
         updateScannerRadioList();
@@ -4583,18 +4590,6 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerObservedRadioCount_ = snapshot.radios.size();
     scannerObservedRadios_ = snapshot.radios;
     scannerSnapshotReceived_ = true;
-    if (scannerConfigSetInProgress_) {
-        if (!scannerModeActive_ || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
-            scannerConfigSetInProgress_ = false;
-        }
-        else {
-            const auto requestedTuning = scannerRequestedManualTuning();
-            if (requestedTuning.has_value() && snapshot.currentTuning.has_value()
-                && scannerTuningsEqual(requestedTuning.value(), snapshot.currentTuning.value())) {
-                scannerConfigSetInProgress_ = false;
-            }
-        }
-    }
     updateScannerStatusLabel();
     updateScannerChannelMap();
     updateScannerRadioList();
@@ -4609,20 +4604,14 @@ void NetworkDiagnosticsPanel::updateScannerConfigControls()
 {
     const ScannerBand selectedBand = scannerConfigBand(scannerConfig_);
     const int selectedWidthMhz = scannerConfigWidthMhz(scannerConfig_);
-    const bool controlsBaseEnabled =
-        scannerModeAvailable_ && !scannerActionInProgress_ && !scannerStatusUnavailable_;
-    const bool allowPendingManualRetuneChanges = controlsBaseEnabled && scannerModeActive_
-        && scannerConfig_.mode == OsManager::ScannerConfigMode::Manual
-        && scannerConfigSetInProgress_ && isScannerManualRetunePending()
-        && !isScannerConfigRequestInFlight();
-    const bool controlsEnabled = controlsBaseEnabled && !scannerConfigSetInProgress_;
-    const bool tuningControlsEnabled = controlsEnabled || allowPendingManualRetuneChanges;
+    const bool controlsEnabled = scannerModeAvailable_ && !scannerActionInProgress_
+        && !scannerStatusUnavailable_ && !scannerConfigSetInProgress_;
 
     if (scannerBandDropdown_) {
         LVGLBuilder::ActionDropdownBuilder::setSelected(
             scannerBandDropdown_, selectedBand == ScannerBand::Band24Ghz ? 0 : 1);
-        setControlEnabled(scannerBandDropdown_, tuningControlsEnabled);
-        setControlEnabled(getActionDropdownWidget(scannerBandDropdown_), tuningControlsEnabled);
+        setControlEnabled(scannerBandDropdown_, controlsEnabled);
+        setControlEnabled(getActionDropdownWidget(scannerBandDropdown_), controlsEnabled);
     }
 
     std::vector<std::string> widthLabels;
@@ -4647,8 +4636,8 @@ void NetworkDiagnosticsPanel::updateScannerConfigControls()
         }
         LVGLBuilder::ActionDropdownBuilder::setSelected(
             scannerWidthDropdown_, static_cast<uint16_t>(selectedWidthIndex));
-        setControlEnabled(scannerWidthDropdown_, tuningControlsEnabled);
-        setControlEnabled(getActionDropdownWidget(scannerWidthDropdown_), tuningControlsEnabled);
+        setControlEnabled(scannerWidthDropdown_, controlsEnabled);
+        setControlEnabled(getActionDropdownWidget(scannerWidthDropdown_), controlsEnabled);
     }
 }
 
@@ -5818,18 +5807,14 @@ void NetworkDiagnosticsPanel::applyPendingUpdates()
     }
 
     if (scannerConfigSetResult.has_value()) {
+        scannerConfigSetInProgress_ = false;
         if (scannerConfigSetResult->isError()) {
-            scannerConfigSetInProgress_ = false;
             LOG_WARN(
                 Controls, "Scanner config update failed: {}", scannerConfigSetResult->errorValue());
             refresh();
         }
         else {
             scannerConfig_ = scannerConfigSetResult->value();
-            if (!scannerModeActive_
-                || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
-                scannerConfigSetInProgress_ = false;
-            }
         }
         updateScannerConfigControls();
         updateScannerStatusLabel();

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
@@ -165,12 +165,38 @@ lv_obj_t* getActionDropdownWidget(lv_obj_t* container)
 
 void setActionDropdownOptions(lv_obj_t* container, const std::string& options)
 {
-    lv_obj_t* dropdown = getActionDropdownWidget(container);
+    auto* dropdown = getActionDropdownWidget(container);
     if (!dropdown) {
         return;
     }
 
     lv_dropdown_set_options(dropdown, options.c_str());
+}
+
+void styleScannerDropdownPopup(lv_obj_t* container)
+{
+    constexpr int popupLineSpace = 28;
+    constexpr int popupPadVertical = 28;
+
+    auto* dropdown = getActionDropdownWidget(container);
+    if (!dropdown) {
+        return;
+    }
+
+    auto* list = lv_dropdown_get_list(dropdown);
+    if (!list) {
+        return;
+    }
+
+    lv_obj_set_style_pad_top(list, popupPadVertical, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(list, popupPadVertical, LV_PART_MAIN);
+    lv_obj_set_style_text_line_space(list, popupLineSpace, LV_PART_MAIN);
+    lv_obj_set_style_text_line_space(list, popupLineSpace, LV_PART_SELECTED);
+
+    auto* label = lv_obj_get_child(list, 0);
+    if (label) {
+        lv_obj_set_style_text_line_space(label, popupLineSpace, LV_PART_MAIN);
+    }
 }
 
 void setControlEnabled(lv_obj_t* control, const bool enabled)
@@ -228,6 +254,12 @@ bool scannerConfigsEqual(const OsManager::ScannerConfig& lhs, const OsManager::S
         && lhs.manualConfig.band == rhs.manualConfig.band
         && lhs.manualConfig.widthMhz == rhs.manualConfig.widthMhz
         && lhs.manualConfig.targetChannel == rhs.manualConfig.targetChannel;
+}
+
+bool scannerTuningsEqual(const OsManager::ScannerTuning& lhs, const OsManager::ScannerTuning& rhs)
+{
+    return lhs.band == rhs.band && lhs.primaryChannel == rhs.primaryChannel
+        && lhs.widthMhz == rhs.widthMhz && lhs.centerChannel == rhs.centerChannel;
 }
 
 std::optional<int> scannerManualPrimaryChannel(const OsManager::ScannerConfig& config)
@@ -395,6 +427,7 @@ constexpr int NETWORK_SCANNER_LIST_AGE_WIDTH = 72;
 constexpr int NETWORK_SCANNER_LIST_CHANNEL_WIDTH = 40;
 constexpr int NETWORK_SCANNER_LIST_RSSI_WIDTH = 56;
 constexpr int NETWORK_SCANNER_MAP_HEIGHT = 116;
+constexpr int NETWORK_SCANNER_SQUARE_BUTTON_SIZE = LVGLBuilder::Style::ACTION_SIZE;
 constexpr uint64_t NETWORK_SCANNER_ROW_STALE_AGE_MS = 5000;
 constexpr float NETWORK_SCANNER_RSSI_SMOOTHING_ALPHA = 0.3f;
 constexpr float NETWORK_SCANNER_RSSI_SWAP_THRESHOLD_DB = 5.0f;
@@ -1000,7 +1033,7 @@ void NetworkDiagnosticsPanel::createUI()
     scannerAutoButton_ = LVGLBuilder::actionButton(scannerControlsRow)
                              .text("Auto")
                              .mode(LVGLBuilder::ActionMode::Push)
-                             .size(NETWORK_ACTION_BUTTON_HEIGHT)
+                             .size(NETWORK_SCANNER_SQUARE_BUTTON_SIZE)
                              .callback(onScannerAutoClicked, this)
                              .buildOrLog();
 
@@ -1010,6 +1043,7 @@ void NetworkDiagnosticsPanel::createUI()
                                .width(NETWORK_SCANNER_CONFIG_DROPDOWN_WIDTH)
                                .callback(onScannerBandChanged, this)
                                .buildOrLog();
+    styleScannerDropdownPopup(scannerBandDropdown_);
 
     scannerWidthDropdown_ = LVGLBuilder::actionDropdown(scannerControlsRow)
                                 .options("20 MHz")
@@ -1017,25 +1051,26 @@ void NetworkDiagnosticsPanel::createUI()
                                 .width(NETWORK_SCANNER_CONFIG_DROPDOWN_WIDTH)
                                 .callback(onScannerWidthChanged, this)
                                 .buildOrLog();
+    styleScannerDropdownPopup(scannerWidthDropdown_);
 
     scannerEnterButton_ = LVGLBuilder::actionButton(scannerControlsRow)
                               .text("Scan")
                               .mode(LVGLBuilder::ActionMode::Push)
-                              .size(NETWORK_ACTION_BUTTON_HEIGHT)
+                              .size(NETWORK_SCANNER_SQUARE_BUTTON_SIZE)
                               .callback(onScannerEnterClicked, this)
                               .buildOrLog();
 
     scannerExitButton_ = LVGLBuilder::actionButton(scannerControlsRow)
                              .text("Wi-Fi")
                              .mode(LVGLBuilder::ActionMode::Push)
-                             .size(NETWORK_ACTION_BUTTON_HEIGHT)
+                             .size(NETWORK_SCANNER_SQUARE_BUTTON_SIZE)
                              .callback(onScannerExitClicked, this)
                              .buildOrLog();
 
     scannerRefreshButton_ = LVGLBuilder::actionButton(scannerControlsRow)
                                 .text("Retry")
                                 .mode(LVGLBuilder::ActionMode::Push)
-                                .size(NETWORK_ACTION_BUTTON_HEIGHT)
+                                .size(NETWORK_SCANNER_SQUARE_BUTTON_SIZE)
                                 .callback(onScannerRefreshClicked, this)
                                 .buildOrLog();
 
@@ -2649,6 +2684,69 @@ void NetworkDiagnosticsPanel::clearScannerRadioRows()
     }
 }
 
+bool NetworkDiagnosticsPanel::isScannerConfigRequestInFlight() const
+{
+    if (!asyncState_) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(asyncState_->mutex);
+    return asyncState_->scannerConfigSetInProgress;
+}
+
+std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerRequestedManualTuning()
+    const
+{
+    if (scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
+        return std::nullopt;
+    }
+
+    const auto tuningResult = scannerManualTargetToTuning(scannerConfig_.manualConfig);
+    if (tuningResult.isError()) {
+        return std::nullopt;
+    }
+
+    return tuningResult.value();
+}
+
+bool NetworkDiagnosticsPanel::isScannerManualRetunePending() const
+{
+    if (!scannerModeActive_ || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual
+        || !scannerCurrentTuning_.has_value()) {
+        return false;
+    }
+
+    const auto requestedTuning = scannerRequestedManualTuning();
+    if (!requestedTuning.has_value()) {
+        return false;
+    }
+
+    return !scannerTuningsEqual(scannerCurrentTuning_.value(), requestedTuning.value());
+}
+
+std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerDisplayedManualTuning()
+    const
+{
+    if (const auto requestedTuning = scannerRequestedManualTuning(); requestedTuning.has_value()) {
+        if (isScannerManualRetunePending() && scannerCurrentTuning_.has_value()) {
+            return scannerCurrentTuning_;
+        }
+
+        return requestedTuning;
+    }
+
+    return std::nullopt;
+}
+
+NetworkDiagnosticsPanel::ScannerBand NetworkDiagnosticsPanel::scannerDisplayedBand() const
+{
+    if (const auto displayTuning = scannerDisplayedManualTuning(); displayTuning.has_value()) {
+        return displayTuning->band;
+    }
+
+    return scannerConfigBand(scannerConfig_);
+}
+
 std::string NetworkDiagnosticsPanel::scannerRadioIdentity(const ScannerObservedRadio& radio) const
 {
     if (!radio.bssid.empty()) {
@@ -2669,7 +2767,7 @@ bool NetworkDiagnosticsPanel::scannerRadioMatchesSelectedBand(
     }
 
     const int channel = radio.channel.value();
-    switch (scannerConfigBand(scannerConfig_)) {
+    switch (scannerDisplayedBand()) {
         case ScannerBand::Band24Ghz:
             return channel >= 1 && channel <= 14;
         case ScannerBand::Band5Ghz:
@@ -2681,7 +2779,7 @@ bool NetworkDiagnosticsPanel::scannerRadioMatchesSelectedBand(
 
 std::string NetworkDiagnosticsPanel::scannerSelectedBandLabel() const
 {
-    switch (scannerConfigBand(scannerConfig_)) {
+    switch (scannerDisplayedBand()) {
         case ScannerBand::Band24Ghz:
             return "2.4 GHz";
         case ScannerBand::Band5Ghz:
@@ -2693,6 +2791,10 @@ std::string NetworkDiagnosticsPanel::scannerSelectedBandLabel() const
 
 int NetworkDiagnosticsPanel::scannerSelectedWidthMhz() const
 {
+    if (const auto displayTuning = scannerDisplayedManualTuning(); displayTuning.has_value()) {
+        return displayTuning->widthMhz;
+    }
+
     return scannerConfigWidthMhz(scannerConfig_);
 }
 
@@ -4417,6 +4519,7 @@ void NetworkDiagnosticsPanel::updateScannerStatus(
     scannerModeDetail_ = status.scannerModeDetail;
 
     if (!scannerModeActive_) {
+        scannerConfigSetInProgress_ = false;
         resetScannerSnapshotState();
         if (scannerChannelMap_) {
             scannerChannelMap_->clear();
@@ -4461,6 +4564,7 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     }
 
     if (!scannerModeActive_) {
+        scannerConfigSetInProgress_ = false;
         resetScannerSnapshotState();
         if (scannerChannelMap_) {
             scannerChannelMap_->clear();
@@ -4479,6 +4583,18 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerObservedRadioCount_ = snapshot.radios.size();
     scannerObservedRadios_ = snapshot.radios;
     scannerSnapshotReceived_ = true;
+    if (scannerConfigSetInProgress_) {
+        if (!scannerModeActive_ || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
+            scannerConfigSetInProgress_ = false;
+        }
+        else {
+            const auto requestedTuning = scannerRequestedManualTuning();
+            if (requestedTuning.has_value() && snapshot.currentTuning.has_value()
+                && scannerTuningsEqual(requestedTuning.value(), snapshot.currentTuning.value())) {
+                scannerConfigSetInProgress_ = false;
+            }
+        }
+    }
     updateScannerStatusLabel();
     updateScannerChannelMap();
     updateScannerRadioList();
@@ -4493,14 +4609,20 @@ void NetworkDiagnosticsPanel::updateScannerConfigControls()
 {
     const ScannerBand selectedBand = scannerConfigBand(scannerConfig_);
     const int selectedWidthMhz = scannerConfigWidthMhz(scannerConfig_);
-    const bool controlsEnabled = scannerModeAvailable_ && !scannerActionInProgress_
-        && !scannerConfigSetInProgress_ && !scannerStatusUnavailable_;
+    const bool controlsBaseEnabled =
+        scannerModeAvailable_ && !scannerActionInProgress_ && !scannerStatusUnavailable_;
+    const bool allowPendingManualRetuneChanges = controlsBaseEnabled && scannerModeActive_
+        && scannerConfig_.mode == OsManager::ScannerConfigMode::Manual
+        && scannerConfigSetInProgress_ && isScannerManualRetunePending()
+        && !isScannerConfigRequestInFlight();
+    const bool controlsEnabled = controlsBaseEnabled && !scannerConfigSetInProgress_;
+    const bool tuningControlsEnabled = controlsEnabled || allowPendingManualRetuneChanges;
 
     if (scannerBandDropdown_) {
         LVGLBuilder::ActionDropdownBuilder::setSelected(
             scannerBandDropdown_, selectedBand == ScannerBand::Band24Ghz ? 0 : 1);
-        setControlEnabled(scannerBandDropdown_, controlsEnabled);
-        setControlEnabled(getActionDropdownWidget(scannerBandDropdown_), controlsEnabled);
+        setControlEnabled(scannerBandDropdown_, tuningControlsEnabled);
+        setControlEnabled(getActionDropdownWidget(scannerBandDropdown_), tuningControlsEnabled);
     }
 
     std::vector<std::string> widthLabels;
@@ -4525,8 +4647,8 @@ void NetworkDiagnosticsPanel::updateScannerConfigControls()
         }
         LVGLBuilder::ActionDropdownBuilder::setSelected(
             scannerWidthDropdown_, static_cast<uint16_t>(selectedWidthIndex));
-        setControlEnabled(scannerWidthDropdown_, controlsEnabled);
-        setControlEnabled(getActionDropdownWidget(scannerWidthDropdown_), controlsEnabled);
+        setControlEnabled(scannerWidthDropdown_, tuningControlsEnabled);
+        setControlEnabled(getActionDropdownWidget(scannerWidthDropdown_), tuningControlsEnabled);
     }
 }
 
@@ -4564,12 +4686,12 @@ void NetworkDiagnosticsPanel::updateScannerChannelMap()
     }
 
     ScannerChannelMapWidget::Model model;
-    model.band = scannerConfigBand(scannerConfig_);
+    model.band = scannerDisplayedBand();
     model.mode = scannerConfig_.mode;
     if (scannerConfig_.mode == OsManager::ScannerConfigMode::Manual) {
-        const auto tuningResult = scannerManualTargetToTuning(scannerConfig_.manualConfig);
-        if (tuningResult.isValue() && tuningResult.value().band == model.band) {
-            model.currentTuning = tuningResult.value();
+        const auto displayTuning = scannerDisplayedManualTuning();
+        if (displayTuning.has_value() && displayTuning->band == model.band) {
+            model.currentTuning = displayTuning;
         }
     }
     else if (scannerCurrentTuning_.has_value() && scannerCurrentTuning_->band == model.band) {
@@ -4732,10 +4854,10 @@ void NetworkDiagnosticsPanel::updateScannerRadioList()
         return;
     }
 
-    if (scannerRenderedBand_ != scannerConfigBand(scannerConfig_)) {
+    if (scannerRenderedBand_ != scannerDisplayedBand()) {
         clearScannerRadioRows();
     }
-    scannerRenderedBand_ = scannerConfigBand(scannerConfig_);
+    scannerRenderedBand_ = scannerDisplayedBand();
 
     std::unordered_set<std::string> currentKeys;
     currentKeys.reserve(radios.size());
@@ -4842,6 +4964,9 @@ void NetworkDiagnosticsPanel::updateScannerRadioList()
 void NetworkDiagnosticsPanel::updateScannerStaleState()
 {
     const bool stale = isScannerSnapshotStale();
+    if (stale && scannerConfigSetInProgress_) {
+        scannerConfigSetInProgress_ = false;
+    }
     if (stale == scannerSnapshotStale_) {
         return;
     }
@@ -4863,11 +4988,21 @@ void NetworkDiagnosticsPanel::updateScannerStatusLabel()
                                             ? "Scanner fixed"
                                             : "Scanner active" };
         if (scannerConfig_.mode == OsManager::ScannerConfigMode::Manual) {
-            parts.push_back(scannerManualTargetShortLabel(
-                scannerConfig_.manualConfig.band,
-                scannerConfig_.manualConfig.widthMhz,
-                scannerConfig_.manualConfig.targetChannel));
-            parts.push_back(std::to_string(scannerConfig_.manualConfig.widthMhz) + " MHz");
+            if (const auto displayTuning = scannerDisplayedManualTuning();
+                displayTuning.has_value()) {
+                parts.push_back(scannerManualTargetShortLabel(
+                    displayTuning->band,
+                    displayTuning->widthMhz,
+                    displayTuning->centerChannel.value_or(displayTuning->primaryChannel)));
+                parts.push_back(std::to_string(displayTuning->widthMhz) + " MHz");
+            }
+            else {
+                parts.push_back(scannerManualTargetShortLabel(
+                    scannerConfig_.manualConfig.band,
+                    scannerConfig_.manualConfig.widthMhz,
+                    scannerConfig_.manualConfig.targetChannel));
+                parts.push_back(std::to_string(scannerConfig_.manualConfig.widthMhz) + " MHz");
+            }
         }
         else if (scannerCurrentTuning_.has_value()) {
             parts.push_back(
@@ -4894,6 +5029,14 @@ void NetworkDiagnosticsPanel::updateScannerStatusLabel()
         }
         else if (!scannerSnapshotReceived_) {
             text += "\nWaiting for scanner data.";
+        }
+        else if (isScannerManualRetunePending()) {
+            text += "\nRetuning to "
+                + scannerManualTargetShortLabel(
+                        scannerConfig_.manualConfig.band,
+                        scannerConfig_.manualConfig.widthMhz,
+                        scannerConfig_.manualConfig.targetChannel)
+                + ".";
         }
     }
     else if (scannerStatusUnavailable_) {
@@ -5675,14 +5818,18 @@ void NetworkDiagnosticsPanel::applyPendingUpdates()
     }
 
     if (scannerConfigSetResult.has_value()) {
-        scannerConfigSetInProgress_ = false;
         if (scannerConfigSetResult->isError()) {
+            scannerConfigSetInProgress_ = false;
             LOG_WARN(
                 Controls, "Scanner config update failed: {}", scannerConfigSetResult->errorValue());
             refresh();
         }
         else {
             scannerConfig_ = scannerConfigSetResult->value();
+            if (!scannerModeActive_
+                || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
+                scannerConfigSetInProgress_ = false;
+            }
         }
         updateScannerConfigControls();
         updateScannerStatusLabel();

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.cpp
@@ -2662,6 +2662,7 @@ bool NetworkDiagnosticsPanel::isScannerSnapshotStale() const
 
 void NetworkDiagnosticsPanel::resetScannerSnapshotState()
 {
+    scannerAppliedConfig_.reset();
     scannerSnapshotActivityAt_.reset();
     scannerCurrentTuning_.reset();
     scannerObservedRadioCount_ = 0;
@@ -2695,6 +2696,21 @@ bool NetworkDiagnosticsPanel::isScannerConfigRequestInFlight() const
     return asyncState_->scannerConfigSetInProgress;
 }
 
+std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerAppliedManualTuning() const
+{
+    if (!scannerAppliedConfig_.has_value()
+        || scannerAppliedConfig_->mode != OsManager::ScannerConfigMode::Manual) {
+        return std::nullopt;
+    }
+
+    const auto tuningResult = scannerManualTargetToTuning(scannerAppliedConfig_->manualConfig);
+    if (tuningResult.isError()) {
+        return std::nullopt;
+    }
+
+    return tuningResult.value();
+}
+
 std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerRequestedManualTuning()
     const
 {
@@ -2712,8 +2728,7 @@ std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerRequeste
 
 bool NetworkDiagnosticsPanel::isScannerManualRetunePending() const
 {
-    if (!scannerModeActive_ || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual
-        || !scannerCurrentTuning_.has_value()) {
+    if (!scannerModeActive_ || scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
         return false;
     }
 
@@ -2722,21 +2737,35 @@ bool NetworkDiagnosticsPanel::isScannerManualRetunePending() const
         return false;
     }
 
-    return !scannerTuningsEqual(scannerCurrentTuning_.value(), requestedTuning.value());
+    if (const auto appliedTuning = scannerAppliedManualTuning(); appliedTuning.has_value()) {
+        return !scannerTuningsEqual(appliedTuning.value(), requestedTuning.value());
+    }
+
+    if (scannerCurrentTuning_.has_value()) {
+        return !scannerTuningsEqual(scannerCurrentTuning_.value(), requestedTuning.value());
+    }
+
+    return false;
 }
 
 std::optional<OsManager::ScannerTuning> NetworkDiagnosticsPanel::scannerDisplayedManualTuning()
     const
 {
-    if (const auto requestedTuning = scannerRequestedManualTuning(); requestedTuning.has_value()) {
-        if (isScannerManualRetunePending() && scannerCurrentTuning_.has_value()) {
+    if (scannerConfig_.mode != OsManager::ScannerConfigMode::Manual) {
+        return std::nullopt;
+    }
+
+    if (scannerModeActive_) {
+        if (scannerCurrentTuning_.has_value()) {
             return scannerCurrentTuning_;
         }
 
-        return requestedTuning;
+        if (const auto appliedTuning = scannerAppliedManualTuning(); appliedTuning.has_value()) {
+            return appliedTuning;
+        }
     }
 
-    return std::nullopt;
+    return scannerRequestedManualTuning();
 }
 
 NetworkDiagnosticsPanel::ScannerBand NetworkDiagnosticsPanel::scannerDisplayedBand() const
@@ -2814,6 +2843,7 @@ void NetworkDiagnosticsPanel::applyScannerConfigChange(OsManager::ScannerConfig 
         return;
     }
 
+    ++scannerConfigRefreshToken_;
     scannerConfig_ = nextConfig;
     updateScannerConfigControls();
     updateScannerStatusLabel();
@@ -3376,8 +3406,10 @@ bool NetworkDiagnosticsPanel::startAsyncRefresh(bool forceRefresh)
     }
 
     auto state = asyncState_;
-    std::thread([state, forceRefresh]() {
+    const uint64_t scannerConfigRefreshToken = scannerConfigRefreshToken_;
+    std::thread([state, forceRefresh, scannerConfigRefreshToken]() {
         PendingRefreshData data;
+        data.scannerConfigRefreshToken = scannerConfigRefreshToken;
         try {
             Network::WebSocketService client;
             const auto connectResult = client.connect(OS_MANAGER_ADDRESS, 2000);
@@ -4558,10 +4590,12 @@ void NetworkDiagnosticsPanel::updateScannerSnapshot(
     scannerSnapshotActivityAt_ = std::chrono::steady_clock::now();
     scannerSnapshotErrorMessage_.clear();
     scannerSnapshotStale_ = false;
+    scannerAppliedConfig_ = snapshot.appliedConfig;
     if (!scannerConfigSetInProgress_) {
         const bool configChanged = !scannerConfigsEqual(scannerConfig_, snapshot.requestedConfig);
         scannerConfig_ = snapshot.requestedConfig;
         if (configChanged) {
+            ++scannerConfigRefreshToken_;
             updateScannerConfigControls();
         }
     }
@@ -5019,13 +5053,19 @@ void NetworkDiagnosticsPanel::updateScannerStatusLabel()
         else if (!scannerSnapshotReceived_) {
             text += "\nWaiting for scanner data.";
         }
-        else if (isScannerManualRetunePending()) {
-            text += "\nRetuning to "
-                + scannerManualTargetShortLabel(
-                        scannerConfig_.manualConfig.band,
-                        scannerConfig_.manualConfig.widthMhz,
-                        scannerConfig_.manualConfig.targetChannel)
-                + ".";
+        else {
+            if (isScannerManualRetunePending()) {
+                text += "\nRetuning to "
+                    + scannerManualTargetShortLabel(
+                            scannerConfig_.manualConfig.band,
+                            scannerConfig_.manualConfig.widthMhz,
+                            scannerConfig_.manualConfig.targetChannel)
+                    + ".";
+            }
+
+            if (!scannerCurrentTuning_.has_value() && !scannerModeDetail_.empty()) {
+                text += "\n" + scannerModeDetail_;
+            }
         }
     }
     else if (scannerStatusUnavailable_) {
@@ -5689,7 +5729,9 @@ void NetworkDiagnosticsPanel::applyPendingUpdates()
     if (refreshData.has_value()) {
         scanInProgress_ = refreshData->scanInProgress;
         updateScannerStatus(refreshData->accessStatusResult);
-        if (!scannerConfigSetInProgress_ && refreshData->scannerConfigResult.has_value()
+        if (!scannerConfigSetInProgress_
+            && refreshData->scannerConfigRefreshToken == scannerConfigRefreshToken_
+            && refreshData->scannerConfigResult.has_value()
             && !refreshData->scannerConfigResult->isError()) {
             scannerConfig_ = refreshData->scannerConfigResult->value();
             updateScannerConfigControls();

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.h
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.h
@@ -238,7 +238,8 @@ private:
 
     struct ScannerSnapshot {
         bool active = false;
-        OsManager::ScannerConfig config = OsManager::scannerDefaultConfig();
+        OsManager::ScannerConfig requestedConfig = OsManager::scannerDefaultConfig();
+        OsManager::ScannerConfig appliedConfig = OsManager::scannerDefaultConfig();
         std::optional<OsManager::ScannerTuning> currentTuning;
         std::string detail;
         std::vector<ScannerObservedRadio> radios;

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.h
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.h
@@ -207,6 +207,7 @@ private:
         Result<std::vector<Network::WifiNetworkInfo>, std::string> listResult;
         Result<NetworkAccessStatus, std::string> accessStatusResult;
         std::optional<Result<OsManager::ScannerConfig, std::string>> scannerConfigResult;
+        uint64_t scannerConfigRefreshToken = 0;
         std::optional<std::vector<Network::WifiAccessPointInfo>> accessPoints;
         std::optional<std::string> activeBssid;
         std::optional<std::vector<NetworkInterfaceInfo>> localAddresses;
@@ -328,6 +329,7 @@ private:
     bool scannerModeActive_ = false;
     bool scannerModeAvailable_ = false;
     std::string scannerModeDetail_;
+    std::optional<OsManager::ScannerConfig> scannerAppliedConfig_;
     std::optional<std::chrono::steady_clock::time_point> scannerSnapshotActivityAt_;
     std::optional<OsManager::ScannerTuning> scannerCurrentTuning_;
     size_t scannerObservedRadioCount_ = 0;
@@ -340,6 +342,7 @@ private:
     bool scannerSnapshotStale_ = false;
     bool scannerStatusUnavailable_ = false;
     OsManager::ScannerConfig scannerConfig_ = OsManager::scannerDefaultConfig();
+    uint64_t scannerConfigRefreshToken_ = 0;
     bool scannerConfigSetInProgress_ = false;
     bool scannerRadiosListScrolling_ = false;
     bool liveScanToggleLocked_ = false;
@@ -395,6 +398,7 @@ private:
     void resetScannerSnapshotState();
     void clearScannerRadioRows();
     bool isScannerConfigRequestInFlight() const;
+    std::optional<OsManager::ScannerTuning> scannerAppliedManualTuning() const;
     std::optional<OsManager::ScannerTuning> scannerDisplayedManualTuning() const;
     ScannerBand scannerDisplayedBand() const;
     bool isScannerManualRetunePending() const;

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.h
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.h
@@ -393,6 +393,11 @@ private:
     bool isScannerSnapshotStale() const;
     void resetScannerSnapshotState();
     void clearScannerRadioRows();
+    bool isScannerConfigRequestInFlight() const;
+    std::optional<OsManager::ScannerTuning> scannerDisplayedManualTuning() const;
+    ScannerBand scannerDisplayedBand() const;
+    bool isScannerManualRetunePending() const;
+    std::optional<OsManager::ScannerTuning> scannerRequestedManualTuning() const;
     std::string scannerRadioIdentity(const ScannerObservedRadio& radio) const;
     bool scannerRadioMatchesSelectedBand(const ScannerObservedRadio& radio) const;
     std::string scannerSelectedBandLabel() const;

--- a/apps/src/ui/controls/NetworkDiagnosticsPanel.h
+++ b/apps/src/ui/controls/NetworkDiagnosticsPanel.h
@@ -397,7 +397,6 @@ private:
     bool isScannerSnapshotStale() const;
     void resetScannerSnapshotState();
     void clearScannerRadioRows();
-    bool isScannerConfigRequestInFlight() const;
     std::optional<OsManager::ScannerTuning> scannerAppliedManualTuning() const;
     std::optional<OsManager::ScannerTuning> scannerDisplayedManualTuning() const;
     ScannerBand scannerDisplayedBand() const;

--- a/apps/src/ui/widgets/ScannerChannelMapWidget.cpp
+++ b/apps/src/ui/widgets/ScannerChannelMapWidget.cpp
@@ -518,23 +518,19 @@ void ScannerChannelMapWidget::drawMap(lv_event_t* e) const
         lv_draw_line(layer, &centerTickDsc);
     }
     else if (hasTuningBounds && model_.currentTuning.has_value()) {
-        int primaryCenterX = 0;
-        if (channelXCenter(
-                channels, plotArea, model_.currentTuning->primaryChannel, primaryCenterX)) {
-            lv_draw_rect_dsc_t markerDsc;
-            lv_draw_rect_dsc_init(&markerDsc);
-            markerDsc.bg_color = accentColor(model_.band);
-            markerDsc.bg_opa = LV_OPA_COVER;
-            markerDsc.radius = LV_RADIUS_CIRCLE;
+        lv_draw_rect_dsc_t markerDsc;
+        lv_draw_rect_dsc_init(&markerDsc);
+        markerDsc.bg_color = accentColor(model_.band);
+        markerDsc.bg_opa = LV_OPA_COVER;
+        markerDsc.radius = LV_RADIUS_CIRCLE;
 
-            lv_area_t markerArea{
-                .x1 = primaryCenterX - 8,
-                .y1 = labelBottom - kCurrentLabelUnderlineHeightPx + 1,
-                .x2 = primaryCenterX + 8,
-                .y2 = labelBottom,
-            };
-            lv_draw_rect(layer, &markerDsc, &markerArea);
-        }
+        lv_area_t markerArea{
+            .x1 = tuningSlotLeft + 1,
+            .y1 = labelBottom - kCurrentLabelUnderlineHeightPx + 1,
+            .x2 = tuningSlotRight - 1,
+            .y2 = labelBottom,
+        };
+        lv_draw_rect(layer, &markerDsc, &markerArea);
     }
 
     int lastLabelRight = std::numeric_limits<int>::min();
@@ -557,15 +553,11 @@ void ScannerChannelMapWidget::drawMap(lv_event_t* e) const
         lastLabelRight = labelRight;
         lv_color_t labelColor = kLabelColor;
         if (model_.currentTuning.has_value() && model_.currentTuning->band == model_.band) {
-            if (model_.mode == OsManager::ScannerConfigMode::Manual
-                && std::find(currentCoveredChannels.begin(), currentCoveredChannels.end(), channel)
-                    != currentCoveredChannels.end()) {
-                labelColor = kManualRailBorderColor;
-            }
-            else if (
-                model_.mode != OsManager::ScannerConfigMode::Manual
-                && channel == model_.currentTuning->primaryChannel) {
-                labelColor = accentColor(model_.band);
+            if (std::find(currentCoveredChannels.begin(), currentCoveredChannels.end(), channel)
+                != currentCoveredChannels.end()) {
+                labelColor = model_.mode == OsManager::ScannerConfigMode::Manual
+                    ? kManualRailBorderColor
+                    : accentColor(model_.band);
             }
         }
 


### PR DESCRIPTION
## Summary

- **Auto mode bandwidth selection**: Split snapshot API into `requestedConfig` + `appliedConfig` to fix race where stale applied config overwrote the UI's bandwidth selection. Fixed dropdown desync by calling `updateScannerConfigControls()` when snapshot config changes.
- **Adaptive scan planner**: Collapsed redundant per-primary-channel tunings at 40/80 MHz to one entry per center channel, so the planner steps by blocks instead of single channels.
- **Channel map rendering**: Auto mode marker now uses full tuning slot width instead of a narrow 16px dot. Label highlighting covers all channels in the current tuning.
- **Incidental beacon classification**: Latched direct observation kind so incidental re-observations on other dwells don't overwrite it. Reset latch when a radio's advertised channel changes. Defaulted RadioState to Incidental so first classification takes effect.
- **Retune packet drain**: Moved stale packet drain from manual-only to all retunes so packets from the previous dwell are not misattributed to the new tuning.

## Test plan
- [x] Auto mode: switching to 40/80 MHz works, channel map shows wide marker
- [x] Manual mode: bandwidth and channel selection works correctly
- [x] Incidental beacons: no longer flicker or render incorrectly as incidental when directly confirmed
- [x] 842 unit tests pass