### PR TITLE
Use learned per-layer leak slopes in duck RNN v2

### DIFF
--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
@@ -41,10 +41,11 @@ constexpr WeightType HIDDEN_STATE_CLAMP_ABS = 3.0f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_MIN = 0.02f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_MAX = 0.98f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_LOGIT_INIT = -1.3862944f; // logit(0.2).
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE = 0.1f;
 
-WeightType relu(WeightType x)
+WeightType leakyRelu(WeightType x)
 {
-    return std::max(static_cast<WeightType>(0.0f), x);
+    return x >= 0.0f ? x : (LEAKY_RELU_NEGATIVE_SLOPE * x);
 }
 
 WeightType sigmoid(WeightType x)
@@ -243,7 +244,7 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         }
 
         for (int h = 0; h < H1_SIZE; ++h) {
-            h1_buffer[h] = relu(h1_buffer[h]);
+            h1_buffer[h] = leakyRelu(h1_buffer[h]);
         }
 
         for (int h = 0; h < H1_SIZE; ++h) {
@@ -279,7 +280,7 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         }
 
         for (int h = 0; h < H2_SIZE; ++h) {
-            h2_buffer[h] = relu(h2_buffer[h]);
+            h2_buffer[h] = leakyRelu(h2_buffer[h]);
         }
 
         for (int h = 0; h < H2_SIZE; ++h) {

--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
@@ -143,6 +143,9 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
             alpha1[i] =
                 std::clamp(sigmoid(alpha1_logit[i]), HIDDEN_LEAK_ALPHA_MIN, HIDDEN_LEAK_ALPHA_MAX);
         }
+        h1NegativeSlopeLogit = genome.weights[idx++];
+        h1NegativeSlope = sigmoidToRange(
+            h1NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
         for (int i = 0; i < W_H1H2_SIZE; ++i) {
             w_h1h2[i] = genome.weights[idx++];
         }
@@ -157,9 +160,6 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
             alpha2[i] =
                 std::clamp(sigmoid(alpha2_logit[i]), HIDDEN_LEAK_ALPHA_MIN, HIDDEN_LEAK_ALPHA_MAX);
         }
-        h1NegativeSlopeLogit = genome.weights[idx++];
-        h1NegativeSlope = sigmoidToRange(
-            h1NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
         h2NegativeSlopeLogit = genome.weights[idx++];
         h2NegativeSlope = sigmoidToRange(
             h2NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
@@ -191,6 +191,7 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         for (int i = 0; i < ALPHA1_LOGIT_SIZE; ++i) {
             genome.weights[idx++] = alpha1_logit[i];
         }
+        genome.weights[idx++] = h1NegativeSlopeLogit;
         for (int i = 0; i < W_H1H2_SIZE; ++i) {
             genome.weights[idx++] = w_h1h2[i];
         }
@@ -203,7 +204,6 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
             genome.weights[idx++] = alpha2_logit[i];
         }
-        genome.weights[idx++] = h1NegativeSlopeLogit;
         genome.weights[idx++] = h2NegativeSlopeLogit;
         for (int i = 0; i < W_H2O_SIZE; ++i) {
             genome.weights[idx++] = w_h2o[i];
@@ -452,6 +452,7 @@ Genome DuckNeuralNetRecurrentBrainV2::randomGenome(std::mt19937& rng)
     for (int i = 0; i < ALPHA1_LOGIT_SIZE; ++i) {
         genome.weights[idx++] = alphaLogitDist(rng);
     }
+    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
     for (int i = 0; i < W_H1H2_SIZE; ++i) {
         genome.weights[idx++] = h1h2Dist(rng);
     }
@@ -464,7 +465,6 @@ Genome DuckNeuralNetRecurrentBrainV2::randomGenome(std::mt19937& rng)
     for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
         genome.weights[idx++] = alphaLogitDist(rng);
     }
-    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
     genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
     for (int i = 0; i < W_H2O_SIZE; ++i) {
         genome.weights[idx++] = h2oDist(rng);
@@ -485,16 +485,15 @@ bool DuckNeuralNetRecurrentBrainV2::isGenomeCompatible(const Genome& genome)
 
 GenomeLayout DuckNeuralNetRecurrentBrainV2::getGenomeLayout()
 {
-    // Keep the learned leak controls in their own small segment so mutation
-    // can actually explore them instead of effectively freezing them inside
-    // the much larger recurrent parameter blocks.
+    // Group each layer's learned leak controls with its recurrent block so the
+    // floor-of-one mutation rule does not force tiny standalone segments to
+    // move on every offspring.
     return GenomeLayout{
         .segments = {
             { "input_h1", W_XH1_SIZE },
-            { "h1_recurrent", W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE },
+            { "h1_recurrent", W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE + 1 },
             { "h1_to_h2", W_H1H2_SIZE },
-            { "h2_recurrent", W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE },
-            { "activation_slopes", ACTIVATION_LEAK_LOGIT_SIZE },
+            { "h2_recurrent", W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE + 1 },
             { "output", W_H2O_SIZE + B_O_SIZE },
         },
     };

--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
@@ -32,20 +32,26 @@ constexpr int W_H1H2_SIZE = H1_SIZE * H2_SIZE;
 constexpr int W_H2H2_SIZE = H2_SIZE * H2_SIZE;
 constexpr int B_H2_SIZE = H2_SIZE;
 constexpr int ALPHA2_LOGIT_SIZE = H2_SIZE;
+constexpr int ACTIVATION_LEAK_LOGIT_SIZE = 2;
 constexpr int W_H2O_SIZE = H2_SIZE * OUTPUT_SIZE;
 constexpr int B_O_SIZE = OUTPUT_SIZE;
 constexpr int TOTAL_WEIGHTS = W_XH1_SIZE + W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE + W_H1H2_SIZE
-    + W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE + W_H2O_SIZE + B_O_SIZE;
+    + W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE + ACTIVATION_LEAK_LOGIT_SIZE + W_H2O_SIZE
+    + B_O_SIZE;
 
 constexpr WeightType HIDDEN_STATE_CLAMP_ABS = 3.0f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_MIN = 0.02f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_MAX = 0.98f;
 constexpr WeightType HIDDEN_LEAK_ALPHA_LOGIT_INIT = -1.3862944f; // logit(0.2).
-constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE = 0.1f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_MIN = 0.02f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_MAX = 0.3f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_INIT = 0.1f;
+// logit((0.1 - 0.02) / (0.3 - 0.02)).
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT = -0.91629076f;
 
-WeightType leakyRelu(WeightType x)
+WeightType leakyRelu(WeightType x, WeightType negativeSlope)
 {
-    return x >= 0.0f ? x : (LEAKY_RELU_NEGATIVE_SLOPE * x);
+    return x >= 0.0f ? x : (negativeSlope * x);
 }
 
 WeightType sigmoid(WeightType x)
@@ -57,6 +63,13 @@ WeightType sigmoid(WeightType x)
 
     const WeightType z = std::exp(x);
     return z / (1.0f + z);
+}
+
+WeightType sigmoidToRange(WeightType x, WeightType minValue, WeightType maxValue)
+{
+    const WeightType unit = sigmoid(x);
+    const WeightType scaled = minValue + ((maxValue - minValue) * unit);
+    return std::clamp(scaled, minValue, maxValue);
 }
 
 } // namespace
@@ -73,6 +86,10 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
     std::vector<WeightType> b_h2;
     std::vector<WeightType> alpha2_logit;
     std::vector<WeightType> alpha2;
+    WeightType h1NegativeSlopeLogit = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    WeightType h1NegativeSlope = LEAKY_RELU_NEGATIVE_SLOPE_INIT;
+    WeightType h2NegativeSlopeLogit = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    WeightType h2NegativeSlope = LEAKY_RELU_NEGATIVE_SLOPE_INIT;
 
     std::vector<WeightType> w_h2o;
     std::vector<WeightType> b_o;
@@ -140,6 +157,12 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
             alpha2[i] =
                 std::clamp(sigmoid(alpha2_logit[i]), HIDDEN_LEAK_ALPHA_MIN, HIDDEN_LEAK_ALPHA_MAX);
         }
+        h1NegativeSlopeLogit = genome.weights[idx++];
+        h1NegativeSlope = sigmoidToRange(
+            h1NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
+        h2NegativeSlopeLogit = genome.weights[idx++];
+        h2NegativeSlope = sigmoidToRange(
+            h2NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
         for (int i = 0; i < W_H2O_SIZE; ++i) {
             w_h2o[i] = genome.weights[idx++];
         }
@@ -180,6 +203,8 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
             genome.weights[idx++] = alpha2_logit[i];
         }
+        genome.weights[idx++] = h1NegativeSlopeLogit;
+        genome.weights[idx++] = h2NegativeSlopeLogit;
         for (int i = 0; i < W_H2O_SIZE; ++i) {
             genome.weights[idx++] = w_h2o[i];
         }
@@ -244,7 +269,7 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         }
 
         for (int h = 0; h < H1_SIZE; ++h) {
-            h1_buffer[h] = leakyRelu(h1_buffer[h]);
+            h1_buffer[h] = leakyRelu(h1_buffer[h], h1NegativeSlope);
         }
 
         for (int h = 0; h < H1_SIZE; ++h) {
@@ -280,7 +305,7 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         }
 
         for (int h = 0; h < H2_SIZE; ++h) {
-            h2_buffer[h] = leakyRelu(h2_buffer[h]);
+            h2_buffer[h] = leakyRelu(h2_buffer[h], h2NegativeSlope);
         }
 
         for (int h = 0; h < H2_SIZE; ++h) {
@@ -439,6 +464,8 @@ Genome DuckNeuralNetRecurrentBrainV2::randomGenome(std::mt19937& rng)
     for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
         genome.weights[idx++] = alphaLogitDist(rng);
     }
+    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
     for (int i = 0; i < W_H2O_SIZE; ++i) {
         genome.weights[idx++] = h2oDist(rng);
     }
@@ -458,15 +485,16 @@ bool DuckNeuralNetRecurrentBrainV2::isGenomeCompatible(const Genome& genome)
 
 GenomeLayout DuckNeuralNetRecurrentBrainV2::getGenomeLayout()
 {
-    // Group small recurrent-control parameters with adjacent matrices so the
-    // budgeted floor-of-one mutation rule does not force every tiny segment
-    // to move on every offspring.
+    // Keep the learned leak controls in their own small segment so mutation
+    // can actually explore them instead of effectively freezing them inside
+    // the much larger recurrent parameter blocks.
     return GenomeLayout{
         .segments = {
             { "input_h1", W_XH1_SIZE },
             { "h1_recurrent", W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE },
             { "h1_to_h2", W_H1H2_SIZE },
             { "h2_recurrent", W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE },
+            { "activation_slopes", ACTIVATION_LEAK_LOGIT_SIZE },
             { "output", W_H2O_SIZE + B_O_SIZE },
         },
     };

--- a/apps/src/core/organisms/evolution/DuckEvaluator.cpp
+++ b/apps/src/core/organisms/evolution/DuckEvaluator.cpp
@@ -10,6 +10,7 @@ namespace DirtSim {
 
 namespace {
 struct DuckClockScoringConfig {
+    double deathPenaltyExponent = 2.0;
     double exitDoorCompletionPoints = 150.0;
     double exitDoorProximityRadiusCells = 10.0;
     double exitDoorProximityPoints = 100.0;
@@ -148,6 +149,18 @@ DuckFitnessBreakdown DuckEvaluator::evaluateWithBreakdown(const FitnessContext& 
     breakdown.exitDoorCompletionPoints =
         breakdown.exitedThroughDoor ? kDuckClockScoringConfig.exitDoorCompletionPoints : 0.0;
     breakdown.survivalPoints = kDuckClockScoringConfig.survivalPoints * breakdown.survivalScore;
+
+    if (context.result.organismDied && !breakdown.exitedThroughDoor) {
+        const double deathPenaltyMultiplier =
+            std::pow(breakdown.survivalScore, kDuckClockScoringConfig.deathPenaltyExponent);
+        breakdown.coursePoints *= deathPenaltyMultiplier;
+        breakdown.exitDoorProximityPoints *= deathPenaltyMultiplier;
+        breakdown.exitDoorCompletionPoints *= deathPenaltyMultiplier;
+        breakdown.obstacleClearRatePoints *= deathPenaltyMultiplier;
+        breakdown.obstacleCompetencePoints *= deathPenaltyMultiplier;
+        breakdown.survivalPoints *= deathPenaltyMultiplier;
+        breakdown.traversalPoints *= deathPenaltyMultiplier;
+    }
 
     breakdown.totalFitness = breakdown.survivalPoints + breakdown.coursePoints
         + breakdown.exitDoorProximityPoints + breakdown.exitDoorCompletionPoints;

--- a/apps/src/core/organisms/evolution/FitnessResult.h
+++ b/apps/src/core/organisms/evolution/FitnessResult.h
@@ -13,6 +13,7 @@ struct FitnessResult {
     int commandsRejected = 0;    // Total rejected commands during lifetime.
     int idleCancels = 0;         // Cancel commands issued while no action was active.
     double nesRewardTotal = 0.0; // Cumulative reward for NES evaluations.
+    bool organismDied = false;   // Whether evaluation ended because the organism died.
     bool exitedThroughDoor = false;
     double exitDoorTime = 0.0; // Sim time when duck exited through door.
 };

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -347,6 +347,9 @@ TrainingRunner::Status TrainingRunner::step(int frames)
         world_->advanceTime(TIMESTEP);
         simTime_ += TIMESTEP;
         updateDuckClockDoors();
+        if (state_ != State::Running) {
+            break;
+        }
 
         Organism::Body* organism = world_->getOrganismManager().getOrganism(organismId_);
         if (!organism) {
@@ -837,6 +840,8 @@ void TrainingRunner::updateDuckClockDoors()
                 }
                 snapshotDuckEvaluationArtifacts();
                 world_->getOrganismManager().removeOrganismFromWorld(*world_, organismId_);
+                state_ = State::ScenarioCompleted;
+                return;
             }
         }
     }

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -57,6 +57,7 @@ class TrainingRunner {
 public:
     enum class State {
         Running,
+        ScenarioCompleted,
         OrganismDied,
         TimeExpired,
     };

--- a/apps/src/core/organisms/evolution/tests/FitnessCalculator_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/FitnessCalculator_test.cpp
@@ -559,6 +559,62 @@ TEST(FitnessCalculatorTest, DuckClockRewardsFasterCourseRates)
     EXPECT_GT(halfBreakdown.totalFitness, fullBreakdown.totalFitness);
 }
 
+TEST(FitnessCalculatorTest, DuckClockDeathPenaltyScalesFitnessBySquaredSurvival)
+{
+    EvolutionConfig config = makeConfig();
+    config.maxSimulationTime = 100.0;
+
+    const FitnessResult aliveResult{ .lifespan = 50.0, .maxEnergy = 0.0 };
+    const FitnessResult deadResult{
+        .lifespan = 50.0,
+        .maxEnergy = 0.0,
+        .organismDied = true,
+    };
+    const DuckClockEvaluationArtifacts clock{
+        .fullTraversals = 2,
+        .hurdleClears = 1,
+        .hurdleOpportunities = 1,
+        .pitClears = 1,
+        .pitOpportunities = 1,
+        .traversalProgress = 2.0,
+        .exitDoorDistanceObserved = true,
+        .bestExitDoorDistanceCells = 5.0,
+    };
+
+    const FitnessContext aliveContext{
+        .result = aliveResult,
+        .organismType = OrganismType::DUCK,
+        .worldWidth = 20,
+        .worldHeight = 20,
+        .evolutionConfig = config,
+        .duckArtifacts = makeClockArtifacts(clock),
+    };
+    const FitnessContext deadContext{
+        .result = deadResult,
+        .organismType = OrganismType::DUCK,
+        .worldWidth = 20,
+        .worldHeight = 20,
+        .evolutionConfig = config,
+        .duckArtifacts = makeClockArtifacts(clock),
+    };
+
+    const DuckFitnessBreakdown aliveBreakdown = DuckEvaluator::evaluateWithBreakdown(aliveContext);
+    const DuckFitnessBreakdown deadBreakdown = DuckEvaluator::evaluateWithBreakdown(deadContext);
+
+    EXPECT_DOUBLE_EQ(aliveBreakdown.survivalScore, 0.5);
+    EXPECT_DOUBLE_EQ(deadBreakdown.survivalScore, 0.5);
+    EXPECT_DOUBLE_EQ(deadBreakdown.survivalPoints, aliveBreakdown.survivalPoints * 0.25);
+    EXPECT_DOUBLE_EQ(deadBreakdown.traversalPoints, aliveBreakdown.traversalPoints * 0.25);
+    EXPECT_DOUBLE_EQ(
+        deadBreakdown.obstacleClearRatePoints, aliveBreakdown.obstacleClearRatePoints * 0.25);
+    EXPECT_DOUBLE_EQ(
+        deadBreakdown.obstacleCompetencePoints, aliveBreakdown.obstacleCompetencePoints * 0.25);
+    EXPECT_DOUBLE_EQ(
+        deadBreakdown.exitDoorProximityPoints, aliveBreakdown.exitDoorProximityPoints * 0.25);
+    EXPECT_DOUBLE_EQ(deadBreakdown.coursePoints, aliveBreakdown.coursePoints * 0.25);
+    EXPECT_DOUBLE_EQ(deadBreakdown.totalFitness, aliveBreakdown.totalFitness * 0.25);
+}
+
 TEST(FitnessCalculatorTest, DuckClockObstacleRateRewardsMoreRepeatedClears)
 {
     EvolutionConfig config = makeConfig();

--- a/apps/src/core/organisms/evolution/tests/TrainingRunnerTraceHarness_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunnerTraceHarness_test.cpp
@@ -293,6 +293,8 @@ std::string formatRunnerState(TrainingRunner::State state)
     switch (state) {
         case TrainingRunner::State::Running:
             return "Running";
+        case TrainingRunner::State::ScenarioCompleted:
+            return "ScenarioCompleted";
         case TrainingRunner::State::TimeExpired:
             return "TimeExpired";
         case TrainingRunner::State::OrganismDied:

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -1185,6 +1185,7 @@ TEST_F(TrainingRunnerTest, ClockDuckDoorLifecycle)
     EXPECT_EQ(runner.getOrganism(), nullptr) << "Duck should be removed after exiting";
 
     const TrainingRunner::Status finalStatus = runner.getStatus();
+    EXPECT_EQ(finalStatus.state, TrainingRunner::State::ScenarioCompleted);
     EXPECT_TRUE(finalStatus.exitedThroughDoor);
     EXPECT_GT(finalStatus.exitDoorTime, 0.0);
 

--- a/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
+++ b/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
@@ -47,9 +47,10 @@ constexpr int kWH1H2Size = kH1Size * kH2Size;
 constexpr int kWH2H2Size = kH2Size * kH2Size;
 constexpr int kBH2Size = kH2Size;
 constexpr int kAlpha2LogitSize = kH2Size;
+constexpr int kActivationLeakLogitSize = 2;
 constexpr int kWH2OSize = kH2Size * kOutputSize;
 constexpr int kBOSize = kOutputSize;
-constexpr float kMaxAlphaLogit = 4.0f;
+constexpr float kStrongPositiveLogit = 4.0f;
 
 size_t energyInputIndex()
 {
@@ -80,11 +81,23 @@ size_t alpha2LogitIndex(size_t hiddenIndex)
         + hiddenIndex;
 }
 
+size_t h1ActivationLeakLogitIndex()
+{
+    return static_cast<size_t>(
+        kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size + kBH2Size
+        + kAlpha2LogitSize);
+}
+
+size_t h2ActivationLeakLogitIndex()
+{
+    return h1ActivationLeakLogitIndex() + 1u;
+}
+
 size_t wH2OIndex(size_t h2Index, size_t outputIndex)
 {
     return static_cast<size_t>(
                kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
-               + kBH2Size + kAlpha2LogitSize)
+               + kBH2Size + kAlpha2LogitSize + kActivationLeakLogitSize)
         + (h2Index * static_cast<size_t>(kOutputSize)) + outputIndex;
 }
 
@@ -93,13 +106,15 @@ Genome makeNegativePropagationGenome()
     Genome genome(
         static_cast<size_t>(
             kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
-            + kBH2Size + kAlpha2LogitSize + kWH2OSize + kBOSize),
+            + kBH2Size + kAlpha2LogitSize + kActivationLeakLogitSize + kWH2OSize + kBOSize),
         0.0f);
 
     genome.weights[wXh1Index(energyInputIndex(), 0)] = -2.0f;
-    genome.weights[alpha1LogitIndex(0)] = kMaxAlphaLogit;
+    genome.weights[alpha1LogitIndex(0)] = kStrongPositiveLogit;
     genome.weights[wH1H2Index(0, 0)] = 2.0f;
-    genome.weights[alpha2LogitIndex(0)] = kMaxAlphaLogit;
+    genome.weights[alpha2LogitIndex(0)] = kStrongPositiveLogit;
+    genome.weights[h1ActivationLeakLogitIndex()] = kStrongPositiveLogit;
+    genome.weights[h2ActivationLeakLogitIndex()] = kStrongPositiveLogit;
     genome.weights[wH2OIndex(0, 0)] = 10.0f;
     return genome;
 }
@@ -373,7 +388,7 @@ TEST(DuckNeuralNetRecurrentBrainV2Test, GenomeLayoutUsesCoarseMutationDomains)
 {
     const GenomeLayout layout = DuckNeuralNetRecurrentBrainV2::getGenomeLayout();
 
-    ASSERT_EQ(layout.segments.size(), 5u);
+    ASSERT_EQ(layout.segments.size(), 6u);
     EXPECT_EQ(layout.segments[0].name, "input_h1");
     EXPECT_EQ(layout.segments[0].size, 284672);
     EXPECT_EQ(layout.segments[1].name, "h1_recurrent");
@@ -382,8 +397,10 @@ TEST(DuckNeuralNetRecurrentBrainV2Test, GenomeLayoutUsesCoarseMutationDomains)
     EXPECT_EQ(layout.segments[2].size, 2048);
     EXPECT_EQ(layout.segments[3].name, "h2_recurrent");
     EXPECT_EQ(layout.segments[3].size, 1088);
-    EXPECT_EQ(layout.segments[4].name, "output");
-    EXPECT_EQ(layout.segments[4].size, 132);
+    EXPECT_EQ(layout.segments[4].name, "activation_slopes");
+    EXPECT_EQ(layout.segments[4].size, 2);
+    EXPECT_EQ(layout.segments[5].name, "output");
+    EXPECT_EQ(layout.segments[5].size, 132);
 }
 
 TEST(DuckNeuralNetRecurrentBrainV2Test, NegativeSignalPropagatesThroughBothHiddenLayers)

--- a/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
+++ b/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
@@ -33,6 +33,76 @@ constexpr double kBenchmarkDeltaTime = 0.016;
 constexpr const char* kBenchmarkIterationsEnv = "DIRTSIM_DUCK_RNN_BENCH_ITERATIONS";
 constexpr const char* kBenchmarkRepeatsEnv = "DIRTSIM_DUCK_RNN_BENCH_REPEATS";
 constexpr const char* kBenchmarkWarmupIterationsEnv = "DIRTSIM_DUCK_RNN_BENCH_WARMUP_ITERATIONS";
+constexpr int kInputHistogramSize =
+    DuckSensoryData::GRID_SIZE * DuckSensoryData::GRID_SIZE * DuckSensoryData::NUM_MATERIALS;
+constexpr int kInputSize = kInputHistogramSize + 4 + DuckSensoryData::SPECIAL_SENSE_COUNT + 2;
+constexpr int kH1Size = 64;
+constexpr int kH2Size = 32;
+constexpr int kOutputSize = 4;
+constexpr int kWXH1Size = kInputSize * kH1Size;
+constexpr int kWH1H1Size = kH1Size * kH1Size;
+constexpr int kBH1Size = kH1Size;
+constexpr int kAlpha1LogitSize = kH1Size;
+constexpr int kWH1H2Size = kH1Size * kH2Size;
+constexpr int kWH2H2Size = kH2Size * kH2Size;
+constexpr int kBH2Size = kH2Size;
+constexpr int kAlpha2LogitSize = kH2Size;
+constexpr int kWH2OSize = kH2Size * kOutputSize;
+constexpr int kBOSize = kOutputSize;
+constexpr float kMaxAlphaLogit = 4.0f;
+
+size_t energyInputIndex()
+{
+    return static_cast<size_t>(kInputHistogramSize + 4 + DuckSensoryData::SPECIAL_SENSE_COUNT);
+}
+
+size_t wXh1Index(size_t inputIndex, size_t hiddenIndex)
+{
+    return inputIndex * static_cast<size_t>(kH1Size) + hiddenIndex;
+}
+
+size_t alpha1LogitIndex(size_t hiddenIndex)
+{
+    return static_cast<size_t>(kWXH1Size + kWH1H1Size + kBH1Size) + hiddenIndex;
+}
+
+size_t wH1H2Index(size_t h1Index, size_t h2Index)
+{
+    return static_cast<size_t>(kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize)
+        + (h1Index * static_cast<size_t>(kH2Size)) + h2Index;
+}
+
+size_t alpha2LogitIndex(size_t hiddenIndex)
+{
+    return static_cast<size_t>(
+               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
+               + kBH2Size)
+        + hiddenIndex;
+}
+
+size_t wH2OIndex(size_t h2Index, size_t outputIndex)
+{
+    return static_cast<size_t>(
+               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
+               + kBH2Size + kAlpha2LogitSize)
+        + (h2Index * static_cast<size_t>(kOutputSize)) + outputIndex;
+}
+
+Genome makeNegativePropagationGenome()
+{
+    Genome genome(
+        static_cast<size_t>(
+            kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
+            + kBH2Size + kAlpha2LogitSize + kWH2OSize + kBOSize),
+        0.0f);
+
+    genome.weights[wXh1Index(energyInputIndex(), 0)] = -2.0f;
+    genome.weights[alpha1LogitIndex(0)] = kMaxAlphaLogit;
+    genome.weights[wH1H2Index(0, 0)] = 2.0f;
+    genome.weights[alpha2LogitIndex(0)] = kMaxAlphaLogit;
+    genome.weights[wH2OIndex(0, 0)] = 10.0f;
+    return genome;
+}
 
 struct DuckBrainBenchmarkSetup {
     std::unique_ptr<World> world;
@@ -314,6 +384,27 @@ TEST(DuckNeuralNetRecurrentBrainV2Test, GenomeLayoutUsesCoarseMutationDomains)
     EXPECT_EQ(layout.segments[3].size, 1088);
     EXPECT_EQ(layout.segments[4].name, "output");
     EXPECT_EQ(layout.segments[4].size, 132);
+}
+
+TEST(DuckNeuralNetRecurrentBrainV2Test, NegativeSignalPropagatesThroughBothHiddenLayers)
+{
+    const Genome genome = makeNegativePropagationGenome();
+    ASSERT_TRUE(DuckNeuralNetRecurrentBrainV2::isGenomeCompatible(genome));
+
+    DuckNeuralNetRecurrentBrainV2 brain(genome);
+    DuckSensoryData sensory{};
+    sensory.energy = 1.0f;
+    sensory.health = 0.0f;
+    sensory.facing_x = 0.0f;
+    sensory.on_ground = false;
+    sensory.velocity = Vector2d{ 0.0, 0.0 };
+
+    const auto output = brain.inferControllerOutput(sensory);
+
+    EXPECT_LT(output.xRaw, -0.2f);
+    EXPECT_LT(output.x, -0.2f);
+    EXPECT_FALSE(output.a);
+    EXPECT_FALSE(output.b);
 }
 
 TEST(DuckNeuralNetRecurrentBrainV2Test, RandomGenomesProduceCommandDiversity)

--- a/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
+++ b/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
@@ -69,35 +69,35 @@ size_t alpha1LogitIndex(size_t hiddenIndex)
 
 size_t wH1H2Index(size_t h1Index, size_t h2Index)
 {
-    return static_cast<size_t>(kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize)
+    return static_cast<size_t>(kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + 1)
         + (h1Index * static_cast<size_t>(kH2Size)) + h2Index;
 }
 
 size_t alpha2LogitIndex(size_t hiddenIndex)
 {
     return static_cast<size_t>(
-               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
+               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + 1 + kWH1H2Size + kWH2H2Size
                + kBH2Size)
         + hiddenIndex;
 }
 
 size_t h1ActivationLeakLogitIndex()
 {
-    return static_cast<size_t>(
-        kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size + kBH2Size
-        + kAlpha2LogitSize);
+    return static_cast<size_t>(kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize);
 }
 
 size_t h2ActivationLeakLogitIndex()
 {
-    return h1ActivationLeakLogitIndex() + 1u;
+    return static_cast<size_t>(
+        kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + 1 + kWH1H2Size + kWH2H2Size
+        + kBH2Size + kAlpha2LogitSize);
 }
 
 size_t wH2OIndex(size_t h2Index, size_t outputIndex)
 {
     return static_cast<size_t>(
-               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + kWH1H2Size + kWH2H2Size
-               + kBH2Size + kAlpha2LogitSize + kActivationLeakLogitSize)
+               kWXH1Size + kWH1H1Size + kBH1Size + kAlpha1LogitSize + 1 + kWH1H2Size + kWH2H2Size
+               + kBH2Size + kAlpha2LogitSize + 1)
         + (h2Index * static_cast<size_t>(kOutputSize)) + outputIndex;
 }
 
@@ -388,19 +388,17 @@ TEST(DuckNeuralNetRecurrentBrainV2Test, GenomeLayoutUsesCoarseMutationDomains)
 {
     const GenomeLayout layout = DuckNeuralNetRecurrentBrainV2::getGenomeLayout();
 
-    ASSERT_EQ(layout.segments.size(), 6u);
+    ASSERT_EQ(layout.segments.size(), 5u);
     EXPECT_EQ(layout.segments[0].name, "input_h1");
     EXPECT_EQ(layout.segments[0].size, 284672);
     EXPECT_EQ(layout.segments[1].name, "h1_recurrent");
-    EXPECT_EQ(layout.segments[1].size, 4224);
+    EXPECT_EQ(layout.segments[1].size, 4225);
     EXPECT_EQ(layout.segments[2].name, "h1_to_h2");
     EXPECT_EQ(layout.segments[2].size, 2048);
     EXPECT_EQ(layout.segments[3].name, "h2_recurrent");
-    EXPECT_EQ(layout.segments[3].size, 1088);
-    EXPECT_EQ(layout.segments[4].name, "activation_slopes");
-    EXPECT_EQ(layout.segments[4].size, 2);
-    EXPECT_EQ(layout.segments[5].name, "output");
-    EXPECT_EQ(layout.segments[5].size, 132);
+    EXPECT_EQ(layout.segments[3].size, 1089);
+    EXPECT_EQ(layout.segments[4].name, "output");
+    EXPECT_EQ(layout.segments[4].size, 132);
 }
 
 TEST(DuckNeuralNetRecurrentBrainV2Test, NegativeSignalPropagatesThroughBothHiddenLayers)

--- a/apps/src/server/evolution/EvaluationExecutor.cpp
+++ b/apps/src/server/evolution/EvaluationExecutor.cpp
@@ -113,6 +113,7 @@ FitnessEvaluation computeFitnessEvaluationForRunner(
         .commandsRejected = status.commandsRejected,
         .idleCancels = status.idleCancels,
         .nesRewardTotal = status.nesRewardTotal,
+        .organismDied = status.state == TrainingRunner::State::OrganismDied,
         .exitedThroughDoor = status.exitedThroughDoor,
         .exitDoorTime = status.exitDoorTime,
     };


### PR DESCRIPTION
## Summary
- switch `DuckNeuralNetRecurrentBrainV2` hidden activations from fixed LeakyReLU to learned per-layer LeakyReLU slopes
- add two bounded leak logits to the v2 genome, one for H1 and one for H2, initialized to a 0.1 slope and constrained to `[0.02, 0.3]`
- keep a focused regression test for negative-signal propagation and update the genome-layout expectations for the new activation-slope segment
- intentionally make old v2 genomes size-incompatible so fresh training starts cannot silently warm-start under changed semantics

## Testing
- `make test ARGS='--gtest_filter=DuckNeuralNetRecurrentBrainV2Test.*:StateEvolutionTest.EvolutionStartWarmResumeSkipsIncompatibleGenomeLayouts'`

## Notes
- this changes the shared v2 brain in place for both `DUCK` and `NES_DUCK`
- archived pre-change v2 genomes no longer pass compatibility checks because the genome now includes two learned activation-slope logits
