### PR TITLE
Speed up SmolNES training and add low-overhead profiling

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -934,6 +934,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/SmolnesApu_test.cpp
     src/core/scenarios/tests/SmolnesApuRegisterCapture_test.cpp
     src/core/scenarios/tests/SmolnesApuSampleBuffer_test.cpp
+    src/core/scenarios/tests/SmolnesRuntime_test.cpp
 
     # Organism tests.
     src/core/organisms/components/LightHandHeld_test.cpp

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -110,6 +110,14 @@
     } while (0)
 #endif
 
+#ifndef SMOLNES_PIXEL_OUTPUT_ENABLED
+#define SMOLNES_PIXEL_OUTPUT_ENABLED 1
+#endif
+
+#ifndef SMOLNES_RGBA_OUTPUT_ENABLED
+#define SMOLNES_RGBA_OUTPUT_ENABLED 1
+#endif
+
 #define PULL mem(++S, 1, 0, 0)
 #define PUSH(x) mem(S--, 1, x, 1)
 
@@ -315,7 +323,13 @@ static inline void render_visible_span(uint16_t span_count,
       }
     }
 
-    SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + current_dot, color, palette);
+    if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      const uint16_t output_offset = scanline_fb_offset + current_dot;
+      const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+      frame_buffer_palette[output_offset] = palette_index;
+      if (SMOLNES_RGBA_OUTPUT_ENABLED)
+        frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
+    }
 
     local_shift_hi <<= 1;
     local_shift_lo <<= 1;
@@ -354,28 +368,79 @@ static inline void render_visible_span(uint16_t span_count,
 
   while (span_count >= 8) {
     const uint16_t base_offset = scanline_fb_offset + current_dot;
-    for (uint16_t pixel = 0; pixel < 8; ++pixel) {
-      uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                      local_shift_lo >> fine_x_shift & 1,
-              palette = local_shift_at >> fine_x_palette_shift & 12;
+    if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                        local_shift_lo >> fine_x_shift & 1,
+                palette = local_shift_at >> fine_x_palette_shift & 12;
 
-      if (sprites_enabled) {
-        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-        if (sprite->color) {
-          if (!(sprite->attr & 32 && color)) {
-            color = sprite->color;
-            palette = sprite->palette;
+        if (sprites_enabled) {
+          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+          if (sprite->color) {
+            if (!(sprite->attr & 32 && color)) {
+              color = sprite->color;
+              palette = sprite->palette;
+            }
+            if (sprite->is_sprite0 && color)
+              ppustatus |= 64;
           }
-          if (sprite->is_sprite0 && color)
-            ppustatus |= 64;
         }
+
+        local_shift_hi <<= 1;
+        local_shift_lo <<= 1;
+        local_shift_at <<= 2;
       }
+    } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                        local_shift_lo >> fine_x_shift & 1,
+                palette = local_shift_at >> fine_x_palette_shift & 12;
 
-      SMOLNES_PIXEL_OUTPUT(base_offset + pixel, color, palette);
+        if (sprites_enabled) {
+          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+          if (sprite->color) {
+            if (!(sprite->attr & 32 && color)) {
+              color = sprite->color;
+              palette = sprite->palette;
+            }
+            if (sprite->is_sprite0 && color)
+              ppustatus |= 64;
+          }
+        }
 
-      local_shift_hi <<= 1;
-      local_shift_lo <<= 1;
-      local_shift_at <<= 2;
+        const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+        frame_buffer_palette[base_offset + pixel] = palette_index;
+        frame_buffer[base_offset + pixel] = nes_palette_rgb565[palette_index];
+
+        local_shift_hi <<= 1;
+        local_shift_lo <<= 1;
+        local_shift_at <<= 2;
+      }
+    } else {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                        local_shift_lo >> fine_x_shift & 1,
+                palette = local_shift_at >> fine_x_palette_shift & 12;
+
+        if (sprites_enabled) {
+          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+          if (sprite->color) {
+            if (!(sprite->attr & 32 && color)) {
+              color = sprite->color;
+              palette = sprite->palette;
+            }
+            if (sprite->is_sprite0 && color)
+              ppustatus |= 64;
+          }
+        }
+
+        frame_buffer_palette[base_offset + pixel] =
+            palette_ram[(color) ? (palette) | (color) : 0];
+
+        local_shift_hi <<= 1;
+        local_shift_lo <<= 1;
+        local_shift_at <<= 2;
+      }
     }
 
     local_ntb = *get_nametable_byte(local_V);
@@ -412,7 +477,13 @@ static inline void render_visible_span(uint16_t span_count,
       }
     }
 
-    SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + current_dot, color, palette);
+    if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      const uint16_t output_offset = scanline_fb_offset + current_dot;
+      const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+      frame_buffer_palette[output_offset] = palette_index;
+      if (SMOLNES_RGBA_OUTPUT_ENABLED)
+        frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
+    }
 
     local_shift_hi <<= 1;
     local_shift_lo <<= 1;

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -81,6 +81,10 @@
 #define SMOLNES_PPU_PHASE_NON_VISIBLE_SCANLINES 6u
 #endif
 
+#ifndef SMOLNES_PPU_VISIBLE_BG_ONLY_STATS
+#define SMOLNES_PPU_VISIBLE_BG_ONLY_STATS(span_pixels, scalar_pixels, batched_pixels, batch_count)
+#endif
+
 #ifndef SMOLNES_APU_WRITE
 #define SMOLNES_APU_WRITE(addr, value)
 #endif
@@ -331,6 +335,7 @@ static inline void step_background_fetch_pipeline_for_dot_aligned(
 static inline void render_visible_span_background_only(uint16_t span_count,
                                                        uint8_t fine_x,
                                                        uint16_t bg_pattern_base) {
+  const uint16_t total_span_count = span_count;
   uint16_t current_dot = dot;
   uint16_t local_V = V;
   uint16_t local_atb = atb;
@@ -340,8 +345,12 @@ static inline void render_visible_span_background_only(uint16_t span_count,
   uint8_t local_ntb = ntb;
   uint8_t local_ptb_lo = ptb_lo;
   uint16_t prefix_count = (8 - (current_dot & 7)) & 7;
+  uint16_t scalar_pixels = 0;
+  uint16_t batched_pixels = 0;
+  uint16_t batched_calls = 0;
   if (prefix_count > span_count)
     prefix_count = span_count;
+  scalar_pixels += prefix_count;
 
   while (prefix_count > 0) {
     uint8_t color = local_shift_hi_aligned >> 14 & 2 |
@@ -371,6 +380,8 @@ static inline void render_visible_span_background_only(uint16_t span_count,
 
   if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
     while (span_count >= 8) {
+      batched_pixels += 8;
+      batched_calls++;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -391,6 +402,8 @@ static inline void render_visible_span_background_only(uint16_t span_count,
     }
   } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
     while (span_count >= 8) {
+      batched_pixels += 8;
+      batched_calls++;
       const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
@@ -416,6 +429,8 @@ static inline void render_visible_span_background_only(uint16_t span_count,
     }
   } else {
     while (span_count >= 8) {
+      batched_pixels += 8;
+      batched_calls++;
       const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
@@ -440,6 +455,7 @@ static inline void render_visible_span_background_only(uint16_t span_count,
     }
   }
 
+  scalar_pixels += span_count;
   while (span_count > 0) {
     uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                     local_shift_lo_aligned >> 15 & 1,
@@ -472,6 +488,8 @@ static inline void render_visible_span_background_only(uint16_t span_count,
   shift_at = local_shift_at_aligned >> (fine_x * 2);
   ntb = local_ntb;
   ptb_lo = local_ptb_lo;
+  SMOLNES_PPU_VISIBLE_BG_ONLY_STATS(
+      total_span_count, scalar_pixels, batched_pixels, batched_calls);
 }
 
 static inline void render_visible_span(uint16_t span_count,

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -65,6 +65,14 @@
 #define SMOLNES_APU_CLOCK(cycles)
 #endif
 
+#ifndef SMOLNES_APU_CLOCK_BEGIN
+#define SMOLNES_APU_CLOCK_BEGIN()
+#endif
+
+#ifndef SMOLNES_APU_CLOCK_END
+#define SMOLNES_APU_CLOCK_END()
+#endif
+
 #define PULL mem(++S, 1, 0, 0)
 #define PUSH(x) mem(S--, 1, x, 1)
 
@@ -714,7 +722,9 @@ loop:
   // Update PPU, which runs 3 times faster than CPU. Each CPU instruction
   // takes at least 2 cycles.
   SMOLNES_CPU_STEP_END();
+  SMOLNES_APU_CLOCK_BEGIN();
   SMOLNES_APU_CLOCK(cycles + 2);
+  SMOLNES_APU_CLOCK_END();
   SMOLNES_PPU_STEP_BEGIN();
   for (tmp = cycles * 3 + 6; tmp--;) {
     if (ppumask & 24) {

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -245,6 +245,219 @@ static void evaluate_scanline_sprites(void) {
   }
 }
 
+static inline void step_background_fetch_pipeline(uint16_t bg_pattern_base) {
+  switch (dot & 7) {
+  case 1:
+    ntb = *get_nametable_byte(V);
+    break;
+  case 3:
+    atb = (*get_nametable_byte(V & 0xc00 | 0x3c0 | V >> 4 & 0x38 |
+                               V / 4 & 7) >>
+           (V >> 5 & 2 | V / 2 & 1) * 2) %
+          4 * 0x5555;
+    break;
+  case 5: {
+    const int temp = bg_pattern_base | ntb << 4 | V >> 12;
+    ptb_lo = *get_chr_byte(temp);
+    break;
+  }
+  case 7: {
+    const int temp = bg_pattern_base | ntb << 4 | V >> 12;
+    const uint8_t ptb_hi = *get_chr_byte(temp | 8);
+    V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
+    shift_hi |= ptb_hi;
+    shift_lo |= ptb_lo;
+    shift_at |= atb;
+    break;
+  }
+  }
+}
+
+static inline void render_visible_span(uint16_t span_count,
+                                       uint8_t sprites_enabled,
+                                       uint8_t fine_x_shift,
+                                       uint8_t fine_x_palette_shift,
+                                       uint16_t bg_pattern_base) {
+  uint16_t current_dot = dot;
+  uint16_t local_V = V;
+  uint16_t local_atb = atb;
+  uint16_t local_shift_hi = shift_hi;
+  uint16_t local_shift_lo = shift_lo;
+  int local_shift_at = shift_at;
+  uint8_t local_ntb = ntb;
+  uint8_t local_ptb_lo = ptb_lo;
+  uint16_t prefix_count = (8 - (current_dot & 7)) & 7;
+  if (prefix_count > span_count)
+    prefix_count = span_count;
+
+  while (prefix_count > 0) {
+    uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                    local_shift_lo >> fine_x_shift & 1,
+            palette = local_shift_at >> fine_x_palette_shift & 12;
+
+    if (sprites_enabled) {
+      ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
+      if (sprite->color) {
+        if (!(sprite->attr & 32 && color)) {
+          color = sprite->color;
+          palette = sprite->palette;
+        }
+        if (sprite->is_sprite0 && color)
+          ppustatus |= 64;
+      }
+    }
+
+    SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + current_dot, color, palette);
+
+    local_shift_hi <<= 1;
+    local_shift_lo <<= 1;
+    local_shift_at <<= 2;
+
+    switch (current_dot & 7) {
+    case 1:
+      local_ntb = *get_nametable_byte(local_V);
+      break;
+    case 3:
+      local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
+                                       local_V / 4 & 7) >>
+                   (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
+                  4 * 0x5555;
+      break;
+    case 5: {
+      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
+      local_ptb_lo = *get_chr_byte(temp);
+      break;
+    }
+    case 7: {
+      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
+      const uint8_t ptb_hi = *get_chr_byte(temp | 8);
+      local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
+      local_shift_hi |= ptb_hi;
+      local_shift_lo |= local_ptb_lo;
+      local_shift_at |= local_atb;
+      break;
+    }
+    }
+
+    ++current_dot;
+    --prefix_count;
+    --span_count;
+  }
+
+  while (span_count >= 8) {
+    const uint16_t base_offset = scanline_fb_offset + current_dot;
+    for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+      uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                      local_shift_lo >> fine_x_shift & 1,
+              palette = local_shift_at >> fine_x_palette_shift & 12;
+
+      if (sprites_enabled) {
+        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+        if (sprite->color) {
+          if (!(sprite->attr & 32 && color)) {
+            color = sprite->color;
+            palette = sprite->palette;
+          }
+          if (sprite->is_sprite0 && color)
+            ppustatus |= 64;
+        }
+      }
+
+      SMOLNES_PIXEL_OUTPUT(base_offset + pixel, color, palette);
+
+      local_shift_hi <<= 1;
+      local_shift_lo <<= 1;
+      local_shift_at <<= 2;
+    }
+
+    local_ntb = *get_nametable_byte(local_V);
+    local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
+                                     local_V / 4 & 7) >>
+                 (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
+                4 * 0x5555;
+    const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
+    local_ptb_lo = *get_chr_byte(temp);
+    const uint8_t ptb_hi = *get_chr_byte(temp | 8);
+    local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
+    local_shift_hi |= ptb_hi;
+    local_shift_lo |= local_ptb_lo;
+    local_shift_at |= local_atb;
+
+    current_dot += 8;
+    span_count -= 8;
+  }
+
+  while (span_count > 0) {
+    uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
+                    local_shift_lo >> fine_x_shift & 1,
+            palette = local_shift_at >> fine_x_palette_shift & 12;
+
+    if (sprites_enabled) {
+      ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
+      if (sprite->color) {
+        if (!(sprite->attr & 32 && color)) {
+          color = sprite->color;
+          palette = sprite->palette;
+        }
+        if (sprite->is_sprite0 && color)
+          ppustatus |= 64;
+      }
+    }
+
+    SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + current_dot, color, palette);
+
+    local_shift_hi <<= 1;
+    local_shift_lo <<= 1;
+    local_shift_at <<= 2;
+
+    switch (current_dot & 7) {
+    case 1:
+      local_ntb = *get_nametable_byte(local_V);
+      break;
+    case 3:
+      local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
+                                       local_V / 4 & 7) >>
+                   (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
+                  4 * 0x5555;
+      break;
+    case 5: {
+      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
+      local_ptb_lo = *get_chr_byte(temp);
+      break;
+    }
+    case 7: {
+      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
+      const uint8_t ptb_hi = *get_chr_byte(temp | 8);
+      local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
+      local_shift_hi |= ptb_hi;
+      local_shift_lo |= local_ptb_lo;
+      local_shift_at |= local_atb;
+      break;
+    }
+    }
+
+    ++current_dot;
+    --span_count;
+  }
+
+  V = local_V;
+  atb = local_atb;
+  shift_hi = local_shift_hi;
+  shift_lo = local_shift_lo;
+  shift_at = local_shift_at;
+  ntb = local_ntb;
+  ptb_lo = local_ptb_lo;
+}
+
+static inline void run_prefetch_dot(uint16_t bg_pattern_base) {
+  if (dot < 336) {
+    shift_hi <<= 1;
+    shift_lo <<= 1;
+    shift_at <<= 2;
+  }
+  step_background_fetch_pipeline(bg_pattern_base);
+}
+
 // If `write` is non-zero, writes `val` to the address `hi:lo`, otherwise reads
 // a value from the address `hi:lo`.
 uint8_t mem(uint8_t lo, uint8_t hi, uint8_t val, uint8_t write) {
@@ -791,54 +1004,14 @@ loop:
             evaluate_scanline_sprites();
             SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_VISIBLE_PIXELS);
           }
-
-          uint8_t color = shift_hi >> (fine_x_shift - 1) & 2 |
-                          shift_lo >> fine_x_shift & 1,
-                  palette = shift_at >> fine_x_palette_shift & 12;
-
-          if (sprites_enabled) {
-            ScanlineSpritePixel *sprite = &scanline_sprite_pixels[dot];
-            if (sprite->color) {
-              if (!(sprite->attr & 32 && color)) {
-                color = sprite->color;
-                palette = sprite->palette;
-              }
-              if (sprite->is_sprite0 && color)
-                ppustatus |= 64;
-            }
-          }
-
-          SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + dot, color, palette);
-
-          shift_hi <<= 1;
-          shift_lo <<= 1;
-          shift_at <<= 2;
-
-          switch (dot & 7) {
-          case 1:
-            ntb = *get_nametable_byte(V);
-            break;
-          case 3:
-            atb = (*get_nametable_byte(V & 0xc00 | 0x3c0 | V >> 4 & 0x38 |
-                                       V / 4 & 7) >>
-                   (V >> 5 & 2 | V / 2 & 1) * 2) %
-                  4 * 0x5555;
-            break;
-          case 5: {
-            int temp = bg_pattern_base | ntb << 4 | V >> 12;
-            ptb_lo = *get_chr_byte(temp);
-            break;
-          }
-          case 7: {
-            int temp = bg_pattern_base | ntb << 4 | V >> 12;
-            uint8_t ptb_hi = *get_chr_byte(temp | 8);
-            V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
-            shift_hi |= ptb_hi;
-            shift_lo |= ptb_lo;
-            shift_at |= atb;
-            break;
-          }
-          }
+          uint16_t visible_span = tmp + 1;
+          if (visible_span > 256 - dot)
+            visible_span = 256 - dot;
+          render_visible_span(
+              visible_span, sprites_enabled, fine_x_shift, fine_x_palette_shift,
+              bg_pattern_base);
+          dot += visible_span - 1;
+          tmp -= visible_span - 1;
         } else if (dot == 256) {
           SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_OTHER);
           V = ((V & 7 << 12) != 7 << 12 ? V + 4096
@@ -850,37 +1023,7 @@ loop:
         } else if (dot >= 320) {
           if (dot == 320)
             SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_PREFETCH);
-          if (dot < 336) {
-            shift_hi <<= 1;
-            shift_lo <<= 1;
-            shift_at <<= 2;
-          }
-
-          switch (dot & 7) {
-          case 1:
-            ntb = *get_nametable_byte(V);
-            break;
-          case 3:
-            atb = (*get_nametable_byte(V & 0xc00 | 0x3c0 | V >> 4 & 0x38 |
-                                       V / 4 & 7) >>
-                   (V >> 5 & 2 | V / 2 & 1) * 2) %
-                  4 * 0x5555;
-            break;
-          case 5: {
-            int temp = bg_pattern_base | ntb << 4 | V >> 12;
-            ptb_lo = *get_chr_byte(temp);
-            break;
-          }
-          case 7: {
-            int temp = bg_pattern_base | ntb << 4 | V >> 12;
-            uint8_t ptb_hi = *get_chr_byte(temp | 8);
-            V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
-            shift_hi |= ptb_hi;
-            shift_lo |= ptb_lo;
-            shift_at |= atb;
-            break;
-          }
-          }
+          run_prefetch_dot(bg_pattern_base);
         }
       }
 

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -73,6 +73,15 @@
 #define SMOLNES_APU_CLOCK_END()
 #endif
 
+#ifndef SMOLNES_PIXEL_OUTPUT
+#define SMOLNES_PIXEL_OUTPUT(offset, color, palette) \
+    do { \
+        uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0]; \
+        frame_buffer_palette[offset] = palette_index; \
+        frame_buffer[offset] = nes_palette_rgb565[palette_index]; \
+    } while (0)
+#endif
+
 #define PULL mem(++S, 1, 0, 0)
 #define PUSH(x) mem(S--, 1, x, 1)
 
@@ -761,10 +770,7 @@ loop:
             }
           }
 
-          uint8_t palette_index = palette_ram[color ? palette | color : 0];
-          frame_buffer_palette[scanline_fb_offset + dot] = palette_index;
-          frame_buffer[scanline_fb_offset + dot] =
-              nes_palette_rgb565[palette_index];
+          SMOLNES_PIXEL_OUTPUT(scanline_fb_offset + dot, color, palette);
 
           shift_hi <<= 1;
           shift_lo <<= 1;

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -57,6 +57,30 @@
 #define SMOLNES_DEFERRED_PPU_STEP_END()
 #endif
 
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_REASON
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON(reason, dots)
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS
+#define SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS(reg, is_write, dots)
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_REASON_PPU_REGISTER_ACCESS
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_PPU_REGISTER_ACCESS 1u
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_REASON_OAM_DMA
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_OAM_DMA 2u
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_REASON_MAPPER_WRITE
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_MAPPER_WRITE 3u
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_FLUSH_REASON_DOT_256_BOUNDARY
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_DOT_256_BOUNDARY 4u
+#endif
+
 #ifndef SMOLNES_PPU_PHASE_SET
 #define SMOLNES_PPU_PHASE_SET(phase)
 #endif
@@ -816,9 +840,10 @@ static inline void runDeferredVisiblePpuDots(uint16_t ppu_dot_count) {
   SMOLNES_DEFERRED_PPU_STEP_END();
 }
 
-static inline void flushDeferredPpuDots(void) {
+static inline void flushDeferredPpuDots(uint32_t flush_reason) {
   if (!deferred_ppu_dots)
     return;
+  SMOLNES_DEFERRED_PPU_FLUSH_REASON(flush_reason, deferred_ppu_dots);
   runDeferredVisiblePpuDots(deferred_ppu_dots);
   deferred_ppu_dots = 0;
 }
@@ -831,8 +856,13 @@ uint8_t mem(uint8_t lo, uint8_t hi, uint8_t val, uint8_t write) {
     const uint8_t is_ppu_register_access = addr >= 0x2000 && addr < 0x4000;
     const uint8_t is_oam_dma = write && addr == 0x4014;
     const uint8_t is_mapper_write = write && addr >= 0x8000;
-    if (is_mapper_write || is_oam_dma || is_ppu_register_access)
-      flushDeferredPpuDots();
+    if (is_ppu_register_access) {
+      SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS(addr & 7, write, deferred_ppu_dots);
+      flushDeferredPpuDots(SMOLNES_DEFERRED_PPU_FLUSH_REASON_PPU_REGISTER_ACCESS);
+    } else if (is_oam_dma)
+      flushDeferredPpuDots(SMOLNES_DEFERRED_PPU_FLUSH_REASON_OAM_DMA);
+    else if (is_mapper_write)
+      flushDeferredPpuDots(SMOLNES_DEFERRED_PPU_FLUSH_REASON_MAPPER_WRITE);
   }
 
   switch (hi >>= 4) {
@@ -1358,7 +1388,7 @@ loop:
     deferred_ppu_dots += ppu_dot_count;
     goto loop;
   }
-  flushDeferredPpuDots();
+  flushDeferredPpuDots(SMOLNES_DEFERRED_PPU_FLUSH_REASON_DOT_256_BOUNDARY);
   SMOLNES_PPU_STEP_BEGIN();
   const uint8_t rendering_enabled = ppumask & 24;
   const uint16_t bg_pattern_base = ppuctrl << 8 & 4096;
@@ -1419,6 +1449,12 @@ loop:
             SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_PREFETCH);
           run_prefetch_dot(bg_pattern_base);
         }
+      } else if (scany > 241 && scany < 261) {
+        uint16_t non_visible_span = tmp + 1;
+        if (non_visible_span > 341 - dot)
+          non_visible_span = 341 - dot;
+        dot += non_visible_span - 1;
+        tmp -= non_visible_span - 1;
       }
 
       // Check for MMC3 IRQ.

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -73,6 +73,14 @@
 #define SMOLNES_PPU_PHASE_SPRITE_EVAL 4u
 #endif
 
+#ifndef SMOLNES_PPU_PHASE_POST_VISIBLE
+#define SMOLNES_PPU_PHASE_POST_VISIBLE 5u
+#endif
+
+#ifndef SMOLNES_PPU_PHASE_NON_VISIBLE_SCANLINES
+#define SMOLNES_PPU_PHASE_NON_VISIBLE_SCANLINES 6u
+#endif
+
 #ifndef SMOLNES_APU_WRITE
 #define SMOLNES_APU_WRITE(addr, value)
 #endif
@@ -987,11 +995,17 @@ loop:
   const uint8_t fine_x_shift = 15 - fine_x;
   const uint8_t fine_x_palette_shift = 28 - fine_x * 2;
   uint32_t smolnes_ppu_phase = SMOLNES_PPU_PHASE_OTHER;
-  if (rendering_enabled && scany < 240) {
-    if (dot < 256)
-      smolnes_ppu_phase = SMOLNES_PPU_PHASE_VISIBLE_PIXELS;
-    else if (dot >= 320)
-      smolnes_ppu_phase = SMOLNES_PPU_PHASE_PREFETCH;
+  if (rendering_enabled) {
+    if (scany < 240) {
+      if (dot < 256)
+        smolnes_ppu_phase = SMOLNES_PPU_PHASE_VISIBLE_PIXELS;
+      else if (dot >= 320)
+        smolnes_ppu_phase = SMOLNES_PPU_PHASE_PREFETCH;
+      else
+        smolnes_ppu_phase = SMOLNES_PPU_PHASE_POST_VISIBLE;
+    } else {
+      smolnes_ppu_phase = SMOLNES_PPU_PHASE_NON_VISIBLE_SCANLINES;
+    }
   }
   SMOLNES_PPU_PHASE_SET_IF_ACTIVE(smolnes_ppu_phase);
   for (tmp = cycles * 3 + 6; tmp--;) {
@@ -1013,13 +1027,27 @@ loop:
           dot += visible_span - 1;
           tmp -= visible_span - 1;
         } else if (dot == 256) {
-          SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_OTHER);
+          SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_POST_VISIBLE);
           V = ((V & 7 << 12) != 7 << 12 ? V + 4096
                : (V & 0x3e0) == 928     ? V & 0x8c1f ^ 2048
                : (V & 0x3e0) == 0x3e0   ? V & 0x8c1f
                                         : V & 0x8c1f | V + 32 & 0x3e0) &
                   ~0x41f |
               T & 0x41f;
+        } else if (dot < 320) {
+          const uint16_t post_visible_start_dot = dot;
+          uint16_t post_visible_span = tmp + 1;
+          if (post_visible_span > 320 - dot)
+            post_visible_span = 320 - dot;
+
+          if (dot <= 261 && dot + post_visible_span > 261 && mmc3_irq
+              && (scany + 1) % 262 < 241) {
+            dot = 261;
+            tmp -= 261 - post_visible_start_dot;
+          } else {
+            dot += post_visible_span - 1;
+            tmp -= post_visible_span - 1;
+          }
         } else if (dot >= 320) {
           if (dot == 320)
             SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_PREFETCH);

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -171,15 +171,13 @@ static const uint16_t nes_palette_rgb565[64] = {
     59092, 53013, 46902, 44857, 44860, 46518,     0,     0};
 
 typedef struct {
-    uint8_t x;
     uint8_t attr;
-    uint8_t pattern_lo;
-    uint8_t pattern_hi;
+    uint8_t color;
     uint8_t is_sprite0;
-} ScanlineSprite;
+    uint8_t palette;
+} ScanlineSpritePixel;
 
-SMOLNES_TLS ScanlineSprite scanline_sprites[64];
-SMOLNES_TLS uint8_t scanline_sprite_count;
+SMOLNES_TLS ScanlineSpritePixel scanline_sprite_pixels[256];
 
 // Read a byte from CHR ROM or CHR RAM.
 static inline uint8_t *get_chr_byte(uint16_t a) {
@@ -195,7 +193,7 @@ uint8_t *get_nametable_byte(uint16_t a) {
 }
 
 static void evaluate_scanline_sprites(void) {
-  scanline_sprite_count = 0;
+  memset(scanline_sprite_pixels, 0, sizeof(scanline_sprite_pixels));
   uint16_t sprite_h = ppuctrl & 32 ? 16 : 8;
   for (uint8_t *sprite = oam; sprite < oam + 256; sprite += 4) {
     uint16_t sprite_y = scany - sprite[0] - 1;
@@ -223,12 +221,27 @@ static void evaluate_scanline_sprites(void) {
       pattern_hi = (pattern_hi & 0xAA) >> 1 | (pattern_hi & 0x55) << 1;
     }
 
-    ScanlineSprite *s = &scanline_sprites[scanline_sprite_count++];
-    s->x = sprite[3];
-    s->attr = sprite[2];
-    s->pattern_lo = pattern_lo;
-    s->pattern_hi = pattern_hi;
-    s->is_sprite0 = (sprite == oam);
+    const uint8_t sprite_attr = sprite[2];
+    const uint8_t sprite_palette = 16 | ((sprite_attr * 4) & 12);
+    const uint8_t is_sprite0 = (sprite == oam);
+    for (uint16_t sprite_x = 0; sprite_x < 8; ++sprite_x) {
+      uint16_t screen_x = sprite[3] + sprite_x;
+      if (screen_x >= 256)
+        break;
+
+      uint8_t offset = 7 - sprite_x;
+      uint8_t sprite_color =
+          (pattern_hi >> offset & 1) << 1 |
+          (pattern_lo >> offset & 1);
+      if (!sprite_color || scanline_sprite_pixels[screen_x].color)
+        continue;
+
+      ScanlineSpritePixel *p = &scanline_sprite_pixels[screen_x];
+      p->attr = sprite_attr;
+      p->color = sprite_color;
+      p->is_sprite0 = is_sprite0;
+      p->palette = sprite_palette;
+    }
   }
 }
 
@@ -779,24 +792,14 @@ loop:
                   palette = shift_at >> 28 - fine_x * 2 & 12;
 
           if (ppumask & 16) {
-            for (uint8_t i = 0; i < scanline_sprite_count; ++i) {
-              ScanlineSprite *s = &scanline_sprites[i];
-              uint16_t sprite_x = dot - s->x;
-              if (sprite_x < 8) {
-                uint8_t offset = 7 - sprite_x;
-                uint8_t sprite_color =
-                    (s->pattern_hi >> offset & 1) << 1 |
-                    (s->pattern_lo >> offset & 1);
-                if (sprite_color) {
-                  if (!(s->attr & 32 && color)) {
-                    color = sprite_color;
-                    palette = 16 | s->attr * 4 & 12;
-                  }
-                  if (s->is_sprite0 && color)
-                    ppustatus |= 64;
-                  break;
-                }
+            ScanlineSpritePixel *sprite = &scanline_sprite_pixels[dot];
+            if (sprite->color) {
+              if (!(sprite->attr & 32 && color)) {
+                color = sprite->color;
+                palette = sprite->palette;
               }
+              if (sprite->is_sprite0 && color)
+                ppustatus |= 64;
             }
           }
 

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -568,7 +568,7 @@ static inline void render_visible_span_background_only(uint16_t span_count,
 static inline void render_visible_span(uint16_t span_count,
                                        uint8_t fine_x,
                                        uint16_t bg_pattern_base) {
-  if (!scanline_has_sprite_pixels) {
+  if (!scanline_has_sprite_pixels || !(ppumask & 16)) {
     render_visible_span_background_only(span_count, fine_x, bg_pattern_base);
     return;
   }

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -185,7 +185,7 @@ static inline uint8_t *get_chr_byte(uint16_t a) {
 }
 
 // Read a byte from nametable RAM.
-uint8_t *get_nametable_byte(uint16_t a) {
+static inline uint8_t *get_nametable_byte(uint16_t a) {
   return &vram[mirror == 0   ? a % 1024                  // single bank 0
                : mirror == 1 ? a % 1024 + 1024           // single bank 1
                : mirror == 2 ? a & 2047                  // vertical mirroring
@@ -768,8 +768,13 @@ loop:
   SMOLNES_APU_CLOCK(cycles + 2);
   SMOLNES_APU_CLOCK_END();
   SMOLNES_PPU_STEP_BEGIN();
+  const uint8_t rendering_enabled = ppumask & 24;
+  const uint8_t sprites_enabled = ppumask & 16;
+  const uint16_t bg_pattern_base = ppuctrl << 8 & 4096;
+  const uint8_t fine_x_shift = 15 - fine_x;
+  const uint8_t fine_x_palette_shift = 28 - fine_x * 2;
   uint32_t smolnes_ppu_phase = SMOLNES_PPU_PHASE_OTHER;
-  if (ppumask & 24 && scany < 240) {
+  if (rendering_enabled && scany < 240) {
     if (dot < 256)
       smolnes_ppu_phase = SMOLNES_PPU_PHASE_VISIBLE_PIXELS;
     else if (dot >= 320)
@@ -777,7 +782,7 @@ loop:
   }
   SMOLNES_PPU_PHASE_SET_IF_ACTIVE(smolnes_ppu_phase);
   for (tmp = cycles * 3 + 6; tmp--;) {
-    if (ppumask & 24) {
+    if (rendering_enabled) {
       if (scany < 240) {
         if (dot < 256) {
           if (dot == 0) {
@@ -787,11 +792,11 @@ loop:
             SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_VISIBLE_PIXELS);
           }
 
-          uint8_t color = shift_hi >> 14 - fine_x & 2 |
-                          shift_lo >> 15 - fine_x & 1,
-                  palette = shift_at >> 28 - fine_x * 2 & 12;
+          uint8_t color = shift_hi >> (fine_x_shift - 1) & 2 |
+                          shift_lo >> fine_x_shift & 1,
+                  palette = shift_at >> fine_x_palette_shift & 12;
 
-          if (ppumask & 16) {
+          if (sprites_enabled) {
             ScanlineSpritePixel *sprite = &scanline_sprite_pixels[dot];
             if (sprite->color) {
               if (!(sprite->attr & 32 && color)) {
@@ -809,7 +814,6 @@ loop:
           shift_lo <<= 1;
           shift_at <<= 2;
 
-          int temp = ppuctrl << 8 & 4096 | ntb << 4 | V >> 12;
           switch (dot & 7) {
           case 1:
             ntb = *get_nametable_byte(V);
@@ -820,12 +824,15 @@ loop:
                    (V >> 5 & 2 | V / 2 & 1) * 2) %
                   4 * 0x5555;
             break;
-          case 5:
+          case 5: {
+            int temp = bg_pattern_base | ntb << 4 | V >> 12;
             ptb_lo = *get_chr_byte(temp);
             break;
+          }
           case 7: {
+            int temp = bg_pattern_base | ntb << 4 | V >> 12;
             uint8_t ptb_hi = *get_chr_byte(temp | 8);
-            V = V % 32 == 31 ? V & ~31 ^ 1024 : V + 1;
+            V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
             shift_hi |= ptb_hi;
             shift_lo |= ptb_lo;
             shift_at |= atb;
@@ -849,7 +856,6 @@ loop:
             shift_at <<= 2;
           }
 
-          int temp = ppuctrl << 8 & 4096 | ntb << 4 | V >> 12;
           switch (dot & 7) {
           case 1:
             ntb = *get_nametable_byte(V);
@@ -860,12 +866,15 @@ loop:
                    (V >> 5 & 2 | V / 2 & 1) * 2) %
                   4 * 0x5555;
             break;
-          case 5:
+          case 5: {
+            int temp = bg_pattern_base | ntb << 4 | V >> 12;
             ptb_lo = *get_chr_byte(temp);
             break;
+          }
           case 7: {
+            int temp = bg_pattern_base | ntb << 4 | V >> 12;
             uint8_t ptb_hi = *get_chr_byte(temp | 8);
-            V = V % 32 == 31 ? V & ~31 ^ 1024 : V + 1;
+            V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
             shift_hi |= ptb_hi;
             shift_lo |= ptb_lo;
             shift_at |= atb;

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -393,6 +393,18 @@ static inline void render_visible_span_background_only(uint16_t span_count,
       }
 
       step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
           &local_ntb, &local_ptb_lo, fine_x);
@@ -420,6 +432,18 @@ static inline void render_visible_span_background_only(uint16_t span_count,
       }
 
       step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
           &local_ntb, &local_ptb_lo, fine_x);
@@ -445,6 +469,18 @@ static inline void render_visible_span_background_only(uint16_t span_count,
         local_shift_at_aligned <<= 2;
       }
 
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
       step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
@@ -571,6 +607,18 @@ static inline void render_visible_span(uint16_t span_count,
       }
 
       step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
           &local_ntb, &local_ptb_lo, fine_x);
@@ -606,6 +654,18 @@ static inline void render_visible_span(uint16_t span_count,
       }
 
       step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
           &local_ntb, &local_ptb_lo, fine_x);
@@ -639,6 +699,18 @@ static inline void render_visible_span(uint16_t span_count,
         local_shift_at_aligned <<= 2;
       }
 
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 1, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 3, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 5, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
       step_background_fetch_pipeline_for_dot_aligned(
           bg_pattern_base, current_dot + 7, &local_V, &local_atb,
           &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -369,9 +369,8 @@ static inline void render_visible_span_background_only(uint16_t span_count,
     --span_count;
   }
 
-  while (span_count >= 8) {
-    const uint16_t base_offset = scanline_fb_offset + current_dot;
-    if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+  if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+    while (span_count >= 8) {
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -381,7 +380,18 @@ static inline void render_visible_span_background_only(uint16_t span_count,
         local_shift_lo_aligned <<= 1;
         local_shift_at_aligned <<= 2;
       }
-    } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
+    }
+  } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+    while (span_count >= 8) {
+      const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -395,7 +405,18 @@ static inline void render_visible_span_background_only(uint16_t span_count,
         local_shift_lo_aligned <<= 1;
         local_shift_at_aligned <<= 2;
       }
-    } else {
+
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
+    }
+  } else {
+    while (span_count >= 8) {
+      const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -408,15 +429,15 @@ static inline void render_visible_span_background_only(uint16_t span_count,
         local_shift_lo_aligned <<= 1;
         local_shift_at_aligned <<= 2;
       }
+
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
     }
-
-    step_background_fetch_pipeline_for_dot_aligned(
-        bg_pattern_base, current_dot + 7, &local_V, &local_atb,
-        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
-        &local_ntb, &local_ptb_lo, fine_x);
-
-    current_dot += 8;
-    span_count -= 8;
   }
 
   while (span_count > 0) {
@@ -509,9 +530,8 @@ static inline void render_visible_span(uint16_t span_count,
     --span_count;
   }
 
-  while (span_count >= 8) {
-    const uint16_t base_offset = scanline_fb_offset + current_dot;
-    if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+  if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+    while (span_count >= 8) {
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -531,7 +551,18 @@ static inline void render_visible_span(uint16_t span_count,
         local_shift_lo_aligned <<= 1;
         local_shift_at_aligned <<= 2;
       }
-    } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
+    }
+  } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+    while (span_count >= 8) {
+      const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -555,7 +586,18 @@ static inline void render_visible_span(uint16_t span_count,
         local_shift_lo_aligned <<= 1;
         local_shift_at_aligned <<= 2;
       }
-    } else {
+
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
+    }
+  } else {
+    while (span_count >= 8) {
+      const uint16_t base_offset = scanline_fb_offset + current_dot;
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
         uint8_t color = local_shift_hi_aligned >> 14 & 2 |
                         local_shift_lo_aligned >> 15 & 1,
@@ -579,15 +621,14 @@ static inline void render_visible_span(uint16_t span_count,
         local_shift_at_aligned <<= 2;
       }
 
+      step_background_fetch_pipeline_for_dot_aligned(
+          bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+          &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+          &local_ntb, &local_ptb_lo, fine_x);
+
+      current_dot += 8;
+      span_count -= 8;
     }
-
-    step_background_fetch_pipeline_for_dot_aligned(
-        bg_pattern_base, current_dot + 7, &local_V, &local_atb,
-        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
-        &local_ntb, &local_ptb_lo, fine_x);
-
-    current_dot += 8;
-    span_count -= 8;
   }
 
   while (span_count > 0) {

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -45,6 +45,18 @@
 #define SMOLNES_PPU_STEP_END()
 #endif
 
+#ifndef SMOLNES_DEFERRED_PPU_SAMPLE
+#define SMOLNES_DEFERRED_PPU_SAMPLE(ppu_dot_count)
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_STEP_BEGIN
+#define SMOLNES_DEFERRED_PPU_STEP_BEGIN(total_ppu_dots)
+#endif
+
+#ifndef SMOLNES_DEFERRED_PPU_STEP_END
+#define SMOLNES_DEFERRED_PPU_STEP_END()
+#endif
+
 #ifndef SMOLNES_PPU_PHASE_SET
 #define SMOLNES_PPU_PHASE_SET(phase)
 #endif
@@ -177,6 +189,7 @@ SMOLNES_TLS uint8_t frame_buffer_palette[61440];
 SMOLNES_TLS int shift_at = 0;
 
 SMOLNES_TLS uint16_t scanline_fb_offset;
+SMOLNES_TLS uint16_t deferred_ppu_dots;
 
 // 2C02G hardware-measured NES palette converted to RGB565.
 // Source: Ricoh 2C02G PPU NTSC decode (Mesen/nesdev wiki reference).
@@ -776,10 +789,51 @@ static inline void run_prefetch_dot(uint16_t bg_pattern_base) {
       &ptb_lo);
 }
 
+static inline uint8_t canDeferVisiblePpuDots(uint16_t ppu_dot_count) {
+  if (!(ppumask & 24))
+    return 0;
+  if (scany >= 240)
+    return 0;
+  if (dot >= 256)
+    return 0;
+  return dot + deferred_ppu_dots + ppu_dot_count <= 256;
+}
+
+static inline void runDeferredVisiblePpuDots(uint16_t ppu_dot_count) {
+  if (!ppu_dot_count)
+    return;
+
+  SMOLNES_DEFERRED_PPU_STEP_BEGIN(ppu_dot_count);
+  if (dot == 0) {
+    SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_SPRITE_EVAL);
+    scanline_fb_offset = scany * 256;
+    evaluate_scanline_sprites();
+  }
+  SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_VISIBLE_PIXELS);
+  render_visible_span(ppu_dot_count, fine_x, ppuctrl << 8 & 4096);
+  dot += ppu_dot_count;
+  SMOLNES_PPU_PHASE_CLEAR();
+  SMOLNES_DEFERRED_PPU_STEP_END();
+}
+
+static inline void flushDeferredPpuDots(void) {
+  if (!deferred_ppu_dots)
+    return;
+  runDeferredVisiblePpuDots(deferred_ppu_dots);
+  deferred_ppu_dots = 0;
+}
+
 // If `write` is non-zero, writes `val` to the address `hi:lo`, otherwise reads
 // a value from the address `hi:lo`.
 uint8_t mem(uint8_t lo, uint8_t hi, uint8_t val, uint8_t write) {
   uint16_t addr = hi << 8 | lo;
+  if (deferred_ppu_dots) {
+    const uint8_t is_ppu_register_access = addr >= 0x2000 && addr < 0x4000;
+    const uint8_t is_oam_dma = write && addr == 0x4014;
+    const uint8_t is_mapper_write = write && addr >= 0x8000;
+    if (is_mapper_write || is_oam_dma || is_ppu_register_access)
+      flushDeferredPpuDots();
+  }
 
   switch (hi >>= 4) {
   case 0: case 1: // $0000...$1fff RAM
@@ -1298,6 +1352,13 @@ loop:
   SMOLNES_APU_CLOCK_BEGIN();
   SMOLNES_APU_CLOCK(cycles + 2);
   SMOLNES_APU_CLOCK_END();
+  const uint16_t ppu_dot_count = cycles * 3 + 6;
+  if (canDeferVisiblePpuDots(ppu_dot_count)) {
+    SMOLNES_DEFERRED_PPU_SAMPLE(ppu_dot_count);
+    deferred_ppu_dots += ppu_dot_count;
+    goto loop;
+  }
+  flushDeferredPpuDots();
   SMOLNES_PPU_STEP_BEGIN();
   const uint8_t rendering_enabled = ppumask & 24;
   const uint16_t bg_pattern_base = ppuctrl << 8 & 4096;
@@ -1315,7 +1376,7 @@ loop:
     }
   }
   SMOLNES_PPU_PHASE_SET_IF_ACTIVE(smolnes_ppu_phase);
-  for (tmp = cycles * 3 + 6; tmp--;) {
+  for (tmp = ppu_dot_count; tmp--;) {
     if (rendering_enabled) {
       if (scany < 240) {
         if (dot < 256) {

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -53,6 +53,26 @@
 #define SMOLNES_PPU_PHASE_CLEAR()
 #endif
 
+#ifndef SMOLNES_PPU_PHASE_SET_IF_ACTIVE
+#define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)
+#endif
+
+#ifndef SMOLNES_PPU_PHASE_VISIBLE_PIXELS
+#define SMOLNES_PPU_PHASE_VISIBLE_PIXELS 1u
+#endif
+
+#ifndef SMOLNES_PPU_PHASE_PREFETCH
+#define SMOLNES_PPU_PHASE_PREFETCH 2u
+#endif
+
+#ifndef SMOLNES_PPU_PHASE_OTHER
+#define SMOLNES_PPU_PHASE_OTHER 3u
+#endif
+
+#ifndef SMOLNES_PPU_PHASE_SPRITE_EVAL
+#define SMOLNES_PPU_PHASE_SPRITE_EVAL 4u
+#endif
+
 #ifndef SMOLNES_APU_WRITE
 #define SMOLNES_APU_WRITE(addr, value)
 #endif
@@ -735,13 +755,23 @@ loop:
   SMOLNES_APU_CLOCK(cycles + 2);
   SMOLNES_APU_CLOCK_END();
   SMOLNES_PPU_STEP_BEGIN();
+  uint32_t smolnes_ppu_phase = SMOLNES_PPU_PHASE_OTHER;
+  if (ppumask & 24 && scany < 240) {
+    if (dot < 256)
+      smolnes_ppu_phase = SMOLNES_PPU_PHASE_VISIBLE_PIXELS;
+    else if (dot >= 320)
+      smolnes_ppu_phase = SMOLNES_PPU_PHASE_PREFETCH;
+  }
+  SMOLNES_PPU_PHASE_SET_IF_ACTIVE(smolnes_ppu_phase);
   for (tmp = cycles * 3 + 6; tmp--;) {
     if (ppumask & 24) {
       if (scany < 240) {
         if (dot < 256) {
           if (dot == 0) {
+            SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_SPRITE_EVAL);
             scanline_fb_offset = scany * 256;
             evaluate_scanline_sprites();
+            SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_VISIBLE_PIXELS);
           }
 
           uint8_t color = shift_hi >> 14 - fine_x & 2 |
@@ -800,6 +830,7 @@ loop:
           }
           }
         } else if (dot == 256) {
+          SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_OTHER);
           V = ((V & 7 << 12) != 7 << 12 ? V + 4096
                : (V & 0x3e0) == 928     ? V & 0x8c1f ^ 2048
                : (V & 0x3e0) == 0x3e0   ? V & 0x8c1f
@@ -807,6 +838,8 @@ loop:
                   ~0x41f |
               T & 0x41f;
         } else if (dot >= 320) {
+          if (dot == 320)
+            SMOLNES_PPU_PHASE_SET_IF_ACTIVE(SMOLNES_PPU_PHASE_PREFETCH);
           if (dot < 336) {
             shift_hi <<= 1;
             shift_lo <<= 1;

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -186,14 +186,7 @@ static const uint16_t nes_palette_rgb565[64] = {
     65535, 48895, 52927, 59039, 65151, 65116, 65145, 63158,
     59092, 53013, 46902, 44857, 44860, 46518,     0,     0};
 
-typedef struct {
-    uint8_t attr;
-    uint8_t color;
-    uint8_t is_sprite0;
-    uint8_t palette;
-} ScanlineSpritePixel;
-
-SMOLNES_TLS ScanlineSpritePixel scanline_sprite_pixels[256];
+SMOLNES_TLS uint8_t scanline_sprite_pixels[256];
 SMOLNES_TLS uint8_t scanline_has_sprite_pixels;
 
 // Read a byte from CHR ROM or CHR RAM.
@@ -240,7 +233,6 @@ static void evaluate_scanline_sprites(void) {
     }
 
     const uint8_t sprite_attr = sprite[2];
-    const uint8_t sprite_palette = 16 | ((sprite_attr * 4) & 12);
     const uint8_t is_sprite0 = (sprite == oam);
     for (uint16_t sprite_x = 0; sprite_x < 8; ++sprite_x) {
       uint16_t screen_x = sprite[3] + sprite_x;
@@ -251,14 +243,12 @@ static void evaluate_scanline_sprites(void) {
       uint8_t sprite_color =
           (pattern_hi >> offset & 1) << 1 |
           (pattern_lo >> offset & 1);
-      if (!sprite_color || scanline_sprite_pixels[screen_x].color)
+      if (!sprite_color || scanline_sprite_pixels[screen_x])
         continue;
-
-      ScanlineSpritePixel *p = &scanline_sprite_pixels[screen_x];
-      p->attr = sprite_attr;
-      p->color = sprite_color;
-      p->is_sprite0 = is_sprite0;
-      p->palette = sprite_palette;
+      scanline_sprite_pixels[screen_x] =
+          sprite_color | ((sprite_attr & 3) << 2) |
+          (sprite_attr & 32 ? 16 : 0) |
+          (is_sprite0 ? 32 : 0);
       scanline_has_sprite_pixels = 1;
     }
   }
@@ -488,13 +478,13 @@ static inline void render_visible_span(uint16_t span_count,
                     local_shift_lo_aligned >> 15 & 1,
             palette = local_shift_at_aligned >> 28 & 12;
 
-    ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
-    if (sprite->color) {
-      if (!(sprite->attr & 32 && color)) {
-        color = sprite->color;
-        palette = sprite->palette;
+    const uint8_t sprite = scanline_sprite_pixels[current_dot];
+    if (sprite) {
+      if (!(sprite & 16 && color)) {
+        color = sprite & 3;
+        palette = 16 | (sprite & 12);
       }
-      if (sprite->is_sprite0 && color)
+      if (sprite & 32 && color)
         ppustatus |= 64;
     }
 
@@ -527,13 +517,13 @@ static inline void render_visible_span(uint16_t span_count,
                         local_shift_lo_aligned >> 15 & 1,
                 palette = local_shift_at_aligned >> 28 & 12;
 
-        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-        if (sprite->color) {
-          if (!(sprite->attr & 32 && color)) {
-            color = sprite->color;
-            palette = sprite->palette;
+        const uint8_t sprite = scanline_sprite_pixels[current_dot + pixel];
+        if (sprite) {
+          if (!(sprite & 16 && color)) {
+            color = sprite & 3;
+            palette = 16 | (sprite & 12);
           }
-          if (sprite->is_sprite0 && color)
+          if (sprite & 32 && color)
             ppustatus |= 64;
         }
 
@@ -547,13 +537,13 @@ static inline void render_visible_span(uint16_t span_count,
                         local_shift_lo_aligned >> 15 & 1,
                 palette = local_shift_at_aligned >> 28 & 12;
 
-        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-        if (sprite->color) {
-          if (!(sprite->attr & 32 && color)) {
-            color = sprite->color;
-            palette = sprite->palette;
+        const uint8_t sprite = scanline_sprite_pixels[current_dot + pixel];
+        if (sprite) {
+          if (!(sprite & 16 && color)) {
+            color = sprite & 3;
+            palette = 16 | (sprite & 12);
           }
-          if (sprite->is_sprite0 && color)
+          if (sprite & 32 && color)
             ppustatus |= 64;
         }
 
@@ -571,13 +561,13 @@ static inline void render_visible_span(uint16_t span_count,
                         local_shift_lo_aligned >> 15 & 1,
                 palette = local_shift_at_aligned >> 28 & 12;
 
-        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-        if (sprite->color) {
-          if (!(sprite->attr & 32 && color)) {
-            color = sprite->color;
-            palette = sprite->palette;
+        const uint8_t sprite = scanline_sprite_pixels[current_dot + pixel];
+        if (sprite) {
+          if (!(sprite & 16 && color)) {
+            color = sprite & 3;
+            palette = 16 | (sprite & 12);
           }
-          if (sprite->is_sprite0 && color)
+          if (sprite & 32 && color)
             ppustatus |= 64;
         }
 
@@ -605,13 +595,13 @@ static inline void render_visible_span(uint16_t span_count,
                     local_shift_lo_aligned >> 15 & 1,
             palette = local_shift_at_aligned >> 28 & 12;
 
-    ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
-    if (sprite->color) {
-      if (!(sprite->attr & 32 && color)) {
-        color = sprite->color;
-        palette = sprite->palette;
+    const uint8_t sprite = scanline_sprite_pixels[current_dot];
+    if (sprite) {
+      if (!(sprite & 16 && color)) {
+        color = sprite & 3;
+        palette = 16 | (sprite & 12);
       }
-      if (sprite->is_sprite0 && color)
+      if (sprite & 32 && color)
         ppustatus |= 64;
     }
 

--- a/apps/external/smolnes/deobfuscated.c
+++ b/apps/external/smolnes/deobfuscated.c
@@ -194,6 +194,7 @@ typedef struct {
 } ScanlineSpritePixel;
 
 SMOLNES_TLS ScanlineSpritePixel scanline_sprite_pixels[256];
+SMOLNES_TLS uint8_t scanline_has_sprite_pixels;
 
 // Read a byte from CHR ROM or CHR RAM.
 static inline uint8_t *get_chr_byte(uint16_t a) {
@@ -210,6 +211,7 @@ static inline uint8_t *get_nametable_byte(uint16_t a) {
 
 static void evaluate_scanline_sprites(void) {
   memset(scanline_sprite_pixels, 0, sizeof(scanline_sprite_pixels));
+  scanline_has_sprite_pixels = 0;
   uint16_t sprite_h = ppuctrl & 32 ? 16 : 8;
   for (uint8_t *sprite = oam; sprite < oam + 256; sprite += 4) {
     uint16_t sprite_y = scany - sprite[0] - 1;
@@ -257,49 +259,94 @@ static void evaluate_scanline_sprites(void) {
       p->color = sprite_color;
       p->is_sprite0 = is_sprite0;
       p->palette = sprite_palette;
+      scanline_has_sprite_pixels = 1;
     }
   }
 }
 
-static inline void step_background_fetch_pipeline(uint16_t bg_pattern_base) {
-  switch (dot & 7) {
+static inline void step_background_fetch_pipeline_for_dot(uint16_t bg_pattern_base,
+                                                          uint16_t current_dot,
+                                                          uint16_t *local_V,
+                                                          uint16_t *local_atb,
+                                                          uint16_t *local_shift_hi,
+                                                          uint16_t *local_shift_lo,
+                                                          int *local_shift_at,
+                                                          uint8_t *local_ntb,
+                                                          uint8_t *local_ptb_lo) {
+  switch (current_dot & 7) {
   case 1:
-    ntb = *get_nametable_byte(V);
+    *local_ntb = *get_nametable_byte(*local_V);
     break;
   case 3:
-    atb = (*get_nametable_byte(V & 0xc00 | 0x3c0 | V >> 4 & 0x38 |
-                               V / 4 & 7) >>
-           (V >> 5 & 2 | V / 2 & 1) * 2) %
-          4 * 0x5555;
+    *local_atb = (*get_nametable_byte(*local_V & 0xc00 | 0x3c0 | *local_V >> 4 & 0x38 |
+                                      *local_V / 4 & 7) >>
+                  (*local_V >> 5 & 2 | *local_V / 2 & 1) * 2) %
+                 4 * 0x5555;
     break;
   case 5: {
-    const int temp = bg_pattern_base | ntb << 4 | V >> 12;
-    ptb_lo = *get_chr_byte(temp);
+    const int temp = bg_pattern_base | *local_ntb << 4 | *local_V >> 12;
+    *local_ptb_lo = *get_chr_byte(temp);
     break;
   }
   case 7: {
-    const int temp = bg_pattern_base | ntb << 4 | V >> 12;
+    const int temp = bg_pattern_base | *local_ntb << 4 | *local_V >> 12;
     const uint8_t ptb_hi = *get_chr_byte(temp | 8);
-    V = (V & 31) == 31 ? V & ~31 ^ 1024 : V + 1;
-    shift_hi |= ptb_hi;
-    shift_lo |= ptb_lo;
-    shift_at |= atb;
+    *local_V = (*local_V & 31) == 31 ? *local_V & ~31 ^ 1024 : *local_V + 1;
+    *local_shift_hi |= ptb_hi;
+    *local_shift_lo |= *local_ptb_lo;
+    *local_shift_at |= *local_atb;
     break;
   }
   }
 }
 
-static inline void render_visible_span(uint16_t span_count,
-                                       uint8_t sprites_enabled,
-                                       uint8_t fine_x_shift,
-                                       uint8_t fine_x_palette_shift,
-                                       uint16_t bg_pattern_base) {
+static inline void step_background_fetch_pipeline_for_dot_aligned(
+    uint16_t bg_pattern_base,
+    uint16_t current_dot,
+    uint16_t *local_V,
+    uint16_t *local_atb,
+    uint32_t *local_shift_hi_aligned,
+    uint32_t *local_shift_lo_aligned,
+    uint64_t *local_shift_at_aligned,
+    uint8_t *local_ntb,
+    uint8_t *local_ptb_lo,
+    uint8_t fine_x) {
+  switch (current_dot & 7) {
+  case 1:
+    *local_ntb = *get_nametable_byte(*local_V);
+    break;
+  case 3:
+    *local_atb = (*get_nametable_byte(*local_V & 0xc00 | 0x3c0 | *local_V >> 4 & 0x38 |
+                                      *local_V / 4 & 7) >>
+                  (*local_V >> 5 & 2 | *local_V / 2 & 1) * 2) %
+                 4 * 0x5555;
+    break;
+  case 5: {
+    const int temp = bg_pattern_base | *local_ntb << 4 | *local_V >> 12;
+    *local_ptb_lo = *get_chr_byte(temp);
+    break;
+  }
+  case 7: {
+    const int temp = bg_pattern_base | *local_ntb << 4 | *local_V >> 12;
+    const uint8_t ptb_hi = *get_chr_byte(temp | 8);
+    *local_V = (*local_V & 31) == 31 ? *local_V & ~31 ^ 1024 : *local_V + 1;
+    *local_shift_hi_aligned |= (uint32_t)ptb_hi << fine_x;
+    *local_shift_lo_aligned |= (uint32_t)(*local_ptb_lo) << fine_x;
+    *local_shift_at_aligned |= (uint64_t)(uint32_t)(*local_atb) << (fine_x * 2);
+    break;
+  }
+  }
+}
+
+static inline void render_visible_span_background_only(uint16_t span_count,
+                                                       uint8_t fine_x,
+                                                       uint16_t bg_pattern_base) {
   uint16_t current_dot = dot;
   uint16_t local_V = V;
   uint16_t local_atb = atb;
-  uint16_t local_shift_hi = shift_hi;
-  uint16_t local_shift_lo = shift_lo;
-  int local_shift_at = shift_at;
+  uint32_t local_shift_hi_aligned = (uint32_t)shift_hi << fine_x;
+  uint32_t local_shift_lo_aligned = (uint32_t)shift_lo << fine_x;
+  uint64_t local_shift_at_aligned = (uint64_t)(uint32_t)shift_at << (fine_x * 2);
   uint8_t local_ntb = ntb;
   uint8_t local_ptb_lo = ptb_lo;
   uint16_t prefix_count = (8 - (current_dot & 7)) & 7;
@@ -307,21 +354,9 @@ static inline void render_visible_span(uint16_t span_count,
     prefix_count = span_count;
 
   while (prefix_count > 0) {
-    uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                    local_shift_lo >> fine_x_shift & 1,
-            palette = local_shift_at >> fine_x_palette_shift & 12;
-
-    if (sprites_enabled) {
-      ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
-      if (sprite->color) {
-        if (!(sprite->attr & 32 && color)) {
-          color = sprite->color;
-          palette = sprite->palette;
-        }
-        if (sprite->is_sprite0 && color)
-          ppustatus |= 64;
-      }
-    }
+    uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                    local_shift_lo_aligned >> 15 & 1,
+            palette = local_shift_at_aligned >> 28 & 12;
 
     if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
       const uint16_t output_offset = scanline_fb_offset + current_dot;
@@ -331,35 +366,13 @@ static inline void render_visible_span(uint16_t span_count,
         frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
     }
 
-    local_shift_hi <<= 1;
-    local_shift_lo <<= 1;
-    local_shift_at <<= 2;
-
-    switch (current_dot & 7) {
-    case 1:
-      local_ntb = *get_nametable_byte(local_V);
-      break;
-    case 3:
-      local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
-                                       local_V / 4 & 7) >>
-                   (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
-                  4 * 0x5555;
-      break;
-    case 5: {
-      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
-      local_ptb_lo = *get_chr_byte(temp);
-      break;
-    }
-    case 7: {
-      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
-      const uint8_t ptb_hi = *get_chr_byte(temp | 8);
-      local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
-      local_shift_hi |= ptb_hi;
-      local_shift_lo |= local_ptb_lo;
-      local_shift_at |= local_atb;
-      break;
-    }
-    }
+    local_shift_hi_aligned <<= 1;
+    local_shift_lo_aligned <<= 1;
+    local_shift_at_aligned <<= 2;
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
 
     ++current_dot;
     --prefix_count;
@@ -370,111 +383,119 @@ static inline void render_visible_span(uint16_t span_count,
     const uint16_t base_offset = scanline_fb_offset + current_dot;
     if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
-        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                        local_shift_lo >> fine_x_shift & 1,
-                palette = local_shift_at >> fine_x_palette_shift & 12;
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
 
-        if (sprites_enabled) {
-          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-          if (sprite->color) {
-            if (!(sprite->attr & 32 && color)) {
-              color = sprite->color;
-              palette = sprite->palette;
-            }
-            if (sprite->is_sprite0 && color)
-              ppustatus |= 64;
-          }
-        }
-
-        local_shift_hi <<= 1;
-        local_shift_lo <<= 1;
-        local_shift_at <<= 2;
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
       }
     } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
-        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                        local_shift_lo >> fine_x_shift & 1,
-                palette = local_shift_at >> fine_x_palette_shift & 12;
-
-        if (sprites_enabled) {
-          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-          if (sprite->color) {
-            if (!(sprite->attr & 32 && color)) {
-              color = sprite->color;
-              palette = sprite->palette;
-            }
-            if (sprite->is_sprite0 && color)
-              ppustatus |= 64;
-          }
-        }
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
 
         const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
         frame_buffer_palette[base_offset + pixel] = palette_index;
         frame_buffer[base_offset + pixel] = nes_palette_rgb565[palette_index];
 
-        local_shift_hi <<= 1;
-        local_shift_lo <<= 1;
-        local_shift_at <<= 2;
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
       }
     } else {
       for (uint16_t pixel = 0; pixel < 8; ++pixel) {
-        uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                        local_shift_lo >> fine_x_shift & 1,
-                palette = local_shift_at >> fine_x_palette_shift & 12;
-
-        if (sprites_enabled) {
-          ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
-          if (sprite->color) {
-            if (!(sprite->attr & 32 && color)) {
-              color = sprite->color;
-              palette = sprite->palette;
-            }
-            if (sprite->is_sprite0 && color)
-              ppustatus |= 64;
-          }
-        }
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
 
         frame_buffer_palette[base_offset + pixel] =
             palette_ram[(color) ? (palette) | (color) : 0];
 
-        local_shift_hi <<= 1;
-        local_shift_lo <<= 1;
-        local_shift_at <<= 2;
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
       }
     }
 
-    local_ntb = *get_nametable_byte(local_V);
-    local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
-                                     local_V / 4 & 7) >>
-                 (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
-                4 * 0x5555;
-    const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
-    local_ptb_lo = *get_chr_byte(temp);
-    const uint8_t ptb_hi = *get_chr_byte(temp | 8);
-    local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
-    local_shift_hi |= ptb_hi;
-    local_shift_lo |= local_ptb_lo;
-    local_shift_at |= local_atb;
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
 
     current_dot += 8;
     span_count -= 8;
   }
 
   while (span_count > 0) {
-    uint8_t color = local_shift_hi >> (fine_x_shift - 1) & 2 |
-                    local_shift_lo >> fine_x_shift & 1,
-            palette = local_shift_at >> fine_x_palette_shift & 12;
+    uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                    local_shift_lo_aligned >> 15 & 1,
+            palette = local_shift_at_aligned >> 28 & 12;
 
-    if (sprites_enabled) {
-      ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
-      if (sprite->color) {
-        if (!(sprite->attr & 32 && color)) {
-          color = sprite->color;
-          palette = sprite->palette;
-        }
-        if (sprite->is_sprite0 && color)
-          ppustatus |= 64;
+    if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      const uint16_t output_offset = scanline_fb_offset + current_dot;
+      const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+      frame_buffer_palette[output_offset] = palette_index;
+      if (SMOLNES_RGBA_OUTPUT_ENABLED)
+        frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
+    }
+
+    local_shift_hi_aligned <<= 1;
+    local_shift_lo_aligned <<= 1;
+    local_shift_at_aligned <<= 2;
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
+
+    ++current_dot;
+    --span_count;
+  }
+
+  V = local_V;
+  atb = local_atb;
+  shift_hi = local_shift_hi_aligned >> fine_x;
+  shift_lo = local_shift_lo_aligned >> fine_x;
+  shift_at = local_shift_at_aligned >> (fine_x * 2);
+  ntb = local_ntb;
+  ptb_lo = local_ptb_lo;
+}
+
+static inline void render_visible_span(uint16_t span_count,
+                                       uint8_t fine_x,
+                                       uint16_t bg_pattern_base) {
+  if (!scanline_has_sprite_pixels) {
+    render_visible_span_background_only(span_count, fine_x, bg_pattern_base);
+    return;
+  }
+
+  uint16_t current_dot = dot;
+  uint16_t local_V = V;
+  uint16_t local_atb = atb;
+  uint32_t local_shift_hi_aligned = (uint32_t)shift_hi << fine_x;
+  uint32_t local_shift_lo_aligned = (uint32_t)shift_lo << fine_x;
+  uint64_t local_shift_at_aligned = (uint64_t)(uint32_t)shift_at << (fine_x * 2);
+  uint8_t local_ntb = ntb;
+  uint8_t local_ptb_lo = ptb_lo;
+  uint16_t prefix_count = (8 - (current_dot & 7)) & 7;
+  if (prefix_count > span_count)
+    prefix_count = span_count;
+
+  while (prefix_count > 0) {
+    uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                    local_shift_lo_aligned >> 15 & 1,
+            palette = local_shift_at_aligned >> 28 & 12;
+
+    ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
+    if (sprite->color) {
+      if (!(sprite->attr & 32 && color)) {
+        color = sprite->color;
+        palette = sprite->palette;
       }
+      if (sprite->is_sprite0 && color)
+        ppustatus |= 64;
     }
 
     if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
@@ -485,35 +506,130 @@ static inline void render_visible_span(uint16_t span_count,
         frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
     }
 
-    local_shift_hi <<= 1;
-    local_shift_lo <<= 1;
-    local_shift_at <<= 2;
+    local_shift_hi_aligned <<= 1;
+    local_shift_lo_aligned <<= 1;
+    local_shift_at_aligned <<= 2;
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
 
-    switch (current_dot & 7) {
-    case 1:
-      local_ntb = *get_nametable_byte(local_V);
-      break;
-    case 3:
-      local_atb = (*get_nametable_byte(local_V & 0xc00 | 0x3c0 | local_V >> 4 & 0x38 |
-                                       local_V / 4 & 7) >>
-                   (local_V >> 5 & 2 | local_V / 2 & 1) * 2) %
-                  4 * 0x5555;
-      break;
-    case 5: {
-      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
-      local_ptb_lo = *get_chr_byte(temp);
-      break;
+    ++current_dot;
+    --prefix_count;
+    --span_count;
+  }
+
+  while (span_count >= 8) {
+    const uint16_t base_offset = scanline_fb_offset + current_dot;
+    if (!SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
+
+        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+        if (sprite->color) {
+          if (!(sprite->attr & 32 && color)) {
+            color = sprite->color;
+            palette = sprite->palette;
+          }
+          if (sprite->is_sprite0 && color)
+            ppustatus |= 64;
+        }
+
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
+      }
+    } else if (SMOLNES_RGBA_OUTPUT_ENABLED) {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
+
+        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+        if (sprite->color) {
+          if (!(sprite->attr & 32 && color)) {
+            color = sprite->color;
+            palette = sprite->palette;
+          }
+          if (sprite->is_sprite0 && color)
+            ppustatus |= 64;
+        }
+
+        const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+        frame_buffer_palette[base_offset + pixel] = palette_index;
+        frame_buffer[base_offset + pixel] = nes_palette_rgb565[palette_index];
+
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
+      }
+    } else {
+      for (uint16_t pixel = 0; pixel < 8; ++pixel) {
+        uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                        local_shift_lo_aligned >> 15 & 1,
+                palette = local_shift_at_aligned >> 28 & 12;
+
+        ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot + pixel];
+        if (sprite->color) {
+          if (!(sprite->attr & 32 && color)) {
+            color = sprite->color;
+            palette = sprite->palette;
+          }
+          if (sprite->is_sprite0 && color)
+            ppustatus |= 64;
+        }
+
+        frame_buffer_palette[base_offset + pixel] =
+            palette_ram[(color) ? (palette) | (color) : 0];
+
+        local_shift_hi_aligned <<= 1;
+        local_shift_lo_aligned <<= 1;
+        local_shift_at_aligned <<= 2;
+      }
+
     }
-    case 7: {
-      const int temp = bg_pattern_base | local_ntb << 4 | local_V >> 12;
-      const uint8_t ptb_hi = *get_chr_byte(temp | 8);
-      local_V = (local_V & 31) == 31 ? local_V & ~31 ^ 1024 : local_V + 1;
-      local_shift_hi |= ptb_hi;
-      local_shift_lo |= local_ptb_lo;
-      local_shift_at |= local_atb;
-      break;
+
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot + 7, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
+
+    current_dot += 8;
+    span_count -= 8;
+  }
+
+  while (span_count > 0) {
+    uint8_t color = local_shift_hi_aligned >> 14 & 2 |
+                    local_shift_lo_aligned >> 15 & 1,
+            palette = local_shift_at_aligned >> 28 & 12;
+
+    ScanlineSpritePixel *sprite = &scanline_sprite_pixels[current_dot];
+    if (sprite->color) {
+      if (!(sprite->attr & 32 && color)) {
+        color = sprite->color;
+        palette = sprite->palette;
+      }
+      if (sprite->is_sprite0 && color)
+        ppustatus |= 64;
     }
+
+    if (SMOLNES_PIXEL_OUTPUT_ENABLED) {
+      const uint16_t output_offset = scanline_fb_offset + current_dot;
+      const uint8_t palette_index = palette_ram[(color) ? (palette) | (color) : 0];
+      frame_buffer_palette[output_offset] = palette_index;
+      if (SMOLNES_RGBA_OUTPUT_ENABLED)
+        frame_buffer[output_offset] = nes_palette_rgb565[palette_index];
     }
+
+    local_shift_hi_aligned <<= 1;
+    local_shift_lo_aligned <<= 1;
+    local_shift_at_aligned <<= 2;
+    step_background_fetch_pipeline_for_dot_aligned(
+        bg_pattern_base, current_dot, &local_V, &local_atb,
+        &local_shift_hi_aligned, &local_shift_lo_aligned, &local_shift_at_aligned,
+        &local_ntb, &local_ptb_lo, fine_x);
 
     ++current_dot;
     --span_count;
@@ -521,9 +637,9 @@ static inline void render_visible_span(uint16_t span_count,
 
   V = local_V;
   atb = local_atb;
-  shift_hi = local_shift_hi;
-  shift_lo = local_shift_lo;
-  shift_at = local_shift_at;
+  shift_hi = local_shift_hi_aligned >> fine_x;
+  shift_lo = local_shift_lo_aligned >> fine_x;
+  shift_at = local_shift_at_aligned >> (fine_x * 2);
   ntb = local_ntb;
   ptb_lo = local_ptb_lo;
 }
@@ -534,7 +650,9 @@ static inline void run_prefetch_dot(uint16_t bg_pattern_base) {
     shift_lo <<= 1;
     shift_at <<= 2;
   }
-  step_background_fetch_pipeline(bg_pattern_base);
+  step_background_fetch_pipeline_for_dot(
+      bg_pattern_base, dot, &V, &atb, &shift_hi, &shift_lo, &shift_at, &ntb,
+      &ptb_lo);
 }
 
 // If `write` is non-zero, writes `val` to the address `hi:lo`, otherwise reads
@@ -1061,10 +1179,7 @@ loop:
   SMOLNES_APU_CLOCK_END();
   SMOLNES_PPU_STEP_BEGIN();
   const uint8_t rendering_enabled = ppumask & 24;
-  const uint8_t sprites_enabled = ppumask & 16;
   const uint16_t bg_pattern_base = ppuctrl << 8 & 4096;
-  const uint8_t fine_x_shift = 15 - fine_x;
-  const uint8_t fine_x_palette_shift = 28 - fine_x * 2;
   uint32_t smolnes_ppu_phase = SMOLNES_PPU_PHASE_OTHER;
   if (rendering_enabled) {
     if (scany < 240) {
@@ -1092,9 +1207,7 @@ loop:
           uint16_t visible_span = tmp + 1;
           if (visible_span > 256 - dot)
             visible_span = 256 - dot;
-          render_visible_span(
-              visible_span, sprites_enabled, fine_x_shift, fine_x_palette_shift,
-              bg_pattern_base);
+          render_visible_span(visible_span, fine_x, bg_pattern_base);
           dot += visible_span - 1;
           tmp -= visible_span - 1;
         } else if (dot == 256) {

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -192,7 +192,9 @@ TrainingRunner::TrainingRunner(
       spawnRng_(runnerConfig.duckClockSpawnRngSeed.value_or(
           static_cast<uint32_t>(std::random_device{}()))),
       evolutionConfig_(evolutionConfig),
-      frameTraceSink_(runnerConfig.frameTraceSink)
+      frameTraceSink_(runnerConfig.frameTraceSink),
+      nesApuEnabled_(runnerConfig.nesApuEnabled),
+      nesDetailedTimingEnabled_(runnerConfig.nesDetailedTimingEnabled)
 {
     resolveBrainEntry();
 
@@ -241,6 +243,11 @@ TrainingRunner::TrainingRunner(
                     setupResult.errorValue());
                 state_ = State::OrganismDied;
             }
+        }
+
+        if (state_ == State::Running) {
+            nesDriver_->setApuEnabled(nesApuEnabled_);
+            nesDriver_->setDetailedTimingEnabled(nesDetailedTimingEnabled_);
         }
 
         nesWorldData_.width = 256;
@@ -670,6 +677,8 @@ Result<std::monostate, std::string> TrainingRunner::setScenarioConfig(const Scen
         if (setupResult.isError()) {
             return Result<std::monostate, std::string>::error(setupResult.errorValue());
         }
+        nesDriver_->setApuEnabled(nesApuEnabled_);
+        nesDriver_->setDetailedTimingEnabled(nesDetailedTimingEnabled_);
 
         if (nesGameAdapter_) {
             nesGameAdapter_->reset(nesDriver_->getRuntimeResolvedRomId());
@@ -907,38 +916,32 @@ TrainingRunner::NesFrameTrace TrainingRunner::runScenarioDrivenStep()
     addSignatureCount(nesCommandSignatureCounts_, commandSignature);
 
     nesControllerMask_ = controllerMask;
-    nesRuntime_->setController1State(nesControllerMask_);
 
-    const auto tickNesDriver = [&] {
-        if (!nesDriver_) {
-            return;
-        }
-
-        nesDriver_->tick(nesTimers_, nesScenarioVideoFrame_);
-        nesWorldData_.timestep += 1;
-        if (nesScenarioVideoFrame_.has_value()) {
-            nesWorldData_.width = static_cast<int16_t>(nesScenarioVideoFrame_->width);
-            nesWorldData_.height = static_cast<int16_t>(nesScenarioVideoFrame_->height);
-        }
-    };
-    tickNesDriver();
+    auto stepResult = nesDriver_->step(nesTimers_, nesControllerMask_);
+    nesWorldData_.timestep += 1;
+    if (stepResult.scenarioVideoFrame.has_value()) {
+        nesScenarioVideoFrame_ = std::move(stepResult.scenarioVideoFrame);
+        nesWorldData_.width = static_cast<int16_t>(nesScenarioVideoFrame_->width);
+        nesWorldData_.height = static_cast<int16_t>(nesScenarioVideoFrame_->height);
+    }
+    else if (!stepResult.runtimeHealthy || !stepResult.runtimeRunning) {
+        nesScenarioVideoFrame_.reset();
+    }
     simTime_ += TIMESTEP;
 
-    const uint64_t renderedFramesAfter = nesRuntime_->getRuntimeRenderedFrameCount();
-    trace.renderedFramesAfter = renderedFramesAfter;
-    if (renderedFramesAfter > renderedFramesBefore) {
+    trace.renderedFramesAfter = stepResult.renderedFramesAfter;
+    if (stepResult.advancedFrames > 0) {
         trace.frameAdvanced = true;
         commandOutcome = "FrameAdvanced";
-        const uint64_t advancedFrames = renderedFramesAfter - renderedFramesBefore;
-        trace.advancedFrames = advancedFrames;
-        nesFramesSurvived_ += advancedFrames;
+        trace.advancedFrames = stepResult.advancedFrames;
+        nesFramesSurvived_ += stepResult.advancedFrames;
 
-        nesPaletteFrame_ = nesRuntime_->copyRuntimePaletteFrame();
+        nesPaletteFrame_ = std::move(stepResult.paletteFrame);
         const NesGameAdapterFrameInput frameInput{
-            .advancedFrames = advancedFrames,
+            .advancedFrames = stepResult.advancedFrames,
             .controllerMask = nesControllerMask_,
             .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
-            .memorySnapshot = nesRuntime_->copyRuntimeMemorySnapshot(),
+            .memorySnapshot = std::move(stepResult.memorySnapshot),
         };
         const NesGameAdapterFrameOutput evaluation = nesGameAdapter_->evaluateFrame(frameInput);
         nesLastDebugState_ = evaluation.debugState;
@@ -956,8 +959,7 @@ TrainingRunner::NesFrameTrace TrainingRunner::runScenarioDrivenStep()
         }
     }
 
-    if (state_ == State::Running
-        && (!nesRuntime_->isRuntimeRunning() || !nesRuntime_->isRuntimeHealthy())) {
+    if (state_ == State::Running && (!stepResult.runtimeRunning || !stepResult.runtimeHealthy)) {
         state_ = State::OrganismDied;
         commandOutcome = "EpisodeEnd";
     }

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -681,6 +681,7 @@ Result<std::monostate, std::string> TrainingRunner::setScenarioConfig(const Scen
         }
         nesDriver_->setApuEnabled(nesApuEnabled_);
         nesDriver_->setDetailedTimingEnabled(nesDetailedTimingEnabled_);
+        nesDriver_->setRgbaOutputEnabled(nesRgbaOutputEnabled_);
 
         if (nesGameAdapter_) {
             nesGameAdapter_->reset(nesDriver_->getRuntimeResolvedRomId());

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -194,7 +194,8 @@ TrainingRunner::TrainingRunner(
       evolutionConfig_(evolutionConfig),
       frameTraceSink_(runnerConfig.frameTraceSink),
       nesApuEnabled_(runnerConfig.nesApuEnabled),
-      nesDetailedTimingEnabled_(runnerConfig.nesDetailedTimingEnabled)
+      nesDetailedTimingEnabled_(runnerConfig.nesDetailedTimingEnabled),
+      nesRgbaOutputEnabled_(runnerConfig.nesRgbaOutputEnabled)
 {
     resolveBrainEntry();
 
@@ -248,6 +249,7 @@ TrainingRunner::TrainingRunner(
         if (state_ == State::Running) {
             nesDriver_->setApuEnabled(nesApuEnabled_);
             nesDriver_->setDetailedTimingEnabled(nesDetailedTimingEnabled_);
+            nesDriver_->setRgbaOutputEnabled(nesRgbaOutputEnabled_);
         }
 
         nesWorldData_.width = 256;

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -120,6 +120,8 @@ public:
         std::optional<bool> duckClockSpawnLeftFirst = std::nullopt;
         std::optional<uint32_t> duckClockSpawnRngSeed = std::nullopt;
         FrameTraceSink frameTraceSink = nullptr;
+        bool nesApuEnabled = false;
+        bool nesDetailedTimingEnabled = false;
         std::optional<ScenarioConfig> scenarioConfigOverride = std::nullopt;
     };
 
@@ -229,6 +231,8 @@ private:
     uint64_t stepOrdinal_ = 0;
     BrainRegistryEntry::ControlMode controlMode_ = BrainRegistryEntry::ControlMode::OrganismDriven;
     NesScenarioRuntime* nesRuntime_ = nullptr;
+    bool nesApuEnabled_ = false;
+    bool nesDetailedTimingEnabled_ = false;
     std::unique_ptr<NesGameAdapter> nesGameAdapter_;
     uint8_t nesControllerMask_ = 0;
     std::optional<NesPaletteFrame> nesPaletteFrame_ = std::nullopt;

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -122,7 +122,7 @@ public:
         FrameTraceSink frameTraceSink = nullptr;
         bool nesApuEnabled = false;
         bool nesDetailedTimingEnabled = false;
-        bool nesRgbaOutputEnabled = false;
+        bool nesRgbaOutputEnabled = true;
         std::optional<ScenarioConfig> scenarioConfigOverride = std::nullopt;
     };
 

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -122,6 +122,7 @@ public:
         FrameTraceSink frameTraceSink = nullptr;
         bool nesApuEnabled = false;
         bool nesDetailedTimingEnabled = false;
+        bool nesRgbaOutputEnabled = false;
         std::optional<ScenarioConfig> scenarioConfigOverride = std::nullopt;
     };
 
@@ -233,6 +234,7 @@ private:
     NesScenarioRuntime* nesRuntime_ = nullptr;
     bool nesApuEnabled_ = false;
     bool nesDetailedTimingEnabled_ = false;
+    bool nesRgbaOutputEnabled_ = false;
     std::unique_ptr<NesGameAdapter> nesGameAdapter_;
     uint8_t nesControllerMask_ = 0;
     std::optional<NesPaletteFrame> nesPaletteFrame_ = std::nullopt;

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -242,6 +242,57 @@ private:
     int* evaluateCallCount_ = nullptr;
 };
 
+class SnapshotRecordingNesAdapter : public NesGameAdapter {
+public:
+    SnapshotRecordingNesAdapter(
+        int* evaluateCallCount, int* memorySnapshotCount, int* paletteFrameCount)
+        : evaluateCallCount_(evaluateCallCount),
+          memorySnapshotCount_(memorySnapshotCount),
+          paletteFrameCount_(paletteFrameCount)
+    {}
+
+    NesGameAdapterControllerOutput resolveControllerMask(
+        const NesGameAdapterControllerInput& input) override
+    {
+        return NesGameAdapterControllerOutput{
+            .resolvedControllerMask = input.inferredControllerMask,
+        };
+    }
+
+    NesGameAdapterFrameOutput evaluateFrame(const NesGameAdapterFrameInput& input) override
+    {
+        if (evaluateCallCount_) {
+            ++(*evaluateCallCount_);
+        }
+        if (memorySnapshotCount_ && input.memorySnapshot.has_value()) {
+            ++(*memorySnapshotCount_);
+        }
+        if (paletteFrameCount_ && input.paletteFrame != nullptr) {
+            ++(*paletteFrameCount_);
+        }
+        return NesGameAdapterFrameOutput{
+            .rewardDelta = static_cast<double>(input.advancedFrames),
+        };
+    }
+
+    DuckSensoryData makeDuckSensoryData(const NesGameAdapterSensoryInput& input) const override
+    {
+        DuckSensoryData sensory{};
+        sensory.actual_width = DuckSensoryData::GRID_SIZE;
+        sensory.actual_height = DuckSensoryData::GRID_SIZE;
+        sensory.scale_factor = 1.0;
+        sensory.world_offset = { 0, 0 };
+        sensory.position = { DuckSensoryData::GRID_SIZE / 2, DuckSensoryData::GRID_SIZE / 2 };
+        sensory.delta_time_seconds = input.deltaTimeSeconds;
+        return sensory;
+    }
+
+private:
+    int* evaluateCallCount_ = nullptr;
+    int* memorySnapshotCount_ = nullptr;
+    int* paletteFrameCount_ = nullptr;
+};
+
 class TraceNesAdapter : public NesGameAdapter {
 public:
     NesGameAdapterControllerOutput resolveControllerMask(
@@ -554,6 +605,59 @@ TEST_F(TrainingRunnerTest, NesScenarioDrivenRunnerEmitsPerFrameTrace)
     EXPECT_TRUE(std::isfinite(telemetry.aRaw));
     EXPECT_TRUE(std::isfinite(telemetry.bRaw));
     EXPECT_EQ(status.state, TrainingRunner::State::Running);
+}
+
+TEST_F(TrainingRunnerTest, NesScenarioDrivenRunnerPaletteOnlyStillFeedsAdapter)
+{
+    const std::optional<std::filesystem::path> romPath = resolveNesFixtureRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing. Run 'cd apps && make fetch-nes-test-rom' or set "
+                        "DIRTSIM_NES_TEST_ROM_PATH.";
+    }
+
+    config_.maxSimulationTime = 1.0;
+
+    TrainingSpec spec;
+    spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    spec.organismType = OrganismType::NES_DUCK;
+
+    TrainingRunner::Individual individual;
+    individual.brain.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
+    individual.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    individual.genome = DuckNeuralNetRecurrentBrainV2::randomGenome(rng_);
+
+    int evaluateCalls = 0;
+    int memorySnapshotCalls = 0;
+    int paletteFrameCalls = 0;
+    NesGameAdapterRegistry adapterRegistry;
+    adapterRegistry.registerAdapter(
+        Scenario::EnumType::NesFlappyParatroopa,
+        [&evaluateCalls, &memorySnapshotCalls, &paletteFrameCalls]() {
+            return std::make_unique<SnapshotRecordingNesAdapter>(
+                &evaluateCalls, &memorySnapshotCalls, &paletteFrameCalls);
+        });
+
+    TrainingRunner::Config runnerConfig{
+        .brainRegistry = TrainingBrainRegistry::createDefault(),
+        .nesGameAdapterRegistry = adapterRegistry,
+        .duckClockSpawnLeftFirst = std::nullopt,
+        .duckClockSpawnRngSeed = std::nullopt,
+        .nesRgbaOutputEnabled = false,
+    };
+    TrainingRunner runner(spec, individual, config_, genomeRepository_, runnerConfig);
+
+    TrainingRunner::Status status;
+    int steps = 0;
+    while (evaluateCalls == 0
+           && (status = runner.step(1)).state == TrainingRunner::State::Running) {
+        ++steps;
+        ASSERT_LT(steps, 60) << "Runner should advance at least one NES frame quickly";
+    }
+
+    EXPECT_GT(status.nesFramesSurvived, 0u);
+    EXPECT_GT(evaluateCalls, 0);
+    EXPECT_GT(memorySnapshotCalls, 0);
+    EXPECT_GT(paletteFrameCalls, 0);
 }
 
 // Proves we can finish and get results.

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -489,10 +489,24 @@ void NesSmolnesScenarioDriver::setAudioVolumePercent(int percent)
     }
 }
 
+void NesSmolnesScenarioDriver::setApuEnabled(bool enabled)
+{
+    if (runtime_) {
+        runtime_->setApuEnabled(enabled);
+    }
+}
+
 void NesSmolnesScenarioDriver::setDetailedTimingEnabled(bool enabled)
 {
     if (runtime_) {
         runtime_->setDetailedTimingEnabled(enabled);
+    }
+}
+
+void NesSmolnesScenarioDriver::setPixelOutputEnabled(bool enabled)
+{
+    if (runtime_) {
+        runtime_->setPixelOutputEnabled(enabled);
     }
 }
 

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -647,11 +647,23 @@ void NesSmolnesScenarioDriver::updateRuntimeProfilingTimers(Timers& timers)
         current.runtimeThreadPpuSpriteEvalCalls,
         previous.runtimeThreadPpuSpriteEvalCalls);
     addDelta(
+        "nes_runtime_thread_ppu_post_visible",
+        current.runtimeThreadPpuPostVisibleMs,
+        previous.runtimeThreadPpuPostVisibleMs,
+        current.runtimeThreadPpuPostVisibleCalls,
+        previous.runtimeThreadPpuPostVisibleCalls);
+    addDelta(
         "nes_runtime_thread_ppu_prefetch",
         current.runtimeThreadPpuPrefetchMs,
         previous.runtimeThreadPpuPrefetchMs,
         current.runtimeThreadPpuPrefetchCalls,
         previous.runtimeThreadPpuPrefetchCalls);
+    addDelta(
+        "nes_runtime_thread_ppu_non_visible_scanlines",
+        current.runtimeThreadPpuNonVisibleScanlinesMs,
+        previous.runtimeThreadPpuNonVisibleScanlinesMs,
+        current.runtimeThreadPpuNonVisibleScanlinesCalls,
+        previous.runtimeThreadPpuNonVisibleScanlinesCalls);
     addDelta(
         "nes_runtime_thread_ppu_other",
         current.runtimeThreadPpuOtherMs,

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -510,6 +510,13 @@ void NesSmolnesScenarioDriver::setPixelOutputEnabled(bool enabled)
     }
 }
 
+void NesSmolnesScenarioDriver::setRgbaOutputEnabled(bool enabled)
+{
+    if (runtime_) {
+        runtime_->setRgbaOutputEnabled(enabled);
+    }
+}
+
 void NesSmolnesScenarioDriver::setLiveServerPacingEnabled(bool enabled)
 {
     if (liveServerPacingEnabled_ == enabled) {

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -489,6 +489,13 @@ void NesSmolnesScenarioDriver::setAudioVolumePercent(int percent)
     }
 }
 
+void NesSmolnesScenarioDriver::setDetailedTimingEnabled(bool enabled)
+{
+    if (runtime_) {
+        runtime_->setDetailedTimingEnabled(enabled);
+    }
+}
+
 void NesSmolnesScenarioDriver::setLiveServerPacingEnabled(bool enabled)
 {
     if (liveServerPacingEnabled_ == enabled) {
@@ -582,6 +589,12 @@ void NesSmolnesScenarioDriver::updateRuntimeProfilingTimers(Timers& timers)
         previous.runtimeThreadIdleWaitMs,
         current.runtimeThreadIdleWaitCalls,
         previous.runtimeThreadIdleWaitCalls);
+    addDelta(
+        "nes_runtime_thread_apu_step",
+        current.runtimeThreadApuStepMs,
+        previous.runtimeThreadApuStepMs,
+        current.runtimeThreadApuStepCalls,
+        previous.runtimeThreadApuStepCalls);
     addDelta(
         "nes_runtime_thread_cpu_step",
         current.runtimeThreadCpuStepMs,

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -395,6 +395,15 @@ std::optional<SmolnesRuntime::MemorySnapshot> NesSmolnesScenarioDriver::copyRunt
     return runtime_->copyMemorySnapshot();
 }
 
+std::optional<SmolnesRuntime::ProfilingSnapshot> NesSmolnesScenarioDriver::
+    copyRuntimeProfilingSnapshot() const
+{
+    if (!runtime_ || !runtime_->isRunning() || !runtime_->isHealthy()) {
+        return std::nullopt;
+    }
+    return runtime_->copyProfilingSnapshot();
+}
+
 std::optional<SmolnesRuntime::ApuSnapshot> NesSmolnesScenarioDriver::copyRuntimeApuSnapshot() const
 {
     if (!runtime_ || !runtime_->isRunning() || !runtime_->isHealthy()) {

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
@@ -77,6 +77,7 @@ public:
     std::optional<ScenarioVideoFrame> copyRuntimeFrameSnapshot() const override;
     std::optional<NesPaletteFrame> copyRuntimePaletteFrame() const override;
     std::optional<SmolnesRuntime::MemorySnapshot> copyRuntimeMemorySnapshot() const override;
+    std::optional<SmolnesRuntime::ProfilingSnapshot> copyRuntimeProfilingSnapshot() const;
     std::optional<SmolnesRuntime::ApuSnapshot> copyRuntimeApuSnapshot() const;
     uint32_t copyRuntimeApuSamples(float* buffer, uint32_t maxSamples) const;
     std::string getRuntimeResolvedRomId() const override;

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
@@ -88,6 +88,7 @@ public:
 
     void setAudioPlaybackEnabled(bool enabled);
     void setAudioVolumePercent(int percent);
+    void setDetailedTimingEnabled(bool enabled);
     void setLiveServerPacingEnabled(bool enabled);
     void setSmbResponseProbeEnabled(bool enabled);
 

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
@@ -86,7 +86,9 @@ public:
     void setController1State(uint8_t buttonMask) override;
     void setLiveController1State(uint8_t buttonMask, uint64_t observedTimestampNs);
 
+    void setApuEnabled(bool enabled);
     void setAudioPlaybackEnabled(bool enabled);
+    void setPixelOutputEnabled(bool enabled);
     void setAudioVolumePercent(int percent);
     void setDetailedTimingEnabled(bool enabled);
     void setLiveServerPacingEnabled(bool enabled);

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
@@ -89,6 +89,7 @@ public:
     void setApuEnabled(bool enabled);
     void setAudioPlaybackEnabled(bool enabled);
     void setPixelOutputEnabled(bool enabled);
+    void setRgbaOutputEnabled(bool enabled);
     void setAudioVolumePercent(int percent);
     void setDetailedTimingEnabled(bool enabled);
     void setLiveServerPacingEnabled(bool enabled);

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -294,6 +294,14 @@ void SmolnesRuntime::setPacingMode(SmolnesRuntimePacingMode mode)
                                                    : SMOLNES_RUNTIME_PACING_MODE_LOCKSTEP);
 }
 
+void SmolnesRuntime::setDetailedTimingEnabled(bool enabled)
+{
+    if (runtimeHandle_ == nullptr) {
+        return;
+    }
+    smolnesRuntimeSetDetailedTimingEnabled(runtimeHandle_, enabled);
+}
+
 std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSnapshot() const
 {
     if (runtimeHandle_ == nullptr) {
@@ -310,6 +318,8 @@ std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSn
     snapshot.runFramesWaitCalls = raw.run_frames_wait_calls;
     snapshot.runtimeThreadIdleWaitMs = raw.runtime_thread_idle_wait_ms;
     snapshot.runtimeThreadIdleWaitCalls = raw.runtime_thread_idle_wait_calls;
+    snapshot.runtimeThreadApuStepMs = raw.runtime_thread_apu_step_ms;
+    snapshot.runtimeThreadApuStepCalls = raw.runtime_thread_apu_step_calls;
     snapshot.runtimeThreadCpuStepMs = raw.runtime_thread_cpu_step_ms;
     snapshot.runtimeThreadCpuStepCalls = raw.runtime_thread_cpu_step_calls;
     snapshot.runtimeThreadFrameExecutionMs = raw.runtime_thread_frame_execution_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -354,8 +354,14 @@ std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSn
     snapshot.runtimeThreadPpuVisiblePixelsCalls = raw.runtime_thread_ppu_visible_pixels_calls;
     snapshot.runtimeThreadPpuSpriteEvalMs = raw.runtime_thread_ppu_sprite_eval_ms;
     snapshot.runtimeThreadPpuSpriteEvalCalls = raw.runtime_thread_ppu_sprite_eval_calls;
+    snapshot.runtimeThreadPpuPostVisibleMs = raw.runtime_thread_ppu_post_visible_ms;
+    snapshot.runtimeThreadPpuPostVisibleCalls = raw.runtime_thread_ppu_post_visible_calls;
     snapshot.runtimeThreadPpuPrefetchMs = raw.runtime_thread_ppu_prefetch_ms;
     snapshot.runtimeThreadPpuPrefetchCalls = raw.runtime_thread_ppu_prefetch_calls;
+    snapshot.runtimeThreadPpuNonVisibleScanlinesMs =
+        raw.runtime_thread_ppu_non_visible_scanlines_ms;
+    snapshot.runtimeThreadPpuNonVisibleScanlinesCalls =
+        raw.runtime_thread_ppu_non_visible_scanlines_calls;
     snapshot.runtimeThreadPpuOtherMs = raw.runtime_thread_ppu_other_ms;
     snapshot.runtimeThreadPpuOtherCalls = raw.runtime_thread_ppu_other_calls;
     snapshot.runtimeThreadFrameSubmitMs = raw.runtime_thread_frame_submit_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -318,6 +318,14 @@ void SmolnesRuntime::setPixelOutputEnabled(bool enabled)
     smolnesRuntimeSetPixelOutputEnabled(runtimeHandle_, enabled);
 }
 
+void SmolnesRuntime::setRgbaOutputEnabled(bool enabled)
+{
+    if (runtimeHandle_ == nullptr) {
+        return;
+    }
+    smolnesRuntimeSetRgbaOutputEnabled(runtimeHandle_, enabled);
+}
+
 std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSnapshot() const
 {
     if (runtimeHandle_ == nullptr) {

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -294,12 +294,28 @@ void SmolnesRuntime::setPacingMode(SmolnesRuntimePacingMode mode)
                                                    : SMOLNES_RUNTIME_PACING_MODE_LOCKSTEP);
 }
 
+void SmolnesRuntime::setApuEnabled(bool enabled)
+{
+    if (runtimeHandle_ == nullptr) {
+        return;
+    }
+    smolnesRuntimeSetApuEnabled(runtimeHandle_, enabled);
+}
+
 void SmolnesRuntime::setDetailedTimingEnabled(bool enabled)
 {
     if (runtimeHandle_ == nullptr) {
         return;
     }
     smolnesRuntimeSetDetailedTimingEnabled(runtimeHandle_, enabled);
+}
+
+void SmolnesRuntime::setPixelOutputEnabled(bool enabled)
+{
+    if (runtimeHandle_ == nullptr) {
+        return;
+    }
+    smolnesRuntimeSetPixelOutputEnabled(runtimeHandle_, enabled);
 }
 
 std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSnapshot() const

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -352,6 +352,16 @@ std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSn
     snapshot.runtimeThreadPpuStepCalls = raw.runtime_thread_ppu_step_calls;
     snapshot.runtimeThreadPpuVisiblePixelsMs = raw.runtime_thread_ppu_visible_pixels_ms;
     snapshot.runtimeThreadPpuVisiblePixelsCalls = raw.runtime_thread_ppu_visible_pixels_calls;
+    snapshot.runtimeThreadPpuVisibleBgOnlySpanCalls =
+        raw.runtime_thread_ppu_visible_bg_only_span_calls;
+    snapshot.runtimeThreadPpuVisibleBgOnlySpanPixels =
+        raw.runtime_thread_ppu_visible_bg_only_span_pixels;
+    snapshot.runtimeThreadPpuVisibleBgOnlyScalarPixels =
+        raw.runtime_thread_ppu_visible_bg_only_scalar_pixels;
+    snapshot.runtimeThreadPpuVisibleBgOnlyBatchedPixels =
+        raw.runtime_thread_ppu_visible_bg_only_batched_pixels;
+    snapshot.runtimeThreadPpuVisibleBgOnlyBatchedCalls =
+        raw.runtime_thread_ppu_visible_bg_only_batched_calls;
     snapshot.runtimeThreadPpuSpriteEvalMs = raw.runtime_thread_ppu_sprite_eval_ms;
     snapshot.runtimeThreadPpuSpriteEvalCalls = raw.runtime_thread_ppu_sprite_eval_calls;
     snapshot.runtimeThreadPpuPostVisibleMs = raw.runtime_thread_ppu_post_visible_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -362,6 +362,34 @@ std::optional<SmolnesRuntime::ProfilingSnapshot> SmolnesRuntime::copyProfilingSn
         raw.runtime_thread_ppu_visible_bg_only_batched_pixels;
     snapshot.runtimeThreadPpuVisibleBgOnlyBatchedCalls =
         raw.runtime_thread_ppu_visible_bg_only_batched_calls;
+    snapshot.runtimeThreadDeferredPpuFlushPpuRegisterCalls =
+        raw.runtime_thread_deferred_ppu_flush_ppu_register_calls;
+    snapshot.runtimeThreadDeferredPpuFlushPpuRegisterDots =
+        raw.runtime_thread_deferred_ppu_flush_ppu_register_dots;
+    for (size_t registerIndex = 0;
+         registerIndex < snapshot.runtimeThreadDeferredPpuFlushPpuRegisterReadCalls.size();
+         ++registerIndex) {
+        snapshot.runtimeThreadDeferredPpuFlushPpuRegisterReadCalls[registerIndex] =
+            raw.runtime_thread_deferred_ppu_flush_ppu_register_read_calls[registerIndex];
+        snapshot.runtimeThreadDeferredPpuFlushPpuRegisterReadDots[registerIndex] =
+            raw.runtime_thread_deferred_ppu_flush_ppu_register_read_dots[registerIndex];
+        snapshot.runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls[registerIndex] =
+            raw.runtime_thread_deferred_ppu_flush_ppu_register_write_calls[registerIndex];
+        snapshot.runtimeThreadDeferredPpuFlushPpuRegisterWriteDots[registerIndex] =
+            raw.runtime_thread_deferred_ppu_flush_ppu_register_write_dots[registerIndex];
+    }
+    snapshot.runtimeThreadDeferredPpuFlushOamDmaCalls =
+        raw.runtime_thread_deferred_ppu_flush_oam_dma_calls;
+    snapshot.runtimeThreadDeferredPpuFlushOamDmaDots =
+        raw.runtime_thread_deferred_ppu_flush_oam_dma_dots;
+    snapshot.runtimeThreadDeferredPpuFlushMapperWriteCalls =
+        raw.runtime_thread_deferred_ppu_flush_mapper_write_calls;
+    snapshot.runtimeThreadDeferredPpuFlushMapperWriteDots =
+        raw.runtime_thread_deferred_ppu_flush_mapper_write_dots;
+    snapshot.runtimeThreadDeferredPpuFlushDot256BoundaryCalls =
+        raw.runtime_thread_deferred_ppu_flush_dot_256_boundary_calls;
+    snapshot.runtimeThreadDeferredPpuFlushDot256BoundaryDots =
+        raw.runtime_thread_deferred_ppu_flush_dot_256_boundary_dots;
     snapshot.runtimeThreadPpuSpriteEvalMs = raw.runtime_thread_ppu_sprite_eval_ms;
     snapshot.runtimeThreadPpuSpriteEvalCalls = raw.runtime_thread_ppu_sprite_eval_calls;
     snapshot.runtimeThreadPpuPostVisibleMs = raw.runtime_thread_ppu_post_visible_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -39,6 +39,11 @@ public:
         uint64_t runtimeThreadPpuStepCalls = 0;
         double runtimeThreadPpuVisiblePixelsMs = 0.0;
         uint64_t runtimeThreadPpuVisiblePixelsCalls = 0;
+        uint64_t runtimeThreadPpuVisibleBgOnlySpanCalls = 0;
+        uint64_t runtimeThreadPpuVisibleBgOnlySpanPixels = 0;
+        uint64_t runtimeThreadPpuVisibleBgOnlyScalarPixels = 0;
+        uint64_t runtimeThreadPpuVisibleBgOnlyBatchedPixels = 0;
+        uint64_t runtimeThreadPpuVisibleBgOnlyBatchedCalls = 0;
         double runtimeThreadPpuSpriteEvalMs = 0.0;
         uint64_t runtimeThreadPpuSpriteEvalCalls = 0;
         double runtimeThreadPpuPostVisibleMs = 0.0;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -44,6 +44,18 @@ public:
         uint64_t runtimeThreadPpuVisibleBgOnlyScalarPixels = 0;
         uint64_t runtimeThreadPpuVisibleBgOnlyBatchedPixels = 0;
         uint64_t runtimeThreadPpuVisibleBgOnlyBatchedCalls = 0;
+        uint64_t runtimeThreadDeferredPpuFlushPpuRegisterCalls = 0;
+        uint64_t runtimeThreadDeferredPpuFlushPpuRegisterDots = 0;
+        std::array<uint64_t, 8> runtimeThreadDeferredPpuFlushPpuRegisterReadCalls{};
+        std::array<uint64_t, 8> runtimeThreadDeferredPpuFlushPpuRegisterReadDots{};
+        std::array<uint64_t, 8> runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls{};
+        std::array<uint64_t, 8> runtimeThreadDeferredPpuFlushPpuRegisterWriteDots{};
+        uint64_t runtimeThreadDeferredPpuFlushOamDmaCalls = 0;
+        uint64_t runtimeThreadDeferredPpuFlushOamDmaDots = 0;
+        uint64_t runtimeThreadDeferredPpuFlushMapperWriteCalls = 0;
+        uint64_t runtimeThreadDeferredPpuFlushMapperWriteDots = 0;
+        uint64_t runtimeThreadDeferredPpuFlushDot256BoundaryCalls = 0;
+        uint64_t runtimeThreadDeferredPpuFlushDot256BoundaryDots = 0;
         double runtimeThreadPpuSpriteEvalMs = 0.0;
         uint64_t runtimeThreadPpuSpriteEvalCalls = 0;
         double runtimeThreadPpuPostVisibleMs = 0.0;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -127,6 +127,7 @@ public:
     virtual void setApuEnabled(bool enabled);
     virtual void setDetailedTimingEnabled(bool enabled);
     virtual void setPixelOutputEnabled(bool enabled);
+    virtual void setRgbaOutputEnabled(bool enabled);
     virtual void setPacingMode(SmolnesRuntimePacingMode mode);
     virtual std::string getLastError() const;
 

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -41,8 +41,12 @@ public:
         uint64_t runtimeThreadPpuVisiblePixelsCalls = 0;
         double runtimeThreadPpuSpriteEvalMs = 0.0;
         uint64_t runtimeThreadPpuSpriteEvalCalls = 0;
+        double runtimeThreadPpuPostVisibleMs = 0.0;
+        uint64_t runtimeThreadPpuPostVisibleCalls = 0;
         double runtimeThreadPpuPrefetchMs = 0.0;
         uint64_t runtimeThreadPpuPrefetchCalls = 0;
+        double runtimeThreadPpuNonVisibleScanlinesMs = 0.0;
+        uint64_t runtimeThreadPpuNonVisibleScanlinesCalls = 0;
         double runtimeThreadPpuOtherMs = 0.0;
         uint64_t runtimeThreadPpuOtherCalls = 0;
         double runtimeThreadFrameSubmitMs = 0.0;

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -124,8 +124,10 @@ public:
     virtual std::optional<ApuSnapshot> copyApuSnapshot() const;
     virtual uint32_t copyApuSamples(float* buffer, uint32_t maxSamples) const;
     virtual void setApuSampleCallback(SmolnesApuSampleCallback callback, void* userdata);
-    virtual void setPacingMode(SmolnesRuntimePacingMode mode);
+    virtual void setApuEnabled(bool enabled);
     virtual void setDetailedTimingEnabled(bool enabled);
+    virtual void setPixelOutputEnabled(bool enabled);
+    virtual void setPacingMode(SmolnesRuntimePacingMode mode);
     virtual std::string getLastError() const;
 
 private:

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -29,6 +29,8 @@ public:
         uint64_t runFramesWaitCalls = 0;
         double runtimeThreadIdleWaitMs = 0.0;
         uint64_t runtimeThreadIdleWaitCalls = 0;
+        double runtimeThreadApuStepMs = 0.0;
+        uint64_t runtimeThreadApuStepCalls = 0;
         double runtimeThreadCpuStepMs = 0.0;
         uint64_t runtimeThreadCpuStepCalls = 0;
         double runtimeThreadFrameExecutionMs = 0.0;
@@ -123,6 +125,7 @@ public:
     virtual uint32_t copyApuSamples(float* buffer, uint32_t maxSamples) const;
     virtual void setApuSampleCallback(SmolnesApuSampleCallback callback, void* userdata);
     virtual void setPacingMode(SmolnesRuntimePacingMode mode);
+    virtual void setDetailedTimingEnabled(bool enabled);
     virtual std::string getLastError() const;
 
 private:

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -990,6 +990,8 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #define SMOLNES_APU_WRITE(addr, value) smolnesRuntimeWrappedApuWrite(addr, value)
 #define SMOLNES_APU_READ(addr) smolnesRuntimeWrappedApuRead(addr)
 #define SMOLNES_APU_CLOCK(cycles) smolnesRuntimeWrappedApuClock(cycles)
+#define SMOLNES_PIXEL_OUTPUT_ENABLED gPixelOutputEnabled
+#define SMOLNES_RGBA_OUTPUT_ENABLED gRgbaOutputEnabled
 #define SMOLNES_TLS SMOLNES_THREAD_LOCAL
 #define main smolnesRuntimeEntryPoint
 
@@ -1023,6 +1025,8 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #undef SMOLNES_APU_WRITE
 #undef SMOLNES_APU_READ
 #undef SMOLNES_APU_CLOCK
+#undef SMOLNES_PIXEL_OUTPUT_ENABLED
+#undef SMOLNES_RGBA_OUTPUT_ENABLED
 #undef SMOLNES_TLS
 #undef main
 

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -583,7 +583,7 @@ void smolnesRuntimeWrappedCpuStepEnd(void)
 
 void smolnesRuntimeWrappedApuClockBegin(void)
 {
-    if (!gTimingThisInstruction) {
+    if (!gTimingThisInstruction || !gApuEnabled) {
         return;
     }
 
@@ -915,6 +915,12 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
 #define SMOLNES_PPU_STEP_END smolnesRuntimeWrappedPpuStepEnd
 #define SMOLNES_PPU_PHASE_SET smolnesRuntimeWrappedPpuPhaseSet
 #define SMOLNES_PPU_PHASE_CLEAR smolnesRuntimeWrappedPpuPhaseClear
+#define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)                                              \
+    do {                                                                                     \
+        if (gPpuStepActive) {                                                                \
+            smolnesRuntimeWrappedPpuPhaseSet(phase);                                         \
+        }                                                                                    \
+    } while (0)
 #define SMOLNES_FRAME_SUBMIT_BEGIN smolnesRuntimeWrappedFrameSubmitBegin
 #define SMOLNES_FRAME_SUBMIT_END smolnesRuntimeWrappedFrameSubmitEnd
 #define SMOLNES_EVENT_POLL_BEGIN smolnesRuntimeWrappedEventPollBegin
@@ -974,6 +980,7 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #undef SMOLNES_PPU_STEP_END
 #undef SMOLNES_PPU_PHASE_SET
 #undef SMOLNES_PPU_PHASE_CLEAR
+#undef SMOLNES_PPU_PHASE_SET_IF_ACTIVE
 #undef SMOLNES_FRAME_SUBMIT_BEGIN
 #undef SMOLNES_FRAME_SUBMIT_END
 #undef SMOLNES_EVENT_POLL_BEGIN
@@ -1076,7 +1083,7 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->apuEnabled = true;
     runtime->pixelOutputEnabled = true;
     runtime->rgbaOutputEnabled = true;
-    runtime->detailedTimingEnabled = true;
+    runtime->detailedTimingEnabled = false;
     runtime->timingSampleRate = 64;
     runtime->healthy = true;
     runtime->renderedFrames = 0;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -58,8 +58,12 @@ struct SmolnesRuntimeHandle {
     uint64_t runtimeThreadPpuVisiblePixelsCalls;
     double runtimeThreadPpuSpriteEvalMs;
     uint64_t runtimeThreadPpuSpriteEvalCalls;
+    double runtimeThreadPpuPostVisibleMs;
+    uint64_t runtimeThreadPpuPostVisibleCalls;
     double runtimeThreadPpuPrefetchMs;
     uint64_t runtimeThreadPpuPrefetchCalls;
+    double runtimeThreadPpuNonVisibleScanlinesMs;
+    uint64_t runtimeThreadPpuNonVisibleScanlinesCalls;
     double runtimeThreadPpuOtherMs;
     uint64_t runtimeThreadPpuOtherCalls;
     double runtimeThreadFrameSubmitMs;
@@ -158,7 +162,9 @@ typedef enum SmolnesPpuPhaseBucket {
     SmolnesPpuPhaseBucketVisiblePixels = 1,
     SmolnesPpuPhaseBucketPrefetch = 2,
     SmolnesPpuPhaseBucketOther = 3,
-    SmolnesPpuPhaseBucketSpriteEval = 4
+    SmolnesPpuPhaseBucketSpriteEval = 4,
+    SmolnesPpuPhaseBucketPostVisible = 5,
+    SmolnesPpuPhaseBucketNonVisibleScanlines = 6
 } SmolnesPpuPhaseBucket;
 static SMOLNES_THREAD_LOCAL SmolnesPpuPhaseBucket gPpuPhaseBucket = SmolnesPpuPhaseBucketNone;
 static SMOLNES_THREAD_LOCAL double gPpuPhaseBucketStartMs = 0.0;
@@ -166,8 +172,12 @@ static SMOLNES_THREAD_LOCAL double gPpuVisiblePixelsAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuVisiblePixelsAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL double gPpuSpriteEvalAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuSpriteEvalAccumCalls = 0;
+static SMOLNES_THREAD_LOCAL double gPpuPostVisibleAccumMs = 0.0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuPostVisibleAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL double gPpuPrefetchAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuPrefetchAccumCalls = 0;
+static SMOLNES_THREAD_LOCAL double gPpuNonVisibleScanlinesAccumMs = 0.0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuNonVisibleScanlinesAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL double gPpuOtherAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuOtherAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL bool gFrameSubmitActive = false;
@@ -273,8 +283,12 @@ static void resetPpuPhaseBreakdown(void)
     gPpuVisiblePixelsAccumCalls = 0;
     gPpuSpriteEvalAccumMs = 0.0;
     gPpuSpriteEvalAccumCalls = 0;
+    gPpuPostVisibleAccumMs = 0.0;
+    gPpuPostVisibleAccumCalls = 0;
     gPpuPrefetchAccumMs = 0.0;
     gPpuPrefetchAccumCalls = 0;
+    gPpuNonVisibleScanlinesAccumMs = 0.0;
+    gPpuNonVisibleScanlinesAccumCalls = 0;
     gPpuOtherAccumMs = 0.0;
     gPpuOtherAccumCalls = 0;
 }
@@ -306,8 +320,12 @@ static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
     runtime->runtimeThreadPpuVisiblePixelsCalls += gPpuVisiblePixelsAccumCalls;
     runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
     runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
+    runtime->runtimeThreadPpuPostVisibleMs += gPpuPostVisibleAccumMs;
+    runtime->runtimeThreadPpuPostVisibleCalls += gPpuPostVisibleAccumCalls;
     runtime->runtimeThreadPpuPrefetchMs += gPpuPrefetchAccumMs;
     runtime->runtimeThreadPpuPrefetchCalls += gPpuPrefetchAccumCalls;
+    runtime->runtimeThreadPpuNonVisibleScanlinesMs += gPpuNonVisibleScanlinesAccumMs;
+    runtime->runtimeThreadPpuNonVisibleScanlinesCalls += gPpuNonVisibleScanlinesAccumCalls;
     runtime->runtimeThreadPpuOtherMs += gPpuOtherAccumMs;
     runtime->runtimeThreadPpuOtherCalls += gPpuOtherAccumCalls;
     resetPerInstructionAccumulators();
@@ -328,9 +346,17 @@ static void accumulatePpuPhaseDuration(SmolnesPpuPhaseBucket phase, double durat
             gPpuSpriteEvalAccumMs += durationMs;
             gPpuSpriteEvalAccumCalls++;
             break;
+        case SmolnesPpuPhaseBucketPostVisible:
+            gPpuPostVisibleAccumMs += durationMs;
+            gPpuPostVisibleAccumCalls++;
+            break;
         case SmolnesPpuPhaseBucketPrefetch:
             gPpuPrefetchAccumMs += durationMs;
             gPpuPrefetchAccumCalls++;
+            break;
+        case SmolnesPpuPhaseBucketNonVisibleScanlines:
+            gPpuNonVisibleScanlinesAccumMs += durationMs;
+            gPpuNonVisibleScanlinesAccumCalls++;
             break;
         case SmolnesPpuPhaseBucketOther:
             gPpuOtherAccumMs += durationMs;
@@ -708,6 +734,12 @@ void smolnesRuntimeWrappedPpuPhaseSet(uint32_t phaseId)
             break;
         case 4u:
             nextPhase = SmolnesPpuPhaseBucketSpriteEval;
+            break;
+        case 5u:
+            nextPhase = SmolnesPpuPhaseBucketPostVisible;
+            break;
+        case 6u:
+            nextPhase = SmolnesPpuPhaseBucketNonVisibleScanlines;
             break;
         default:
             nextPhase = SmolnesPpuPhaseBucketNone;
@@ -1108,8 +1140,12 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->runtimeThreadPpuVisiblePixelsCalls = 0;
     runtime->runtimeThreadPpuSpriteEvalMs = 0.0;
     runtime->runtimeThreadPpuSpriteEvalCalls = 0;
+    runtime->runtimeThreadPpuPostVisibleMs = 0.0;
+    runtime->runtimeThreadPpuPostVisibleCalls = 0;
     runtime->runtimeThreadPpuPrefetchMs = 0.0;
     runtime->runtimeThreadPpuPrefetchCalls = 0;
+    runtime->runtimeThreadPpuNonVisibleScanlinesMs = 0.0;
+    runtime->runtimeThreadPpuNonVisibleScanlinesCalls = 0;
     runtime->runtimeThreadPpuOtherMs = 0.0;
     runtime->runtimeThreadPpuOtherCalls = 0;
     runtime->runtimeThreadFrameSubmitMs = 0.0;
@@ -1457,8 +1493,15 @@ bool smolnesRuntimeCopyProfilingSnapshot(
     snapshotOut->runtime_thread_ppu_sprite_eval_ms = mutableRuntime->runtimeThreadPpuSpriteEvalMs;
     snapshotOut->runtime_thread_ppu_sprite_eval_calls =
         mutableRuntime->runtimeThreadPpuSpriteEvalCalls;
+    snapshotOut->runtime_thread_ppu_post_visible_ms = mutableRuntime->runtimeThreadPpuPostVisibleMs;
+    snapshotOut->runtime_thread_ppu_post_visible_calls =
+        mutableRuntime->runtimeThreadPpuPostVisibleCalls;
     snapshotOut->runtime_thread_ppu_prefetch_ms = mutableRuntime->runtimeThreadPpuPrefetchMs;
     snapshotOut->runtime_thread_ppu_prefetch_calls = mutableRuntime->runtimeThreadPpuPrefetchCalls;
+    snapshotOut->runtime_thread_ppu_non_visible_scanlines_ms =
+        mutableRuntime->runtimeThreadPpuNonVisibleScanlinesMs;
+    snapshotOut->runtime_thread_ppu_non_visible_scanlines_calls =
+        mutableRuntime->runtimeThreadPpuNonVisibleScanlinesCalls;
     snapshotOut->runtime_thread_ppu_other_ms = mutableRuntime->runtimeThreadPpuOtherMs;
     snapshotOut->runtime_thread_ppu_other_calls = mutableRuntime->runtimeThreadPpuOtherCalls;
     snapshotOut->runtime_thread_frame_submit_ms = mutableRuntime->runtimeThreadFrameSubmitMs;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -50,6 +50,8 @@ struct SmolnesRuntimeHandle {
     uint64_t runtimeThreadCpuStepCalls;
     double runtimeThreadFrameExecutionMs;
     uint64_t runtimeThreadFrameExecutionCalls;
+    double runtimeThreadApuStepMs;
+    uint64_t runtimeThreadApuStepCalls;
     double runtimeThreadPpuStepMs;
     uint64_t runtimeThreadPpuStepCalls;
     double runtimeThreadPpuVisiblePixelsMs;
@@ -106,6 +108,8 @@ struct SmolnesRuntimeHandle {
     SmolnesApuSampleCallback apuSampleCallback;
     void* apuSampleCallbackUserdata;
 
+    bool detailedTimingEnabled;
+    uint32_t timingSampleRate;
     SmolnesRuntimePacingModeValue pacingMode;
     double realtimePacingOriginMs;
     uint64_t realtimePacingOriginFrame;
@@ -117,14 +121,32 @@ static const double kNtscFramePeriodMs = 1000.0 / 60.0988;
 static SMOLNES_THREAD_LOCAL SmolnesRuntimeHandle* gCurrentRuntime = NULL;
 static const uint8_t gEmptyKeyboardState[SDL_NUM_SCANCODES] = { 0 };
 static SMOLNES_THREAD_LOCAL uint8_t gThreadKeyboardState[SDL_NUM_SCANCODES] = { 0 };
+// Per-instruction CPU/APU/PPU timing. When detailedTimingEnabled is false,
+// these are no-ops. When enabled, only every Nth instruction is timed
+// (controlled by timingSampleRate) and results are scaled at flush time.
+// Frame-level timing (FRAME_EXEC) is always active.
+static SMOLNES_THREAD_LOCAL bool gDetailedTimingEnabled = true;
+static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleRate = 64;
+static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleCounter = 0;
+static SMOLNES_THREAD_LOCAL bool gTimingThisInstruction = false;
+static SMOLNES_THREAD_LOCAL uint64_t gTotalInstructions = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gSampledInstructions = 0;
+static SMOLNES_THREAD_LOCAL bool gApuStepActive = false;
+static SMOLNES_THREAD_LOCAL double gApuStepStartMs = 0.0;
+static SMOLNES_THREAD_LOCAL double gApuStepAccumMs = 0.0;
+static SMOLNES_THREAD_LOCAL uint64_t gApuStepAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL bool gCpuStepActive = false;
 static SMOLNES_THREAD_LOCAL double gCpuStepStartMs = 0.0;
+static SMOLNES_THREAD_LOCAL double gCpuStepAccumMs = 0.0;
+static SMOLNES_THREAD_LOCAL uint64_t gCpuStepAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL bool gEventPollActive = false;
 static SMOLNES_THREAD_LOCAL double gEventPollStartMs = 0.0;
 static SMOLNES_THREAD_LOCAL bool gFrameExecutionActive = false;
 static SMOLNES_THREAD_LOCAL double gFrameExecutionStartMs = 0.0;
 static SMOLNES_THREAD_LOCAL bool gPpuStepActive = false;
 static SMOLNES_THREAD_LOCAL double gPpuStepStartMs = 0.0;
+static SMOLNES_THREAD_LOCAL double gPpuStepAccumMs = 0.0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuStepAccumCalls = 0;
 typedef enum SmolnesPpuPhaseBucket {
     SmolnesPpuPhaseBucketNone = 0,
     SmolnesPpuPhaseBucketVisiblePixels = 1,
@@ -251,6 +273,40 @@ static void resetPpuPhaseBreakdown(void)
     gPpuOtherAccumCalls = 0;
 }
 
+static void resetPerInstructionAccumulators(void)
+{
+    gTimingSampleCounter = 0;
+    gTimingThisInstruction = false;
+    gTotalInstructions = 0;
+    gSampledInstructions = 0;
+    gCpuStepAccumMs = 0.0;
+    gCpuStepAccumCalls = 0;
+    gApuStepAccumMs = 0.0;
+    gApuStepAccumCalls = 0;
+    gPpuStepAccumMs = 0.0;
+    gPpuStepAccumCalls = 0;
+    resetPpuPhaseBreakdown();
+}
+
+static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
+{
+    runtime->runtimeThreadCpuStepMs += gCpuStepAccumMs;
+    runtime->runtimeThreadCpuStepCalls += gSampledInstructions;
+    runtime->runtimeThreadApuStepMs += gApuStepAccumMs;
+    runtime->runtimeThreadApuStepCalls += gSampledInstructions;
+    runtime->runtimeThreadPpuStepMs += gPpuStepAccumMs;
+    runtime->runtimeThreadPpuStepCalls += gSampledInstructions;
+    runtime->runtimeThreadPpuVisiblePixelsMs += gPpuVisiblePixelsAccumMs;
+    runtime->runtimeThreadPpuVisiblePixelsCalls += gPpuVisiblePixelsAccumCalls;
+    runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
+    runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
+    runtime->runtimeThreadPpuPrefetchMs += gPpuPrefetchAccumMs;
+    runtime->runtimeThreadPpuPrefetchCalls += gPpuPrefetchAccumCalls;
+    runtime->runtimeThreadPpuOtherMs += gPpuOtherAccumMs;
+    runtime->runtimeThreadPpuOtherCalls += gPpuOtherAccumCalls;
+    resetPerInstructionAccumulators();
+}
+
 static void accumulatePpuPhaseDuration(SmolnesPpuPhaseBucket phase, double durationMs)
 {
     if (durationMs <= 0.0) {
@@ -310,6 +366,10 @@ static void* runtimeThreadMain(void* arg)
     }
 
     gCurrentRuntime = runtime;
+    gDetailedTimingEnabled = runtime->detailedTimingEnabled;
+    gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
+    gApuStepActive = false;
+    gApuStepStartMs = 0.0;
     gCpuStepActive = false;
     gCpuStepStartMs = 0.0;
     gEventPollActive = false;
@@ -318,7 +378,7 @@ static void* runtimeThreadMain(void* arg)
     gFrameExecutionStartMs = 0.0;
     gPpuStepActive = false;
     gPpuStepStartMs = 0.0;
-    resetPpuPhaseBreakdown();
+    resetPerInstructionAccumulators();
     gFrameSubmitActive = false;
     gFrameSubmitStartMs = 0.0;
     smolnesApuInit(&gApuState, 48000.0);
@@ -334,6 +394,8 @@ static void* runtimeThreadMain(void* arg)
     pthread_cond_broadcast(&runtime->runtimeCond);
     pthread_mutex_unlock(&runtime->runtimeMutex);
     gCurrentRuntime = NULL;
+    gApuStepActive = false;
+    gApuStepStartMs = 0.0;
     gCpuStepActive = false;
     gCpuStepStartMs = 0.0;
     gEventPollActive = false;
@@ -342,7 +404,7 @@ static void* runtimeThreadMain(void* arg)
     gFrameExecutionStartMs = 0.0;
     gPpuStepActive = false;
     gPpuStepStartMs = 0.0;
-    resetPpuPhaseBreakdown();
+    resetPerInstructionAccumulators();
     gFrameSubmitActive = false;
     gFrameSubmitStartMs = 0.0;
     return NULL;
@@ -475,12 +537,21 @@ int smolnesRuntimeWrappedRenderCopy(
     return 0;
 }
 
+// CPU_STEP_BEGIN decides whether this instruction triplet (CPU/APU/PPU) is
+// sampled. APU and PPU begin/end follow that decision via gTimingThisInstruction.
 void smolnesRuntimeWrappedCpuStepBegin(void)
 {
-    SmolnesRuntimeHandle* runtime = getCurrentRuntime();
-    if (runtime == NULL || gCpuStepActive) {
+    gTotalInstructions++;
+    if (!gDetailedTimingEnabled) {
         return;
     }
+
+    if (++gTimingSampleCounter < gTimingSampleRate) {
+        return;
+    }
+    gTimingSampleCounter = 0;
+    gTimingThisInstruction = true;
+    gSampledInstructions++;
 
     gCpuStepStartMs = monotonicNowMs();
     gCpuStepActive = true;
@@ -488,22 +559,38 @@ void smolnesRuntimeWrappedCpuStepBegin(void)
 
 void smolnesRuntimeWrappedCpuStepEnd(void)
 {
-    SmolnesRuntimeHandle* runtime = getCurrentRuntime();
-    if (runtime == NULL || !gCpuStepActive) {
+    if (!gCpuStepActive) {
         return;
     }
 
     const double cpuStepMs = monotonicNowMs() - gCpuStepStartMs;
     gCpuStepActive = false;
-    gCpuStepStartMs = 0.0;
-    if (cpuStepMs <= 0.0) {
+    if (cpuStepMs > 0.0) {
+        gCpuStepAccumMs += cpuStepMs;
+    }
+}
+
+void smolnesRuntimeWrappedApuClockBegin(void)
+{
+    if (!gTimingThisInstruction) {
         return;
     }
 
-    pthread_mutex_lock(&runtime->runtimeMutex);
-    runtime->runtimeThreadCpuStepMs += cpuStepMs;
-    runtime->runtimeThreadCpuStepCalls++;
-    pthread_mutex_unlock(&runtime->runtimeMutex);
+    gApuStepStartMs = monotonicNowMs();
+    gApuStepActive = true;
+}
+
+void smolnesRuntimeWrappedApuClockEnd(void)
+{
+    if (!gApuStepActive) {
+        return;
+    }
+
+    const double apuStepMs = monotonicNowMs() - gApuStepStartMs;
+    gApuStepActive = false;
+    if (apuStepMs > 0.0) {
+        gApuStepAccumMs += apuStepMs;
+    }
 }
 
 void smolnesRuntimeWrappedFrameExecutionBegin(void)
@@ -533,6 +620,8 @@ void smolnesRuntimeWrappedFrameExecutionBegin(void)
             (runtime->latchedController1SequenceId == 0) ? 0 : monotonicNowNs();
     }
     latchThreadKeyboardStateFromRuntime(runtime);
+    gDetailedTimingEnabled = runtime->detailedTimingEnabled;
+    gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
     pthread_mutex_unlock(&runtime->runtimeMutex);
     gFrameExecutionStartMs = monotonicNowMs();
     gFrameExecutionActive = true;
@@ -555,49 +644,34 @@ void smolnesRuntimeWrappedFrameExecutionEnd(void)
     pthread_mutex_lock(&runtime->runtimeMutex);
     runtime->runtimeThreadFrameExecutionMs += frameExecutionMs;
     runtime->runtimeThreadFrameExecutionCalls++;
+    flushPerInstructionAccumulatorsLocked(runtime);
     pthread_mutex_unlock(&runtime->runtimeMutex);
 }
 
 void smolnesRuntimeWrappedPpuStepBegin(void)
 {
-    SmolnesRuntimeHandle* runtime = getCurrentRuntime();
-    if (runtime == NULL || gPpuStepActive) {
+    if (!gTimingThisInstruction) {
         return;
     }
 
-    resetPpuPhaseBreakdown();
     gPpuStepStartMs = monotonicNowMs();
     gPpuStepActive = true;
 }
 
 void smolnesRuntimeWrappedPpuStepEnd(void)
 {
-    SmolnesRuntimeHandle* runtime = getCurrentRuntime();
-    if (runtime == NULL || !gPpuStepActive) {
+    if (!gPpuStepActive) {
+        gTimingThisInstruction = false;
         return;
     }
 
     setPpuPhaseBucket(SmolnesPpuPhaseBucketNone);
     const double ppuStepMs = monotonicNowMs() - gPpuStepStartMs;
     gPpuStepActive = false;
-    gPpuStepStartMs = 0.0;
-    if (ppuStepMs <= 0.0) {
-        return;
+    gTimingThisInstruction = false;
+    if (ppuStepMs > 0.0) {
+        gPpuStepAccumMs += ppuStepMs;
     }
-
-    pthread_mutex_lock(&runtime->runtimeMutex);
-    runtime->runtimeThreadPpuStepMs += ppuStepMs;
-    runtime->runtimeThreadPpuStepCalls++;
-    runtime->runtimeThreadPpuVisiblePixelsMs += gPpuVisiblePixelsAccumMs;
-    runtime->runtimeThreadPpuVisiblePixelsCalls += gPpuVisiblePixelsAccumCalls;
-    runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
-    runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
-    runtime->runtimeThreadPpuPrefetchMs += gPpuPrefetchAccumMs;
-    runtime->runtimeThreadPpuPrefetchCalls += gPpuPrefetchAccumCalls;
-    runtime->runtimeThreadPpuOtherMs += gPpuOtherAccumMs;
-    runtime->runtimeThreadPpuOtherCalls += gPpuOtherAccumCalls;
-    pthread_mutex_unlock(&runtime->runtimeMutex);
-    resetPpuPhaseBreakdown();
 }
 
 void smolnesRuntimeWrappedPpuPhaseSet(uint32_t phaseId)
@@ -846,6 +920,8 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
     smolnesApuClock(&gApuState, cycles);
 }
 
+#define SMOLNES_APU_CLOCK_BEGIN smolnesRuntimeWrappedApuClockBegin
+#define SMOLNES_APU_CLOCK_END smolnesRuntimeWrappedApuClockEnd
 #define SMOLNES_APU_WRITE(addr, value) smolnesRuntimeWrappedApuWrite(addr, value)
 #define SMOLNES_APU_READ(addr) smolnesRuntimeWrappedApuRead(addr)
 #define SMOLNES_APU_CLOCK(cycles) smolnesRuntimeWrappedApuClock(cycles)
@@ -875,6 +951,8 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #undef SMOLNES_FRAME_SUBMIT_END
 #undef SMOLNES_EVENT_POLL_BEGIN
 #undef SMOLNES_EVENT_POLL_END
+#undef SMOLNES_APU_CLOCK_BEGIN
+#undef SMOLNES_APU_CLOCK_END
 #undef SMOLNES_APU_WRITE
 #undef SMOLNES_APU_READ
 #undef SMOLNES_APU_CLOCK
@@ -967,6 +1045,8 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     snprintf(runtime->romPath, sizeof(runtime->romPath), "%s", romPath);
 
     runtime->stopRequested = false;
+    runtime->detailedTimingEnabled = true;
+    runtime->timingSampleRate = 64;
     runtime->healthy = true;
     runtime->renderedFrames = 0;
     runtime->targetFrames = 0;
@@ -978,6 +1058,8 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->runFramesWaitCalls = 0;
     runtime->runtimeThreadIdleWaitMs = 0.0;
     runtime->runtimeThreadIdleWaitCalls = 0;
+    runtime->runtimeThreadApuStepMs = 0.0;
+    runtime->runtimeThreadApuStepCalls = 0;
     runtime->runtimeThreadCpuStepMs = 0.0;
     runtime->runtimeThreadCpuStepCalls = 0;
     runtime->runtimeThreadFrameExecutionMs = 0.0;
@@ -1321,6 +1403,8 @@ bool smolnesRuntimeCopyProfilingSnapshot(
     snapshotOut->run_frames_wait_calls = mutableRuntime->runFramesWaitCalls;
     snapshotOut->runtime_thread_idle_wait_ms = mutableRuntime->runtimeThreadIdleWaitMs;
     snapshotOut->runtime_thread_idle_wait_calls = mutableRuntime->runtimeThreadIdleWaitCalls;
+    snapshotOut->runtime_thread_apu_step_ms = mutableRuntime->runtimeThreadApuStepMs;
+    snapshotOut->runtime_thread_apu_step_calls = mutableRuntime->runtimeThreadApuStepCalls;
     snapshotOut->runtime_thread_cpu_step_ms = mutableRuntime->runtimeThreadCpuStepMs;
     snapshotOut->runtime_thread_cpu_step_calls = mutableRuntime->runtimeThreadCpuStepCalls;
     snapshotOut->runtime_thread_frame_execution_ms = mutableRuntime->runtimeThreadFrameExecutionMs;
@@ -1516,5 +1600,15 @@ void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePa
     runtime->realtimePacingOriginMs = 0.0;
     runtime->realtimePacingOriginFrame = 0;
     pthread_cond_broadcast(&runtime->runtimeCond);
+    pthread_mutex_unlock(&runtime->runtimeMutex);
+}
+
+void smolnesRuntimeSetDetailedTimingEnabled(SmolnesRuntimeHandle* runtime, bool enabled)
+{
+    if (runtime == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&runtime->runtimeMutex);
+    runtime->detailedTimingEnabled = enabled;
     pthread_mutex_unlock(&runtime->runtimeMutex);
 }

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -56,6 +56,11 @@ struct SmolnesRuntimeHandle {
     uint64_t runtimeThreadPpuStepCalls;
     double runtimeThreadPpuVisiblePixelsMs;
     uint64_t runtimeThreadPpuVisiblePixelsCalls;
+    uint64_t runtimeThreadPpuVisibleBgOnlySpanCalls;
+    uint64_t runtimeThreadPpuVisibleBgOnlySpanPixels;
+    uint64_t runtimeThreadPpuVisibleBgOnlyScalarPixels;
+    uint64_t runtimeThreadPpuVisibleBgOnlyBatchedPixels;
+    uint64_t runtimeThreadPpuVisibleBgOnlyBatchedCalls;
     double runtimeThreadPpuSpriteEvalMs;
     uint64_t runtimeThreadPpuSpriteEvalCalls;
     double runtimeThreadPpuPostVisibleMs;
@@ -157,6 +162,11 @@ static SMOLNES_THREAD_LOCAL bool gPpuStepActive = false;
 static SMOLNES_THREAD_LOCAL double gPpuStepStartMs = 0.0;
 static SMOLNES_THREAD_LOCAL double gPpuStepAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuStepAccumCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlySpanCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlySpanPixels = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyScalarPixels = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyBatchedPixels = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyBatchedCalls = 0;
 typedef enum SmolnesPpuPhaseBucket {
     SmolnesPpuPhaseBucketNone = 0,
     SmolnesPpuPhaseBucketVisiblePixels = 1,
@@ -305,6 +315,11 @@ static void resetPerInstructionAccumulators(void)
     gApuStepAccumCalls = 0;
     gPpuStepAccumMs = 0.0;
     gPpuStepAccumCalls = 0;
+    gPpuVisibleBgOnlySpanCalls = 0;
+    gPpuVisibleBgOnlySpanPixels = 0;
+    gPpuVisibleBgOnlyScalarPixels = 0;
+    gPpuVisibleBgOnlyBatchedPixels = 0;
+    gPpuVisibleBgOnlyBatchedCalls = 0;
     resetPpuPhaseBreakdown();
 }
 
@@ -318,6 +333,11 @@ static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
     runtime->runtimeThreadPpuStepCalls += gSampledInstructions;
     runtime->runtimeThreadPpuVisiblePixelsMs += gPpuVisiblePixelsAccumMs;
     runtime->runtimeThreadPpuVisiblePixelsCalls += gPpuVisiblePixelsAccumCalls;
+    runtime->runtimeThreadPpuVisibleBgOnlySpanCalls += gPpuVisibleBgOnlySpanCalls;
+    runtime->runtimeThreadPpuVisibleBgOnlySpanPixels += gPpuVisibleBgOnlySpanPixels;
+    runtime->runtimeThreadPpuVisibleBgOnlyScalarPixels += gPpuVisibleBgOnlyScalarPixels;
+    runtime->runtimeThreadPpuVisibleBgOnlyBatchedPixels += gPpuVisibleBgOnlyBatchedPixels;
+    runtime->runtimeThreadPpuVisibleBgOnlyBatchedCalls += gPpuVisibleBgOnlyBatchedCalls;
     runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
     runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
     runtime->runtimeThreadPpuPostVisibleMs += gPpuPostVisibleAccumMs;
@@ -758,6 +778,23 @@ void smolnesRuntimeWrappedPpuPhaseClear(void)
     setPpuPhaseBucket(SmolnesPpuPhaseBucketNone);
 }
 
+void smolnesRuntimeWrappedPpuVisibleBgOnlyStats(
+    uint16_t spanPixels,
+    uint16_t scalarPixels,
+    uint16_t batchedPixels,
+    uint16_t batchedCalls)
+{
+    if (!gDetailedTimingEnabled) {
+        return;
+    }
+
+    gPpuVisibleBgOnlySpanCalls++;
+    gPpuVisibleBgOnlySpanPixels += spanPixels;
+    gPpuVisibleBgOnlyScalarPixels += scalarPixels;
+    gPpuVisibleBgOnlyBatchedPixels += batchedPixels;
+    gPpuVisibleBgOnlyBatchedCalls += batchedCalls;
+}
+
 void smolnesRuntimeWrappedFrameSubmitBegin(void)
 {
     SmolnesRuntimeHandle* runtime = getCurrentRuntime();
@@ -953,6 +990,9 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
             smolnesRuntimeWrappedPpuPhaseSet(phase);                                         \
         }                                                                                    \
     } while (0)
+#define SMOLNES_PPU_VISIBLE_BG_ONLY_STATS(span_pixels, scalar_pixels, batched_pixels, batch_count) \
+    smolnesRuntimeWrappedPpuVisibleBgOnlyStats(                                                  \
+        (span_pixels), (scalar_pixels), (batched_pixels), (batch_count))
 #define SMOLNES_FRAME_SUBMIT_BEGIN smolnesRuntimeWrappedFrameSubmitBegin
 #define SMOLNES_FRAME_SUBMIT_END smolnesRuntimeWrappedFrameSubmitEnd
 #define SMOLNES_EVENT_POLL_BEGIN smolnesRuntimeWrappedEventPollBegin
@@ -1142,6 +1182,11 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->runtimeThreadPpuStepCalls = 0;
     runtime->runtimeThreadPpuVisiblePixelsMs = 0.0;
     runtime->runtimeThreadPpuVisiblePixelsCalls = 0;
+    runtime->runtimeThreadPpuVisibleBgOnlySpanCalls = 0;
+    runtime->runtimeThreadPpuVisibleBgOnlySpanPixels = 0;
+    runtime->runtimeThreadPpuVisibleBgOnlyScalarPixels = 0;
+    runtime->runtimeThreadPpuVisibleBgOnlyBatchedPixels = 0;
+    runtime->runtimeThreadPpuVisibleBgOnlyBatchedCalls = 0;
     runtime->runtimeThreadPpuSpriteEvalMs = 0.0;
     runtime->runtimeThreadPpuSpriteEvalCalls = 0;
     runtime->runtimeThreadPpuPostVisibleMs = 0.0;
@@ -1494,6 +1539,16 @@ bool smolnesRuntimeCopyProfilingSnapshot(
         mutableRuntime->runtimeThreadPpuVisiblePixelsMs;
     snapshotOut->runtime_thread_ppu_visible_pixels_calls =
         mutableRuntime->runtimeThreadPpuVisiblePixelsCalls;
+    snapshotOut->runtime_thread_ppu_visible_bg_only_span_calls =
+        mutableRuntime->runtimeThreadPpuVisibleBgOnlySpanCalls;
+    snapshotOut->runtime_thread_ppu_visible_bg_only_span_pixels =
+        mutableRuntime->runtimeThreadPpuVisibleBgOnlySpanPixels;
+    snapshotOut->runtime_thread_ppu_visible_bg_only_scalar_pixels =
+        mutableRuntime->runtimeThreadPpuVisibleBgOnlyScalarPixels;
+    snapshotOut->runtime_thread_ppu_visible_bg_only_batched_pixels =
+        mutableRuntime->runtimeThreadPpuVisibleBgOnlyBatchedPixels;
+    snapshotOut->runtime_thread_ppu_visible_bg_only_batched_calls =
+        mutableRuntime->runtimeThreadPpuVisibleBgOnlyBatchedCalls;
     snapshotOut->runtime_thread_ppu_sprite_eval_ms = mutableRuntime->runtimeThreadPpuSpriteEvalMs;
     snapshotOut->runtime_thread_ppu_sprite_eval_calls =
         mutableRuntime->runtimeThreadPpuSpriteEvalCalls;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -524,8 +524,8 @@ int smolnesRuntimeWrappedUpdateTexture(
             uint8_t* dst = runtime->latestFrame + (row * SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
             memcpy(dst, src, SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
         }
-        runtime->hasLatestFrame = true;
     }
+    runtime->hasLatestFrame = true;
     const uint8_t* paletteSrc = frame_buffer_palette + (SMOLNES_RUNTIME_FRAME_WIDTH * 8u);
     for (uint32_t row = 0; row < SMOLNES_RUNTIME_FRAME_HEIGHT; ++row) {
         const uint8_t* src = paletteSrc + (row * SMOLNES_RUNTIME_FRAME_WIDTH);

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -110,6 +110,7 @@ struct SmolnesRuntimeHandle {
 
     bool apuEnabled;
     bool pixelOutputEnabled;
+    bool rgbaOutputEnabled;
     bool detailedTimingEnabled;
     uint32_t timingSampleRate;
     SmolnesRuntimePacingModeValue pacingMode;
@@ -129,6 +130,7 @@ static SMOLNES_THREAD_LOCAL uint8_t gThreadKeyboardState[SDL_NUM_SCANCODES] = { 
 // Frame-level timing (FRAME_EXEC) is always active.
 static SMOLNES_THREAD_LOCAL bool gApuEnabled = true;
 static SMOLNES_THREAD_LOCAL bool gPixelOutputEnabled = true;
+static SMOLNES_THREAD_LOCAL bool gRgbaOutputEnabled = true;
 static SMOLNES_THREAD_LOCAL bool gDetailedTimingEnabled = true;
 static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleRate = 64;
 static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleCounter = 0;
@@ -372,6 +374,7 @@ static void* runtimeThreadMain(void* arg)
     gCurrentRuntime = runtime;
     gApuEnabled = runtime->apuEnabled;
     gPixelOutputEnabled = runtime->pixelOutputEnabled;
+    gRgbaOutputEnabled = runtime->rgbaOutputEnabled;
     gDetailedTimingEnabled = runtime->detailedTimingEnabled;
     gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
     gApuStepActive = false;
@@ -515,10 +518,13 @@ int smolnesRuntimeWrappedUpdateTexture(
     }
 
     pthread_mutex_lock(&runtime->runtimeMutex);
-    for (uint32_t row = 0; row < SMOLNES_RUNTIME_FRAME_HEIGHT; ++row) {
-        const uint8_t* src = (const uint8_t*)pixels + ((size_t)row * (size_t)pitch);
-        uint8_t* dst = runtime->latestFrame + (row * SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
-        memcpy(dst, src, SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
+    if (gRgbaOutputEnabled) {
+        for (uint32_t row = 0; row < SMOLNES_RUNTIME_FRAME_HEIGHT; ++row) {
+            const uint8_t* src = (const uint8_t*)pixels + ((size_t)row * (size_t)pitch);
+            uint8_t* dst = runtime->latestFrame + (row * SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
+            memcpy(dst, src, SMOLNES_RUNTIME_FRAME_PITCH_BYTES);
+        }
+        runtime->hasLatestFrame = true;
     }
     const uint8_t* paletteSrc = frame_buffer_palette + (SMOLNES_RUNTIME_FRAME_WIDTH * 8u);
     for (uint32_t row = 0; row < SMOLNES_RUNTIME_FRAME_HEIGHT; ++row) {
@@ -526,7 +532,6 @@ int smolnesRuntimeWrappedUpdateTexture(
         uint8_t* dst = runtime->latestPaletteFrame + (row * SMOLNES_RUNTIME_FRAME_WIDTH);
         memcpy(dst, src, SMOLNES_RUNTIME_FRAME_WIDTH);
     }
-    runtime->hasLatestFrame = true;
     runtime->hasLatestPaletteFrame = true;
     pthread_mutex_unlock(&runtime->runtimeMutex);
 
@@ -628,6 +633,7 @@ void smolnesRuntimeWrappedFrameExecutionBegin(void)
     latchThreadKeyboardStateFromRuntime(runtime);
     gApuEnabled = runtime->apuEnabled;
     gPixelOutputEnabled = runtime->pixelOutputEnabled;
+    gRgbaOutputEnabled = runtime->rgbaOutputEnabled;
     gDetailedTimingEnabled = runtime->detailedTimingEnabled;
     gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
     pthread_mutex_unlock(&runtime->runtimeMutex);
@@ -936,7 +942,9 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
         if (gPixelOutputEnabled) { \
             uint8_t pi_ = palette_ram[(color) ? (palette) | (color) : 0]; \
             frame_buffer_palette[offset] = pi_; \
-            frame_buffer[offset] = nes_palette_rgb565[pi_]; \
+            if (gRgbaOutputEnabled) { \
+                frame_buffer[offset] = nes_palette_rgb565[pi_]; \
+            } \
         } \
     } while (0)
 #define SMOLNES_APU_CLOCK_BEGIN smolnesRuntimeWrappedApuClockBegin
@@ -1067,6 +1075,7 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->stopRequested = false;
     runtime->apuEnabled = true;
     runtime->pixelOutputEnabled = true;
+    runtime->rgbaOutputEnabled = true;
     runtime->detailedTimingEnabled = true;
     runtime->timingSampleRate = 64;
     runtime->healthy = true;
@@ -1632,6 +1641,16 @@ void smolnesRuntimeSetPixelOutputEnabled(SmolnesRuntimeHandle* runtime, bool ena
     }
     pthread_mutex_lock(&runtime->runtimeMutex);
     runtime->pixelOutputEnabled = enabled;
+    pthread_mutex_unlock(&runtime->runtimeMutex);
+}
+
+void smolnesRuntimeSetRgbaOutputEnabled(SmolnesRuntimeHandle* runtime, bool enabled)
+{
+    if (runtime == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&runtime->runtimeMutex);
+    runtime->rgbaOutputEnabled = enabled;
     pthread_mutex_unlock(&runtime->runtimeMutex);
 }
 

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -61,6 +61,18 @@ struct SmolnesRuntimeHandle {
     uint64_t runtimeThreadPpuVisibleBgOnlyScalarPixels;
     uint64_t runtimeThreadPpuVisibleBgOnlyBatchedPixels;
     uint64_t runtimeThreadPpuVisibleBgOnlyBatchedCalls;
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterCalls;
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterDots;
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterReadCalls[8];
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterReadDots[8];
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls[8];
+    uint64_t runtimeThreadDeferredPpuFlushPpuRegisterWriteDots[8];
+    uint64_t runtimeThreadDeferredPpuFlushOamDmaCalls;
+    uint64_t runtimeThreadDeferredPpuFlushOamDmaDots;
+    uint64_t runtimeThreadDeferredPpuFlushMapperWriteCalls;
+    uint64_t runtimeThreadDeferredPpuFlushMapperWriteDots;
+    uint64_t runtimeThreadDeferredPpuFlushDot256BoundaryCalls;
+    uint64_t runtimeThreadDeferredPpuFlushDot256BoundaryDots;
     double runtimeThreadPpuSpriteEvalMs;
     uint64_t runtimeThreadPpuSpriteEvalCalls;
     double runtimeThreadPpuPostVisibleMs;
@@ -167,6 +179,18 @@ static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlySpanPixels = 0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyScalarPixels = 0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyBatchedPixels = 0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuVisibleBgOnlyBatchedCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterDots = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterReadCalls[8] = { 0 };
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterReadDots[8] = { 0 };
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterWriteCalls[8] = { 0 };
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushPpuRegisterWriteDots[8] = { 0 };
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushOamDmaCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushOamDmaDots = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushMapperWriteCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushMapperWriteDots = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushDot256BoundaryCalls = 0;
+static SMOLNES_THREAD_LOCAL uint64_t gDeferredPpuFlushDot256BoundaryDots = 0;
 typedef enum SmolnesPpuPhaseBucket {
     SmolnesPpuPhaseBucketNone = 0,
     SmolnesPpuPhaseBucketVisiblePixels = 1,
@@ -325,6 +349,19 @@ static void resetPerInstructionAccumulators(void)
     gPpuVisibleBgOnlyScalarPixels = 0;
     gPpuVisibleBgOnlyBatchedPixels = 0;
     gPpuVisibleBgOnlyBatchedCalls = 0;
+    gDeferredPpuFlushPpuRegisterCalls = 0;
+    gDeferredPpuFlushPpuRegisterDots = 0;
+    memset(gDeferredPpuFlushPpuRegisterReadCalls, 0, sizeof(gDeferredPpuFlushPpuRegisterReadCalls));
+    memset(gDeferredPpuFlushPpuRegisterReadDots, 0, sizeof(gDeferredPpuFlushPpuRegisterReadDots));
+    memset(
+        gDeferredPpuFlushPpuRegisterWriteCalls, 0, sizeof(gDeferredPpuFlushPpuRegisterWriteCalls));
+    memset(gDeferredPpuFlushPpuRegisterWriteDots, 0, sizeof(gDeferredPpuFlushPpuRegisterWriteDots));
+    gDeferredPpuFlushOamDmaCalls = 0;
+    gDeferredPpuFlushOamDmaDots = 0;
+    gDeferredPpuFlushMapperWriteCalls = 0;
+    gDeferredPpuFlushMapperWriteDots = 0;
+    gDeferredPpuFlushDot256BoundaryCalls = 0;
+    gDeferredPpuFlushDot256BoundaryDots = 0;
     gDeferredPausedApuStep = false;
     gDeferredPausedCpuStep = false;
     gDeferredPpuProfilingActive = false;
@@ -348,6 +385,27 @@ static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
     runtime->runtimeThreadPpuVisibleBgOnlyScalarPixels += gPpuVisibleBgOnlyScalarPixels;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedPixels += gPpuVisibleBgOnlyBatchedPixels;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedCalls += gPpuVisibleBgOnlyBatchedCalls;
+    runtime->runtimeThreadDeferredPpuFlushPpuRegisterCalls +=
+        gDeferredPpuFlushPpuRegisterCalls;
+    runtime->runtimeThreadDeferredPpuFlushPpuRegisterDots += gDeferredPpuFlushPpuRegisterDots;
+    for (size_t registerIndex = 0; registerIndex < 8; ++registerIndex) {
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls[registerIndex] +=
+            gDeferredPpuFlushPpuRegisterReadCalls[registerIndex];
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadDots[registerIndex] +=
+            gDeferredPpuFlushPpuRegisterReadDots[registerIndex];
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls[registerIndex] +=
+            gDeferredPpuFlushPpuRegisterWriteCalls[registerIndex];
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteDots[registerIndex] +=
+            gDeferredPpuFlushPpuRegisterWriteDots[registerIndex];
+    }
+    runtime->runtimeThreadDeferredPpuFlushOamDmaCalls += gDeferredPpuFlushOamDmaCalls;
+    runtime->runtimeThreadDeferredPpuFlushOamDmaDots += gDeferredPpuFlushOamDmaDots;
+    runtime->runtimeThreadDeferredPpuFlushMapperWriteCalls += gDeferredPpuFlushMapperWriteCalls;
+    runtime->runtimeThreadDeferredPpuFlushMapperWriteDots += gDeferredPpuFlushMapperWriteDots;
+    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryCalls +=
+        gDeferredPpuFlushDot256BoundaryCalls;
+    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryDots +=
+        gDeferredPpuFlushDot256BoundaryDots;
     runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
     runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
     runtime->runtimeThreadPpuPostVisibleMs += gPpuPostVisibleAccumMs;
@@ -881,6 +939,47 @@ void smolnesRuntimeWrappedPpuVisibleBgOnlyStats(
     gPpuVisibleBgOnlyBatchedCalls += batchedCalls;
 }
 
+void smolnesRuntimeWrappedDeferredPpuFlushReason(uint32_t reasonId, uint32_t dotCount)
+{
+    switch (reasonId) {
+        case 1u:
+            gDeferredPpuFlushPpuRegisterCalls++;
+            gDeferredPpuFlushPpuRegisterDots += dotCount;
+            break;
+        case 2u:
+            gDeferredPpuFlushOamDmaCalls++;
+            gDeferredPpuFlushOamDmaDots += dotCount;
+            break;
+        case 3u:
+            gDeferredPpuFlushMapperWriteCalls++;
+            gDeferredPpuFlushMapperWriteDots += dotCount;
+            break;
+        case 4u:
+            gDeferredPpuFlushDot256BoundaryCalls++;
+            gDeferredPpuFlushDot256BoundaryDots += dotCount;
+            break;
+        default:
+            break;
+    }
+}
+
+void smolnesRuntimeWrappedDeferredPpuFlushPpuRegisterAccess(
+    uint32_t registerIndex, uint32_t isWrite, uint32_t dotCount)
+{
+    if (registerIndex >= 8) {
+        return;
+    }
+
+    if (isWrite) {
+        gDeferredPpuFlushPpuRegisterWriteCalls[registerIndex]++;
+        gDeferredPpuFlushPpuRegisterWriteDots[registerIndex] += dotCount;
+        return;
+    }
+
+    gDeferredPpuFlushPpuRegisterReadCalls[registerIndex]++;
+    gDeferredPpuFlushPpuRegisterReadDots[registerIndex] += dotCount;
+}
+
 void smolnesRuntimeWrappedFrameSubmitBegin(void)
 {
     SmolnesRuntimeHandle* runtime = getCurrentRuntime();
@@ -1071,6 +1170,14 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
 #define SMOLNES_DEFERRED_PPU_SAMPLE smolnesRuntimeWrappedDeferredPpuSample
 #define SMOLNES_DEFERRED_PPU_STEP_BEGIN smolnesRuntimeWrappedDeferredPpuStepBegin
 #define SMOLNES_DEFERRED_PPU_STEP_END smolnesRuntimeWrappedDeferredPpuStepEnd
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON(reason, dots)                                       \
+    smolnesRuntimeWrappedDeferredPpuFlushReason((reason), (dots))
+#define SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS(reg, is_write, dots)                   \
+    smolnesRuntimeWrappedDeferredPpuFlushPpuRegisterAccess((reg), (is_write), (dots))
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_PPU_REGISTER_ACCESS 1u
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_OAM_DMA 2u
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_MAPPER_WRITE 3u
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON_DOT_256_BOUNDARY 4u
 #define SMOLNES_PPU_PHASE_SET smolnesRuntimeWrappedPpuPhaseSet
 #define SMOLNES_PPU_PHASE_CLEAR smolnesRuntimeWrappedPpuPhaseClear
 #define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)                                              \
@@ -1279,6 +1386,30 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->runtimeThreadPpuVisibleBgOnlyScalarPixels = 0;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedPixels = 0;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedCalls = 0;
+    runtime->runtimeThreadDeferredPpuFlushPpuRegisterCalls = 0;
+    runtime->runtimeThreadDeferredPpuFlushPpuRegisterDots = 0;
+    memset(
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls,
+        0,
+        sizeof(runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls));
+    memset(
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadDots,
+        0,
+        sizeof(runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadDots));
+    memset(
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls,
+        0,
+        sizeof(runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls));
+    memset(
+        runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteDots,
+        0,
+        sizeof(runtime->runtimeThreadDeferredPpuFlushPpuRegisterWriteDots));
+    runtime->runtimeThreadDeferredPpuFlushOamDmaCalls = 0;
+    runtime->runtimeThreadDeferredPpuFlushOamDmaDots = 0;
+    runtime->runtimeThreadDeferredPpuFlushMapperWriteCalls = 0;
+    runtime->runtimeThreadDeferredPpuFlushMapperWriteDots = 0;
+    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryCalls = 0;
+    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryDots = 0;
     runtime->runtimeThreadPpuSpriteEvalMs = 0.0;
     runtime->runtimeThreadPpuSpriteEvalCalls = 0;
     runtime->runtimeThreadPpuPostVisibleMs = 0.0;
@@ -1641,6 +1772,38 @@ bool smolnesRuntimeCopyProfilingSnapshot(
         mutableRuntime->runtimeThreadPpuVisibleBgOnlyBatchedPixels;
     snapshotOut->runtime_thread_ppu_visible_bg_only_batched_calls =
         mutableRuntime->runtimeThreadPpuVisibleBgOnlyBatchedCalls;
+    snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_calls =
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterCalls;
+    snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_dots =
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterDots;
+    memcpy(
+        snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_read_calls,
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls,
+        sizeof(snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_read_calls));
+    memcpy(
+        snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_read_dots,
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterReadDots,
+        sizeof(snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_read_dots));
+    memcpy(
+        snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_write_calls,
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls,
+        sizeof(snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_write_calls));
+    memcpy(
+        snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_write_dots,
+        mutableRuntime->runtimeThreadDeferredPpuFlushPpuRegisterWriteDots,
+        sizeof(snapshotOut->runtime_thread_deferred_ppu_flush_ppu_register_write_dots));
+    snapshotOut->runtime_thread_deferred_ppu_flush_oam_dma_calls =
+        mutableRuntime->runtimeThreadDeferredPpuFlushOamDmaCalls;
+    snapshotOut->runtime_thread_deferred_ppu_flush_oam_dma_dots =
+        mutableRuntime->runtimeThreadDeferredPpuFlushOamDmaDots;
+    snapshotOut->runtime_thread_deferred_ppu_flush_mapper_write_calls =
+        mutableRuntime->runtimeThreadDeferredPpuFlushMapperWriteCalls;
+    snapshotOut->runtime_thread_deferred_ppu_flush_mapper_write_dots =
+        mutableRuntime->runtimeThreadDeferredPpuFlushMapperWriteDots;
+    snapshotOut->runtime_thread_deferred_ppu_flush_dot_256_boundary_calls =
+        mutableRuntime->runtimeThreadDeferredPpuFlushDot256BoundaryCalls;
+    snapshotOut->runtime_thread_deferred_ppu_flush_dot_256_boundary_dots =
+        mutableRuntime->runtimeThreadDeferredPpuFlushDot256BoundaryDots;
     snapshotOut->runtime_thread_ppu_sprite_eval_ms = mutableRuntime->runtimeThreadPpuSpriteEvalMs;
     snapshotOut->runtime_thread_ppu_sprite_eval_calls =
         mutableRuntime->runtimeThreadPpuSpriteEvalCalls;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -190,6 +190,11 @@ static SMOLNES_THREAD_LOCAL double gPpuNonVisibleScanlinesAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuNonVisibleScanlinesAccumCalls = 0;
 static SMOLNES_THREAD_LOCAL double gPpuOtherAccumMs = 0.0;
 static SMOLNES_THREAD_LOCAL uint64_t gPpuOtherAccumCalls = 0;
+static SMOLNES_THREAD_LOCAL bool gDeferredPausedApuStep = false;
+static SMOLNES_THREAD_LOCAL bool gDeferredPausedCpuStep = false;
+static SMOLNES_THREAD_LOCAL bool gDeferredPpuProfilingActive = false;
+static SMOLNES_THREAD_LOCAL double gDeferredPpuScale = 1.0;
+static SMOLNES_THREAD_LOCAL uint32_t gDeferredSampledPpuDots = 0;
 static SMOLNES_THREAD_LOCAL bool gFrameSubmitActive = false;
 static SMOLNES_THREAD_LOCAL double gFrameSubmitStartMs = 0.0;
 
@@ -320,6 +325,11 @@ static void resetPerInstructionAccumulators(void)
     gPpuVisibleBgOnlyScalarPixels = 0;
     gPpuVisibleBgOnlyBatchedPixels = 0;
     gPpuVisibleBgOnlyBatchedCalls = 0;
+    gDeferredPausedApuStep = false;
+    gDeferredPausedCpuStep = false;
+    gDeferredPpuProfilingActive = false;
+    gDeferredPpuScale = 1.0;
+    gDeferredSampledPpuDots = 0;
     resetPpuPhaseBreakdown();
 }
 
@@ -355,6 +365,9 @@ static void accumulatePpuPhaseDuration(SmolnesPpuPhaseBucket phase, double durat
 {
     if (durationMs <= 0.0) {
         return;
+    }
+    if (gDeferredPpuProfilingActive) {
+        durationMs *= gDeferredPpuScale;
     }
 
     switch (phase) {
@@ -734,6 +747,79 @@ void smolnesRuntimeWrappedPpuStepEnd(void)
     }
 }
 
+void smolnesRuntimeWrappedDeferredPpuSample(uint32_t ppuDotCount)
+{
+    if (!gTimingThisInstruction || ppuDotCount == 0) {
+        return;
+    }
+
+    gDeferredSampledPpuDots += ppuDotCount;
+    gTimingThisInstruction = false;
+}
+
+void smolnesRuntimeWrappedDeferredPpuStepBegin(uint32_t totalPpuDots)
+{
+    gDeferredPausedApuStep = false;
+    gDeferredPausedCpuStep = false;
+
+    const double nowMs = monotonicNowMs();
+    if (gCpuStepActive) {
+        const double cpuStepMs = nowMs - gCpuStepStartMs;
+        gCpuStepActive = false;
+        gCpuStepStartMs = 0.0;
+        if (cpuStepMs > 0.0) {
+            gCpuStepAccumMs += cpuStepMs;
+        }
+        gDeferredPausedCpuStep = true;
+    }
+    if (gApuStepActive) {
+        const double apuStepMs = nowMs - gApuStepStartMs;
+        gApuStepActive = false;
+        gApuStepStartMs = 0.0;
+        if (apuStepMs > 0.0) {
+            gApuStepAccumMs += apuStepMs;
+        }
+        gDeferredPausedApuStep = true;
+    }
+
+    if (!gDetailedTimingEnabled || totalPpuDots == 0 || gDeferredSampledPpuDots == 0) {
+        return;
+    }
+
+    gDeferredPpuProfilingActive = true;
+    gDeferredPpuScale = (double)gDeferredSampledPpuDots / (double)totalPpuDots;
+    gPpuStepStartMs = nowMs;
+    gPpuStepActive = true;
+}
+
+void smolnesRuntimeWrappedDeferredPpuStepEnd(void)
+{
+    const double nowMs = monotonicNowMs();
+    if (gPpuStepActive) {
+        setPpuPhaseBucket(SmolnesPpuPhaseBucketNone);
+        const double ppuStepMs = nowMs - gPpuStepStartMs;
+        gPpuStepActive = false;
+        if (ppuStepMs > 0.0) {
+            gPpuStepAccumMs += ppuStepMs * gDeferredPpuScale;
+        }
+    }
+
+    gDeferredPpuProfilingActive = false;
+    gDeferredPpuScale = 1.0;
+    gDeferredSampledPpuDots = 0;
+
+    if (gDeferredPausedApuStep) {
+        gApuStepStartMs = nowMs;
+        gApuStepActive = true;
+        gDeferredPausedApuStep = false;
+    }
+    if (gDeferredPausedCpuStep) {
+        gCpuStepStartMs = nowMs;
+        gCpuStepActive = true;
+        gDeferredPausedCpuStep = false;
+    }
+}
+
 void smolnesRuntimeWrappedPpuPhaseSet(uint32_t phaseId)
 {
     SmolnesRuntimeHandle* runtime = getCurrentRuntime();
@@ -982,6 +1068,9 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
 #define SMOLNES_FRAME_EXEC_END smolnesRuntimeWrappedFrameExecutionEnd
 #define SMOLNES_PPU_STEP_BEGIN smolnesRuntimeWrappedPpuStepBegin
 #define SMOLNES_PPU_STEP_END smolnesRuntimeWrappedPpuStepEnd
+#define SMOLNES_DEFERRED_PPU_SAMPLE smolnesRuntimeWrappedDeferredPpuSample
+#define SMOLNES_DEFERRED_PPU_STEP_BEGIN smolnesRuntimeWrappedDeferredPpuStepBegin
+#define SMOLNES_DEFERRED_PPU_STEP_END smolnesRuntimeWrappedDeferredPpuStepEnd
 #define SMOLNES_PPU_PHASE_SET smolnesRuntimeWrappedPpuPhaseSet
 #define SMOLNES_PPU_PHASE_CLEAR smolnesRuntimeWrappedPpuPhaseClear
 #define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)                                              \
@@ -1052,6 +1141,9 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #undef SMOLNES_FRAME_EXEC_END
 #undef SMOLNES_PPU_STEP_BEGIN
 #undef SMOLNES_PPU_STEP_END
+#undef SMOLNES_DEFERRED_PPU_SAMPLE
+#undef SMOLNES_DEFERRED_PPU_STEP_BEGIN
+#undef SMOLNES_DEFERRED_PPU_STEP_END
 #undef SMOLNES_PPU_PHASE_SET
 #undef SMOLNES_PPU_PHASE_CLEAR
 #undef SMOLNES_PPU_PHASE_SET_IF_ACTIVE

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -108,6 +108,8 @@ struct SmolnesRuntimeHandle {
     SmolnesApuSampleCallback apuSampleCallback;
     void* apuSampleCallbackUserdata;
 
+    bool apuEnabled;
+    bool pixelOutputEnabled;
     bool detailedTimingEnabled;
     uint32_t timingSampleRate;
     SmolnesRuntimePacingModeValue pacingMode;
@@ -125,6 +127,8 @@ static SMOLNES_THREAD_LOCAL uint8_t gThreadKeyboardState[SDL_NUM_SCANCODES] = { 
 // these are no-ops. When enabled, only every Nth instruction is timed
 // (controlled by timingSampleRate) and results are scaled at flush time.
 // Frame-level timing (FRAME_EXEC) is always active.
+static SMOLNES_THREAD_LOCAL bool gApuEnabled = true;
+static SMOLNES_THREAD_LOCAL bool gPixelOutputEnabled = true;
 static SMOLNES_THREAD_LOCAL bool gDetailedTimingEnabled = true;
 static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleRate = 64;
 static SMOLNES_THREAD_LOCAL uint32_t gTimingSampleCounter = 0;
@@ -366,6 +370,8 @@ static void* runtimeThreadMain(void* arg)
     }
 
     gCurrentRuntime = runtime;
+    gApuEnabled = runtime->apuEnabled;
+    gPixelOutputEnabled = runtime->pixelOutputEnabled;
     gDetailedTimingEnabled = runtime->detailedTimingEnabled;
     gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
     gApuStepActive = false;
@@ -620,6 +626,8 @@ void smolnesRuntimeWrappedFrameExecutionBegin(void)
             (runtime->latchedController1SequenceId == 0) ? 0 : monotonicNowNs();
     }
     latchThreadKeyboardStateFromRuntime(runtime);
+    gApuEnabled = runtime->apuEnabled;
+    gPixelOutputEnabled = runtime->pixelOutputEnabled;
     gDetailedTimingEnabled = runtime->detailedTimingEnabled;
     gTimingSampleRate = runtime->timingSampleRate > 0 ? runtime->timingSampleRate : 1;
     pthread_mutex_unlock(&runtime->runtimeMutex);
@@ -917,9 +925,20 @@ static uint8_t smolnesRuntimeWrappedApuRead(uint16_t addr)
 
 static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 {
+    if (!gApuEnabled) {
+        return;
+    }
     smolnesApuClock(&gApuState, cycles);
 }
 
+#define SMOLNES_PIXEL_OUTPUT(offset, color, palette) \
+    do { \
+        if (gPixelOutputEnabled) { \
+            uint8_t pi_ = palette_ram[(color) ? (palette) | (color) : 0]; \
+            frame_buffer_palette[offset] = pi_; \
+            frame_buffer[offset] = nes_palette_rgb565[pi_]; \
+        } \
+    } while (0)
 #define SMOLNES_APU_CLOCK_BEGIN smolnesRuntimeWrappedApuClockBegin
 #define SMOLNES_APU_CLOCK_END smolnesRuntimeWrappedApuClockEnd
 #define SMOLNES_APU_WRITE(addr, value) smolnesRuntimeWrappedApuWrite(addr, value)
@@ -951,6 +970,7 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
 #undef SMOLNES_FRAME_SUBMIT_END
 #undef SMOLNES_EVENT_POLL_BEGIN
 #undef SMOLNES_EVENT_POLL_END
+#undef SMOLNES_PIXEL_OUTPUT
 #undef SMOLNES_APU_CLOCK_BEGIN
 #undef SMOLNES_APU_CLOCK_END
 #undef SMOLNES_APU_WRITE
@@ -1045,6 +1065,8 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     snprintf(runtime->romPath, sizeof(runtime->romPath), "%s", romPath);
 
     runtime->stopRequested = false;
+    runtime->apuEnabled = true;
+    runtime->pixelOutputEnabled = true;
     runtime->detailedTimingEnabled = true;
     runtime->timingSampleRate = 64;
     runtime->healthy = true;
@@ -1600,6 +1622,26 @@ void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePa
     runtime->realtimePacingOriginMs = 0.0;
     runtime->realtimePacingOriginFrame = 0;
     pthread_cond_broadcast(&runtime->runtimeCond);
+    pthread_mutex_unlock(&runtime->runtimeMutex);
+}
+
+void smolnesRuntimeSetPixelOutputEnabled(SmolnesRuntimeHandle* runtime, bool enabled)
+{
+    if (runtime == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&runtime->runtimeMutex);
+    runtime->pixelOutputEnabled = enabled;
+    pthread_mutex_unlock(&runtime->runtimeMutex);
+}
+
+void smolnesRuntimeSetApuEnabled(SmolnesRuntimeHandle* runtime, bool enabled)
+{
+    if (runtime == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&runtime->runtimeMutex);
+    runtime->apuEnabled = enabled;
     pthread_mutex_unlock(&runtime->runtimeMutex);
 }
 

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -25,6 +25,11 @@ typedef struct SmolnesRuntimeProfilingSnapshot {
     uint64_t runtime_thread_ppu_step_calls;
     double runtime_thread_ppu_visible_pixels_ms;
     uint64_t runtime_thread_ppu_visible_pixels_calls;
+    uint64_t runtime_thread_ppu_visible_bg_only_span_calls;
+    uint64_t runtime_thread_ppu_visible_bg_only_span_pixels;
+    uint64_t runtime_thread_ppu_visible_bg_only_scalar_pixels;
+    uint64_t runtime_thread_ppu_visible_bg_only_batched_pixels;
+    uint64_t runtime_thread_ppu_visible_bg_only_batched_calls;
     double runtime_thread_ppu_sprite_eval_ms;
     uint64_t runtime_thread_ppu_sprite_eval_calls;
     double runtime_thread_ppu_post_visible_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -131,6 +131,7 @@ void smolnesRuntimeSetApuSampleCallback(
 void smolnesRuntimeSetApuEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
 void smolnesRuntimeSetDetailedTimingEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
 void smolnesRuntimeSetPixelOutputEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
+void smolnesRuntimeSetRgbaOutputEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
 void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePacingModeValue mode);
 
 #ifdef __cplusplus

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -27,8 +27,12 @@ typedef struct SmolnesRuntimeProfilingSnapshot {
     uint64_t runtime_thread_ppu_visible_pixels_calls;
     double runtime_thread_ppu_sprite_eval_ms;
     uint64_t runtime_thread_ppu_sprite_eval_calls;
+    double runtime_thread_ppu_post_visible_ms;
+    uint64_t runtime_thread_ppu_post_visible_calls;
     double runtime_thread_ppu_prefetch_ms;
     uint64_t runtime_thread_ppu_prefetch_calls;
+    double runtime_thread_ppu_non_visible_scanlines_ms;
+    uint64_t runtime_thread_ppu_non_visible_scanlines_calls;
     double runtime_thread_ppu_other_ms;
     uint64_t runtime_thread_ppu_other_calls;
     double runtime_thread_frame_submit_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -30,6 +30,18 @@ typedef struct SmolnesRuntimeProfilingSnapshot {
     uint64_t runtime_thread_ppu_visible_bg_only_scalar_pixels;
     uint64_t runtime_thread_ppu_visible_bg_only_batched_pixels;
     uint64_t runtime_thread_ppu_visible_bg_only_batched_calls;
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_calls;
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_dots;
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_read_calls[8];
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_read_dots[8];
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_write_calls[8];
+    uint64_t runtime_thread_deferred_ppu_flush_ppu_register_write_dots[8];
+    uint64_t runtime_thread_deferred_ppu_flush_oam_dma_calls;
+    uint64_t runtime_thread_deferred_ppu_flush_oam_dma_dots;
+    uint64_t runtime_thread_deferred_ppu_flush_mapper_write_calls;
+    uint64_t runtime_thread_deferred_ppu_flush_mapper_write_dots;
+    uint64_t runtime_thread_deferred_ppu_flush_dot_256_boundary_calls;
+    uint64_t runtime_thread_deferred_ppu_flush_dot_256_boundary_dots;
     double runtime_thread_ppu_sprite_eval_ms;
     uint64_t runtime_thread_ppu_sprite_eval_calls;
     double runtime_thread_ppu_post_visible_ms;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -15,6 +15,8 @@ typedef struct SmolnesRuntimeProfilingSnapshot {
     uint64_t run_frames_wait_calls;
     double runtime_thread_idle_wait_ms;
     uint64_t runtime_thread_idle_wait_calls;
+    double runtime_thread_apu_step_ms;
+    uint64_t runtime_thread_apu_step_calls;
     double runtime_thread_cpu_step_ms;
     uint64_t runtime_thread_cpu_step_calls;
     double runtime_thread_frame_execution_ms;
@@ -127,6 +129,7 @@ void smolnesRuntimeGetLastErrorCopy(
 void smolnesRuntimeSetApuSampleCallback(
     SmolnesRuntimeHandle* runtime, SmolnesApuSampleCallback callback, void* userdata);
 void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePacingModeValue mode);
+void smolnesRuntimeSetDetailedTimingEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
 
 #ifdef __cplusplus
 }

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -128,8 +128,10 @@ void smolnesRuntimeGetLastErrorCopy(
     const SmolnesRuntimeHandle* runtime, char* buffer, uint32_t bufferSize);
 void smolnesRuntimeSetApuSampleCallback(
     SmolnesRuntimeHandle* runtime, SmolnesApuSampleCallback callback, void* userdata);
-void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePacingModeValue mode);
+void smolnesRuntimeSetApuEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
 void smolnesRuntimeSetDetailedTimingEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
+void smolnesRuntimeSetPixelOutputEnabled(SmolnesRuntimeHandle* runtime, bool enabled);
+void smolnesRuntimeSetPacingMode(SmolnesRuntimeHandle* runtime, SmolnesRuntimePacingModeValue mode);
 
 #ifdef __cplusplus
 }

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -20,6 +20,8 @@ struct PpuPerfParam {
     std::function<std::optional<std::filesystem::path>()> resolveRom;
     const char* label;
     bool detailedTiming = true;
+    bool apuEnabled = true;
+    bool pixelOutputEnabled = true;
 };
 
 std::string nameGenerator(const testing::TestParamInfo<PpuPerfParam>& info)
@@ -64,6 +66,12 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     ASSERT_TRUE(driver.isRuntimeRunning()) << driver.getRuntimeLastError();
     ASSERT_TRUE(driver.isRuntimeHealthy()) << driver.getRuntimeLastError();
 
+    if (!param.apuEnabled) {
+        driver.setApuEnabled(false);
+    }
+    if (!param.pixelOutputEnabled) {
+        driver.setPixelOutputEnabled(false);
+    }
     if (!param.detailedTiming) {
         driver.setDetailedTimingEnabled(false);
     }
@@ -172,25 +180,26 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             memCopyMs);
     }
 
-    // Correctness: verify rendering produced non-trivial output.
-    ASSERT_TRUE(paletteFrame100.has_value()) << "No palette frame at frame 100.";
-    ASSERT_TRUE(paletteFrame500.has_value()) << "No palette frame at frame 500.";
-    ASSERT_FALSE(paletteFrame100->indices.empty()) << "Palette frame 100 has no data.";
-    ASSERT_FALSE(paletteFrame500->indices.empty()) << "Palette frame 500 has no data.";
+    if (param.pixelOutputEnabled) {
+        ASSERT_TRUE(paletteFrame100.has_value()) << "No palette frame at frame 100.";
+        ASSERT_TRUE(paletteFrame500.has_value()) << "No palette frame at frame 500.";
+        ASSERT_FALSE(paletteFrame100->indices.empty()) << "Palette frame 100 has no data.";
+        ASSERT_FALSE(paletteFrame500->indices.empty()) << "Palette frame 500 has no data.";
 
-    const bool frame100AllZero = std::all_of(
-        paletteFrame100->indices.begin(), paletteFrame100->indices.end(), [](uint8_t v) {
-            return v == 0;
-        });
-    const bool frame500AllZero = std::all_of(
-        paletteFrame500->indices.begin(), paletteFrame500->indices.end(), [](uint8_t v) {
-            return v == 0;
-        });
-    EXPECT_FALSE(frame100AllZero) << "Palette frame 100 is all-zero (rendering broken).";
-    EXPECT_FALSE(frame500AllZero) << "Palette frame 500 is all-zero (rendering broken).";
+        const bool frame100AllZero = std::all_of(
+            paletteFrame100->indices.begin(), paletteFrame100->indices.end(), [](uint8_t v) {
+                return v == 0;
+            });
+        const bool frame500AllZero = std::all_of(
+            paletteFrame500->indices.begin(), paletteFrame500->indices.end(), [](uint8_t v) {
+                return v == 0;
+            });
+        EXPECT_FALSE(frame100AllZero) << "Palette frame 100 is all-zero (rendering broken).";
+        EXPECT_FALSE(frame500AllZero) << "Palette frame 500 is all-zero (rendering broken).";
 
-    EXPECT_NE(paletteFrame100->indices, paletteFrame500->indices)
-        << "Palette frames 100 and 500 are identical (game not progressing).";
+        EXPECT_NE(paletteFrame100->indices, paletteFrame500->indices)
+            << "Palette frames 100 and 500 are identical (game not progressing).";
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -198,27 +207,57 @@ INSTANTIATE_TEST_SUITE_P(
     SmolnesPpuPerformance,
     testing::Values(
         PpuPerfParam{
-            Scenario::EnumType::NesFlappyParatroopa,
-            Test::resolveFlappyRomPath,
-            "FlappyParatroopa_Profiled",
-            true,
+            .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+            .resolveRom = Test::resolveFlappyRomPath,
+            .label = "FlappyParatroopa_Profiled",
+            .detailedTiming = true,
         },
         PpuPerfParam{
-            Scenario::EnumType::NesFlappyParatroopa,
-            Test::resolveFlappyRomPath,
-            "FlappyParatroopa_Throughput",
-            false,
+            .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+            .resolveRom = Test::resolveFlappyRomPath,
+            .label = "FlappyParatroopa_Throughput",
+            .detailedTiming = false,
         },
         PpuPerfParam{
-            Scenario::EnumType::NesSuperMarioBros,
-            Test::resolveSmbRomPath,
-            "SuperMarioBros_Profiled",
-            true,
+            .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+            .resolveRom = Test::resolveFlappyRomPath,
+            .label = "FlappyParatroopa_Throughput_NoApu",
+            .detailedTiming = false,
+            .apuEnabled = false,
         },
         PpuPerfParam{
-            Scenario::EnumType::NesSuperMarioBros,
-            Test::resolveSmbRomPath,
-            "SuperMarioBros_Throughput",
-            false,
+            .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+            .resolveRom = Test::resolveFlappyRomPath,
+            .label = "FlappyParatroopa_Throughput_NoApu_NoPixels",
+            .detailedTiming = false,
+            .apuEnabled = false,
+            .pixelOutputEnabled = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Profiled",
+            .detailedTiming = true,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Throughput",
+            .detailedTiming = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Throughput_NoApu",
+            .detailedTiming = false,
+            .apuEnabled = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Throughput_NoApu_NoPixels",
+            .detailedTiming = false,
+            .apuEnabled = false,
+            .pixelOutputEnabled = false,
         }),
     nameGenerator);

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -1,11 +1,12 @@
+#include "NesTestRomPath.h"
 #include "core/ScenarioConfig.h"
 #include "core/Timers.h"
 #include "core/scenarios/nes/NesPaletteFrame.h"
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include <algorithm>
 #include <chrono>
-#include <cstdlib>
 #include <filesystem>
+#include <functional>
 #include <gtest/gtest.h>
 #include <optional>
 #include <string>
@@ -14,49 +15,58 @@ using namespace DirtSim;
 
 namespace {
 
-std::optional<std::filesystem::path> resolveFlappyRomPath()
+struct PpuPerfParam {
+    Scenario::EnumType scenarioId;
+    std::function<std::optional<std::filesystem::path>()> resolveRom;
+    const char* label;
+    bool detailedTiming = true;
+};
+
+std::string nameGenerator(const testing::TestParamInfo<PpuPerfParam>& info)
 {
-    if (const char* env = std::getenv("DIRTSIM_NES_TEST_ROM_PATH"); env != nullptr) {
-        const std::filesystem::path romPath{ env };
-        if (std::filesystem::exists(romPath)) {
-            return romPath;
-        }
-    }
-
-    const std::filesystem::path repoRelative =
-        std::filesystem::path("testdata") / "roms" / "Flappy.Paratroopa.World.Unl.nes";
-    if (std::filesystem::exists(repoRelative)) {
-        return repoRelative;
-    }
-
-    return std::nullopt;
+    return info.param.label;
 }
 
 } // namespace
 
-TEST(SmolnesPpuPerformance, FlappyParatroopa1000Frames)
+class SmolnesPpuPerformance : public testing::TestWithParam<PpuPerfParam> {};
+
+TEST_P(SmolnesPpuPerformance, Run1000Frames)
 {
-    const auto romPath = resolveFlappyRomPath();
+    const auto& param = GetParam();
+    const auto romPath = param.resolveRom();
     if (!romPath.has_value()) {
-        GTEST_SKIP() << "ROM fixture missing. Set DIRTSIM_NES_TEST_ROM_PATH or run "
-                        "'cd apps && make fetch-nes-test-rom'.";
+        GTEST_SKIP() << "ROM fixture missing for " << param.label << ".";
     }
 
     constexpr int kFrameCount = 1000;
 
-    NesSmolnesScenarioDriver driver(Scenario::EnumType::NesFlappyParatroopa);
-    Config::NesFlappyParatroopa config = std::get<Config::NesFlappyParatroopa>(
-        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
-    config.romPath = romPath.value().string();
-    config.requireSmolnesMapper = true;
-    config.maxEpisodeFrames = kFrameCount + 100;
+    NesSmolnesScenarioDriver driver(param.scenarioId);
+    ScenarioConfig config = makeDefaultConfig(param.scenarioId);
+    std::visit(
+        [&](auto& c) {
+            if constexpr (requires {
+                              c.romPath;
+                              c.requireSmolnesMapper;
+                              c.maxEpisodeFrames;
+                          }) {
+                c.romPath = romPath.value().string();
+                c.requireSmolnesMapper = true;
+                c.maxEpisodeFrames = kFrameCount + 100;
+            }
+        },
+        config);
 
-    const auto setResult = driver.setConfig(ScenarioConfig{ config });
+    const auto setResult = driver.setConfig(config);
     ASSERT_TRUE(setResult.isValue()) << setResult.errorValue();
     const auto setupResult = driver.setup();
     ASSERT_TRUE(setupResult.isValue()) << setupResult.errorValue();
     ASSERT_TRUE(driver.isRuntimeRunning()) << driver.getRuntimeLastError();
     ASSERT_TRUE(driver.isRuntimeHealthy()) << driver.getRuntimeLastError();
+
+    if (!param.detailedTiming) {
+        driver.setDetailedTimingEnabled(false);
+    }
 
     Timers timers;
     std::optional<ScenarioVideoFrame> videoFrame;
@@ -82,70 +92,85 @@ TEST(SmolnesPpuPerformance, FlappyParatroopa1000Frames)
     // Collect profiling results from Timers (populated by driver.tick).
     const double frameExecMs = timers.getAccumulatedTime("nes_runtime_thread_frame_execution");
     const double cpuStepMs = timers.getAccumulatedTime("nes_runtime_thread_cpu_step");
+    const double apuStepMs = timers.getAccumulatedTime("nes_runtime_thread_apu_step");
     const double ppuStepMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_step");
-    const double ppuVisibleMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_visible_pixels");
-    const double ppuSpriteMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_sprite_eval");
-    const double ppuPrefetchMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_prefetch");
-    const double ppuOtherMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_other");
     const double frameSubmitMs = timers.getAccumulatedTime("nes_runtime_thread_frame_submit");
-    const double eventPollMs = timers.getAccumulatedTime("nes_runtime_thread_event_poll");
     const double presentMs = timers.getAccumulatedTime("nes_runtime_thread_present");
     const double memCopyMs = timers.getAccumulatedTime("nes_runtime_memory_snapshot_copy");
 
-    const double ppuPhaseTotalMs = ppuVisibleMs + ppuSpriteMs + ppuPrefetchMs + ppuOtherMs;
+    auto clamp0 = [](double v) -> double { return v > 0.0 ? v : 0.0; };
 
-    auto pct = [](double part, double whole) -> double {
-        return whole > 0.0 ? (part / whole) * 100.0 : 0.0;
-    };
+    if (param.detailedTiming) {
+        // Sampled times include per-sample clock_gettime overhead, so absolute
+        // values are inflated. Use the ratios between phases to estimate their
+        // share of frame execution time.
+        const double sampledTotal = clamp0(cpuStepMs) + clamp0(apuStepMs) + clamp0(ppuStepMs);
+        const double cpuPct = sampledTotal > 0.0 ? clamp0(cpuStepMs) / sampledTotal * 100.0 : 0.0;
+        const double apuPct = sampledTotal > 0.0 ? clamp0(apuStepMs) / sampledTotal * 100.0 : 0.0;
+        const double ppuPct = sampledTotal > 0.0 ? clamp0(ppuStepMs) / sampledTotal * 100.0 : 0.0;
+        const double cpuEstMs = clamp0(frameExecMs) * cpuPct / 100.0;
+        const double apuEstMs = clamp0(frameExecMs) * apuPct / 100.0;
+        const double ppuEstMs = clamp0(frameExecMs) * ppuPct / 100.0;
 
-    fprintf(
-        stderr,
-        "\n"
-        "=== SmolNES PPU Performance: %d frames ===\n"
-        "\n"
-        "Wall clock:              %8.1f ms  (%5.2f ms/frame, %.1f fps)\n"
-        "\n"
-        "Frame execution total:   %8.1f ms  (%5.2f ms/frame)\n"
-        "  CPU step:              %8.1f ms  (%5.1f%%)\n"
-        "  PPU step:              %8.1f ms  (%5.1f%%)\n"
-        "  Frame submit:          %8.1f ms  (%5.1f%%)\n"
-        "  Event poll:            %8.1f ms  (%5.1f%%)\n"
-        "\n"
-        "PPU phase breakdown:     %8.1f ms\n"
-        "  Visible pixels:        %8.1f ms  (%5.1f%%)\n"
-        "  Sprite eval:           %8.1f ms  (%5.1f%%)\n"
-        "  Prefetch:              %8.1f ms  (%5.1f%%)\n"
-        "  Other:                 %8.1f ms  (%5.1f%%)\n"
-        "\n"
-        "Other:\n"
-        "  Present (sync+copy):   %8.1f ms\n"
-        "  Memory snapshot copy:  %8.1f ms\n"
-        "\n",
-        kFrameCount,
-        wallMs,
-        wallMs / kFrameCount,
-        kFrameCount / (wallMs / 1000.0),
-        frameExecMs,
-        frameExecMs / kFrameCount,
-        cpuStepMs,
-        pct(cpuStepMs, frameExecMs),
-        ppuStepMs,
-        pct(ppuStepMs, frameExecMs),
-        frameSubmitMs,
-        pct(frameSubmitMs, frameExecMs),
-        eventPollMs,
-        pct(eventPollMs, frameExecMs),
-        ppuPhaseTotalMs,
-        ppuVisibleMs,
-        pct(ppuVisibleMs, ppuPhaseTotalMs),
-        ppuSpriteMs,
-        pct(ppuSpriteMs, ppuPhaseTotalMs),
-        ppuPrefetchMs,
-        pct(ppuPrefetchMs, ppuPhaseTotalMs),
-        ppuOtherMs,
-        pct(ppuOtherMs, ppuPhaseTotalMs),
-        presentMs,
-        memCopyMs);
+        fprintf(
+            stderr,
+            "\n"
+            "=== SmolNES Profiled [%s]: %d frames (sampled) ===\n"
+            "\n"
+            "Wall clock:              %8.1f ms  (%5.2f ms/frame, %.1f fps)\n"
+            "\n"
+            "Frame execution total:   %8.1f ms  (%5.2f ms/frame)\n"
+            "  CPU step (est):        %8.1f ms  (%5.1f%%)\n"
+            "  APU step (est):        %8.1f ms  (%5.1f%%)\n"
+            "  PPU step (est):        %8.1f ms  (%5.1f%%)\n"
+            "\n"
+            "Outside frame execution:\n"
+            "  Frame submit:          %8.1f ms\n"
+            "  Present (sync+copy):   %8.1f ms\n"
+            "  Memory snapshot copy:  %8.1f ms\n"
+            "\n",
+            param.label,
+            kFrameCount,
+            wallMs,
+            wallMs / kFrameCount,
+            kFrameCount / (wallMs / 1000.0),
+            frameExecMs,
+            frameExecMs / kFrameCount,
+            cpuEstMs,
+            cpuPct,
+            apuEstMs,
+            apuPct,
+            ppuEstMs,
+            ppuPct,
+            frameSubmitMs,
+            presentMs,
+            memCopyMs);
+    }
+    else {
+        fprintf(
+            stderr,
+            "\n"
+            "=== SmolNES Throughput [%s]: %d frames ===\n"
+            "\n"
+            "Wall clock:              %8.1f ms  (%5.2f ms/frame, %.1f fps)\n"
+            "Frame execution total:   %8.1f ms  (%5.2f ms/frame)\n"
+            "\n"
+            "Outside frame execution:\n"
+            "  Frame submit:          %8.1f ms\n"
+            "  Present (sync+copy):   %8.1f ms\n"
+            "  Memory snapshot copy:  %8.1f ms\n"
+            "\n",
+            param.label,
+            kFrameCount,
+            wallMs,
+            wallMs / kFrameCount,
+            kFrameCount / (wallMs / 1000.0),
+            frameExecMs,
+            frameExecMs / kFrameCount,
+            frameSubmitMs,
+            presentMs,
+            memCopyMs);
+    }
 
     // Correctness: verify rendering produced non-trivial output.
     ASSERT_TRUE(paletteFrame100.has_value()) << "No palette frame at frame 100.";
@@ -167,3 +192,33 @@ TEST(SmolnesPpuPerformance, FlappyParatroopa1000Frames)
     EXPECT_NE(paletteFrame100->indices, paletteFrame500->indices)
         << "Palette frames 100 and 500 are identical (game not progressing).";
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    NesRoms,
+    SmolnesPpuPerformance,
+    testing::Values(
+        PpuPerfParam{
+            Scenario::EnumType::NesFlappyParatroopa,
+            Test::resolveFlappyRomPath,
+            "FlappyParatroopa_Profiled",
+            true,
+        },
+        PpuPerfParam{
+            Scenario::EnumType::NesFlappyParatroopa,
+            Test::resolveFlappyRomPath,
+            "FlappyParatroopa_Throughput",
+            false,
+        },
+        PpuPerfParam{
+            Scenario::EnumType::NesSuperMarioBros,
+            Test::resolveSmbRomPath,
+            "SuperMarioBros_Profiled",
+            true,
+        },
+        PpuPerfParam{
+            Scenario::EnumType::NesSuperMarioBros,
+            Test::resolveSmbRomPath,
+            "SuperMarioBros_Throughput",
+            false,
+        }),
+    nameGenerator);

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -22,6 +22,7 @@ struct PpuPerfParam {
     bool detailedTiming = true;
     bool apuEnabled = true;
     bool pixelOutputEnabled = true;
+    bool rgbaOutputEnabled = true;
 };
 
 std::string nameGenerator(const testing::TestParamInfo<PpuPerfParam>& info)
@@ -71,6 +72,9 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     }
     if (!param.pixelOutputEnabled) {
         driver.setPixelOutputEnabled(false);
+    }
+    if (!param.rgbaOutputEnabled) {
+        driver.setRgbaOutputEnabled(false);
     }
     if (!param.detailedTiming) {
         driver.setDetailedTimingEnabled(false);
@@ -228,6 +232,14 @@ INSTANTIATE_TEST_SUITE_P(
         PpuPerfParam{
             .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
             .resolveRom = Test::resolveFlappyRomPath,
+            .label = "FlappyParatroopa_Throughput_NoApu_PaletteOnly",
+            .detailedTiming = false,
+            .apuEnabled = false,
+            .rgbaOutputEnabled = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+            .resolveRom = Test::resolveFlappyRomPath,
             .label = "FlappyParatroopa_Throughput_NoApu_NoPixels",
             .detailedTiming = false,
             .apuEnabled = false,
@@ -251,6 +263,14 @@ INSTANTIATE_TEST_SUITE_P(
             .label = "SuperMarioBros_Throughput_NoApu",
             .detailedTiming = false,
             .apuEnabled = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Throughput_NoApu_PaletteOnly",
+            .detailedTiming = false,
+            .apuEnabled = false,
+            .rgbaOutputEnabled = false,
         },
         PpuPerfParam{
             .scenarioId = Scenario::EnumType::NesSuperMarioBros,

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -107,7 +107,11 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     const double ppuVisiblePixelsMs =
         timers.getAccumulatedTime("nes_runtime_thread_ppu_visible_pixels");
     const double ppuSpriteEvalMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_sprite_eval");
+    const double ppuPostVisibleMs =
+        timers.getAccumulatedTime("nes_runtime_thread_ppu_post_visible");
     const double ppuPrefetchMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_prefetch");
+    const double ppuNonVisibleScanlinesMs =
+        timers.getAccumulatedTime("nes_runtime_thread_ppu_non_visible_scanlines");
     const double ppuOtherMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_other");
     const double frameSubmitMs = timers.getAccumulatedTime("nes_runtime_thread_frame_submit");
     const double presentMs = timers.getAccumulatedTime("nes_runtime_thread_present");
@@ -127,18 +131,26 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
         const double apuEstMs = clamp0(frameExecMs) * apuPct / 100.0;
         const double ppuEstMs = clamp0(frameExecMs) * ppuPct / 100.0;
         const double sampledPpuTotal = clamp0(ppuVisiblePixelsMs) + clamp0(ppuSpriteEvalMs)
-            + clamp0(ppuPrefetchMs) + clamp0(ppuOtherMs);
+            + clamp0(ppuPostVisibleMs) + clamp0(ppuPrefetchMs) + clamp0(ppuNonVisibleScanlinesMs)
+            + clamp0(ppuOtherMs);
         const double ppuVisiblePixelsPct =
             sampledPpuTotal > 0.0 ? clamp0(ppuVisiblePixelsMs) / sampledPpuTotal * 100.0 : 0.0;
         const double ppuSpriteEvalPct =
             sampledPpuTotal > 0.0 ? clamp0(ppuSpriteEvalMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuPostVisiblePct =
+            sampledPpuTotal > 0.0 ? clamp0(ppuPostVisibleMs) / sampledPpuTotal * 100.0 : 0.0;
         const double ppuPrefetchPct =
             sampledPpuTotal > 0.0 ? clamp0(ppuPrefetchMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuNonVisibleScanlinesPct = sampledPpuTotal > 0.0
+            ? clamp0(ppuNonVisibleScanlinesMs) / sampledPpuTotal * 100.0
+            : 0.0;
         const double ppuOtherPct =
             sampledPpuTotal > 0.0 ? clamp0(ppuOtherMs) / sampledPpuTotal * 100.0 : 0.0;
         const double ppuVisiblePixelsEstMs = ppuEstMs * ppuVisiblePixelsPct / 100.0;
         const double ppuSpriteEvalEstMs = ppuEstMs * ppuSpriteEvalPct / 100.0;
+        const double ppuPostVisibleEstMs = ppuEstMs * ppuPostVisiblePct / 100.0;
         const double ppuPrefetchEstMs = ppuEstMs * ppuPrefetchPct / 100.0;
+        const double ppuNonVisibleScanlinesEstMs = ppuEstMs * ppuNonVisibleScanlinesPct / 100.0;
         const double ppuOtherEstMs = ppuEstMs * ppuOtherPct / 100.0;
 
         fprintf(
@@ -154,7 +166,9 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             "  PPU step (est):        %8.1f ms  (%5.1f%%)\n"
             "    Visible pixels:      %8.1f ms  (%5.1f%% of PPU)\n"
             "    Sprite eval:         %8.1f ms  (%5.1f%% of PPU)\n"
+            "    Post-visible 256-319:%8.1f ms  (%5.1f%% of PPU)\n"
             "    Prefetch:            %8.1f ms  (%5.1f%% of PPU)\n"
+            "    Non-visible scans:   %8.1f ms  (%5.1f%% of PPU)\n"
             "    Other:               %8.1f ms  (%5.1f%% of PPU)\n"
             "\n"
             "Outside frame execution:\n"
@@ -179,8 +193,12 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             ppuVisiblePixelsPct,
             ppuSpriteEvalEstMs,
             ppuSpriteEvalPct,
+            ppuPostVisibleEstMs,
+            ppuPostVisiblePct,
             ppuPrefetchEstMs,
             ppuPrefetchPct,
+            ppuNonVisibleScanlinesEstMs,
+            ppuNonVisibleScanlinesPct,
             ppuOtherEstMs,
             ppuOtherPct,
             frameSubmitMs,

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -76,9 +76,7 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     if (!param.rgbaOutputEnabled) {
         driver.setRgbaOutputEnabled(false);
     }
-    if (!param.detailedTiming) {
-        driver.setDetailedTimingEnabled(false);
-    }
+    driver.setDetailedTimingEnabled(param.detailedTiming);
 
     Timers timers;
     std::optional<ScenarioVideoFrame> videoFrame;
@@ -106,6 +104,11 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     const double cpuStepMs = timers.getAccumulatedTime("nes_runtime_thread_cpu_step");
     const double apuStepMs = timers.getAccumulatedTime("nes_runtime_thread_apu_step");
     const double ppuStepMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_step");
+    const double ppuVisiblePixelsMs =
+        timers.getAccumulatedTime("nes_runtime_thread_ppu_visible_pixels");
+    const double ppuSpriteEvalMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_sprite_eval");
+    const double ppuPrefetchMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_prefetch");
+    const double ppuOtherMs = timers.getAccumulatedTime("nes_runtime_thread_ppu_other");
     const double frameSubmitMs = timers.getAccumulatedTime("nes_runtime_thread_frame_submit");
     const double presentMs = timers.getAccumulatedTime("nes_runtime_thread_present");
     const double memCopyMs = timers.getAccumulatedTime("nes_runtime_memory_snapshot_copy");
@@ -123,6 +126,20 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
         const double cpuEstMs = clamp0(frameExecMs) * cpuPct / 100.0;
         const double apuEstMs = clamp0(frameExecMs) * apuPct / 100.0;
         const double ppuEstMs = clamp0(frameExecMs) * ppuPct / 100.0;
+        const double sampledPpuTotal = clamp0(ppuVisiblePixelsMs) + clamp0(ppuSpriteEvalMs)
+            + clamp0(ppuPrefetchMs) + clamp0(ppuOtherMs);
+        const double ppuVisiblePixelsPct =
+            sampledPpuTotal > 0.0 ? clamp0(ppuVisiblePixelsMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuSpriteEvalPct =
+            sampledPpuTotal > 0.0 ? clamp0(ppuSpriteEvalMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuPrefetchPct =
+            sampledPpuTotal > 0.0 ? clamp0(ppuPrefetchMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuOtherPct =
+            sampledPpuTotal > 0.0 ? clamp0(ppuOtherMs) / sampledPpuTotal * 100.0 : 0.0;
+        const double ppuVisiblePixelsEstMs = ppuEstMs * ppuVisiblePixelsPct / 100.0;
+        const double ppuSpriteEvalEstMs = ppuEstMs * ppuSpriteEvalPct / 100.0;
+        const double ppuPrefetchEstMs = ppuEstMs * ppuPrefetchPct / 100.0;
+        const double ppuOtherEstMs = ppuEstMs * ppuOtherPct / 100.0;
 
         fprintf(
             stderr,
@@ -135,6 +152,10 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             "  CPU step (est):        %8.1f ms  (%5.1f%%)\n"
             "  APU step (est):        %8.1f ms  (%5.1f%%)\n"
             "  PPU step (est):        %8.1f ms  (%5.1f%%)\n"
+            "    Visible pixels:      %8.1f ms  (%5.1f%% of PPU)\n"
+            "    Sprite eval:         %8.1f ms  (%5.1f%% of PPU)\n"
+            "    Prefetch:            %8.1f ms  (%5.1f%% of PPU)\n"
+            "    Other:               %8.1f ms  (%5.1f%% of PPU)\n"
             "\n"
             "Outside frame execution:\n"
             "  Frame submit:          %8.1f ms\n"
@@ -154,6 +175,14 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             apuPct,
             ppuEstMs,
             ppuPct,
+            ppuVisiblePixelsEstMs,
+            ppuVisiblePixelsPct,
+            ppuSpriteEvalEstMs,
+            ppuSpriteEvalPct,
+            ppuPrefetchEstMs,
+            ppuPrefetchPct,
+            ppuOtherEstMs,
+            ppuOtherPct,
             frameSubmitMs,
             presentMs,
             memCopyMs);
@@ -250,6 +279,22 @@ INSTANTIATE_TEST_SUITE_P(
             .resolveRom = Test::resolveSmbRomPath,
             .label = "SuperMarioBros_Profiled",
             .detailedTiming = true,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Profiled_NoApu_PaletteOnly",
+            .detailedTiming = true,
+            .apuEnabled = false,
+            .rgbaOutputEnabled = false,
+        },
+        PpuPerfParam{
+            .scenarioId = Scenario::EnumType::NesSuperMarioBros,
+            .resolveRom = Test::resolveSmbRomPath,
+            .label = "SuperMarioBros_Profiled_NoApu_NoPixels",
+            .detailedTiming = true,
+            .apuEnabled = false,
+            .pixelOutputEnabled = false,
         },
         PpuPerfParam{
             .scenarioId = Scenario::EnumType::NesSuperMarioBros,

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -4,6 +4,7 @@
 #include "core/scenarios/nes/NesPaletteFrame.h"
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -168,6 +169,46 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
         const uint64_t bgOnlyBatchedCalls = profilingSnapshot.has_value()
             ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlyBatchedCalls
             : 0;
+        const uint64_t deferredFlushPpuRegisterCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterCalls
+            : 0;
+        const uint64_t deferredFlushPpuRegisterDots = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterDots
+            : 0;
+        const std::array<uint64_t, 8> deferredFlushPpuRegisterReadCalls =
+            profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls
+            : std::array<uint64_t, 8>{};
+        const std::array<uint64_t, 8> deferredFlushPpuRegisterReadDots =
+            profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterReadDots
+            : std::array<uint64_t, 8>{};
+        const std::array<uint64_t, 8> deferredFlushPpuRegisterWriteCalls =
+            profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterWriteCalls
+            : std::array<uint64_t, 8>{};
+        const std::array<uint64_t, 8> deferredFlushPpuRegisterWriteDots =
+            profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushPpuRegisterWriteDots
+            : std::array<uint64_t, 8>{};
+        const uint64_t deferredFlushOamDmaCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushOamDmaCalls
+            : 0;
+        const uint64_t deferredFlushOamDmaDots = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushOamDmaDots
+            : 0;
+        const uint64_t deferredFlushMapperWriteCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushMapperWriteCalls
+            : 0;
+        const uint64_t deferredFlushMapperWriteDots = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushMapperWriteDots
+            : 0;
+        const uint64_t deferredFlushDot256BoundaryCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushDot256BoundaryCalls
+            : 0;
+        const uint64_t deferredFlushDot256BoundaryDots = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadDeferredPpuFlushDot256BoundaryDots
+            : 0;
         const double bgOnlyAvgSpanPixels = bgOnlySpanCalls > 0
             ? static_cast<double>(bgOnlySpanPixels) / static_cast<double>(bgOnlySpanCalls)
             : 0.0;
@@ -181,6 +222,22 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             : 0.0;
         const double bgOnlyAvgBatchesPerCall = bgOnlySpanCalls > 0
             ? static_cast<double>(bgOnlyBatchedCalls) / static_cast<double>(bgOnlySpanCalls)
+            : 0.0;
+        const double deferredFlushPpuRegisterAvgDots = deferredFlushPpuRegisterCalls > 0
+            ? static_cast<double>(deferredFlushPpuRegisterDots)
+                / static_cast<double>(deferredFlushPpuRegisterCalls)
+            : 0.0;
+        const double deferredFlushOamDmaAvgDots = deferredFlushOamDmaCalls > 0
+            ? static_cast<double>(deferredFlushOamDmaDots)
+                / static_cast<double>(deferredFlushOamDmaCalls)
+            : 0.0;
+        const double deferredFlushMapperWriteAvgDots = deferredFlushMapperWriteCalls > 0
+            ? static_cast<double>(deferredFlushMapperWriteDots)
+                / static_cast<double>(deferredFlushMapperWriteCalls)
+            : 0.0;
+        const double deferredFlushDot256BoundaryAvgDots = deferredFlushDot256BoundaryCalls > 0
+            ? static_cast<double>(deferredFlushDot256BoundaryDots)
+                / static_cast<double>(deferredFlushDot256BoundaryCalls)
             : 0.0;
 
         fprintf(
@@ -207,6 +264,12 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             "  Scalar pixels:         %8llu  (%5.1f%%)\n"
             "  Batched pixels:        %8llu  (%5.1f%%)\n"
             "  Avg 8px batches/call: %8.2f\n"
+            "\n"
+            "Deferred visible flushes:\n"
+            "  Dot 256 boundary:      %8llu  (%8llu dots, avg %5.2f)\n"
+            "  PPU register access:   %8llu  (%8llu dots, avg %5.2f)\n"
+            "  OAM DMA:               %8llu  (%8llu dots, avg %5.2f)\n"
+            "  Mapper write:          %8llu  (%8llu dots, avg %5.2f)\n"
             "\n"
             "Outside frame execution:\n"
             "  Frame submit:          %8.1f ms\n"
@@ -245,9 +308,57 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             static_cast<unsigned long long>(bgOnlyBatchedPixels),
             bgOnlyBatchedPixelsPct,
             bgOnlyAvgBatchesPerCall,
+            static_cast<unsigned long long>(deferredFlushDot256BoundaryCalls),
+            static_cast<unsigned long long>(deferredFlushDot256BoundaryDots),
+            deferredFlushDot256BoundaryAvgDots,
+            static_cast<unsigned long long>(deferredFlushPpuRegisterCalls),
+            static_cast<unsigned long long>(deferredFlushPpuRegisterDots),
+            deferredFlushPpuRegisterAvgDots,
+            static_cast<unsigned long long>(deferredFlushOamDmaCalls),
+            static_cast<unsigned long long>(deferredFlushOamDmaDots),
+            deferredFlushOamDmaAvgDots,
+            static_cast<unsigned long long>(deferredFlushMapperWriteCalls),
+            static_cast<unsigned long long>(deferredFlushMapperWriteDots),
+            deferredFlushMapperWriteAvgDots,
             frameSubmitMs,
             presentMs,
             memCopyMs);
+
+        if (deferredFlushPpuRegisterCalls > 0) {
+            constexpr std::array<const char*, 8> kPpuRegisterNames = { "$2000", "$2001", "$2002",
+                                                                       "$2003", "$2004", "$2005",
+                                                                       "$2006", "$2007" };
+            fprintf(stderr, "PPU register access detail:\n");
+            for (size_t registerIndex = 0; registerIndex < kPpuRegisterNames.size();
+                 ++registerIndex) {
+                const uint64_t readCalls = deferredFlushPpuRegisterReadCalls[registerIndex];
+                const uint64_t readDots = deferredFlushPpuRegisterReadDots[registerIndex];
+                const uint64_t writeCalls = deferredFlushPpuRegisterWriteCalls[registerIndex];
+                const uint64_t writeDots = deferredFlushPpuRegisterWriteDots[registerIndex];
+                if (readCalls == 0 && writeCalls == 0) {
+                    continue;
+                }
+
+                const double readAvgDots = readCalls > 0
+                    ? static_cast<double>(readDots) / static_cast<double>(readCalls)
+                    : 0.0;
+                const double writeAvgDots = writeCalls > 0
+                    ? static_cast<double>(writeDots) / static_cast<double>(writeCalls)
+                    : 0.0;
+                fprintf(
+                    stderr,
+                    "  %s reads: %8llu (%8llu dots, avg %5.2f), writes: %8llu (%8llu dots, avg "
+                    "%5.2f)\n",
+                    kPpuRegisterNames[registerIndex],
+                    static_cast<unsigned long long>(readCalls),
+                    static_cast<unsigned long long>(readDots),
+                    readAvgDots,
+                    static_cast<unsigned long long>(writeCalls),
+                    static_cast<unsigned long long>(writeDots),
+                    writeAvgDots);
+            }
+            fprintf(stderr, "\n");
+        }
     }
     else {
         fprintf(

--- a/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
@@ -95,6 +95,7 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
     }
     const auto wallEnd = std::chrono::steady_clock::now();
     const double wallMs = std::chrono::duration<double, std::milli>(wallEnd - wallStart).count();
+    const auto profilingSnapshot = driver.copyRuntimeProfilingSnapshot();
 
     ASSERT_TRUE(driver.isRuntimeHealthy()) << driver.getRuntimeLastError();
     EXPECT_EQ(driver.getRuntimeRenderedFrameCount(), static_cast<uint64_t>(kFrameCount));
@@ -152,6 +153,35 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
         const double ppuPrefetchEstMs = ppuEstMs * ppuPrefetchPct / 100.0;
         const double ppuNonVisibleScanlinesEstMs = ppuEstMs * ppuNonVisibleScanlinesPct / 100.0;
         const double ppuOtherEstMs = ppuEstMs * ppuOtherPct / 100.0;
+        const uint64_t bgOnlySpanCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlySpanCalls
+            : 0;
+        const uint64_t bgOnlySpanPixels = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlySpanPixels
+            : 0;
+        const uint64_t bgOnlyScalarPixels = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlyScalarPixels
+            : 0;
+        const uint64_t bgOnlyBatchedPixels = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlyBatchedPixels
+            : 0;
+        const uint64_t bgOnlyBatchedCalls = profilingSnapshot.has_value()
+            ? profilingSnapshot->runtimeThreadPpuVisibleBgOnlyBatchedCalls
+            : 0;
+        const double bgOnlyAvgSpanPixels = bgOnlySpanCalls > 0
+            ? static_cast<double>(bgOnlySpanPixels) / static_cast<double>(bgOnlySpanCalls)
+            : 0.0;
+        const double bgOnlyScalarPixelsPct = bgOnlySpanPixels > 0
+            ? static_cast<double>(bgOnlyScalarPixels) / static_cast<double>(bgOnlySpanPixels)
+                * 100.0
+            : 0.0;
+        const double bgOnlyBatchedPixelsPct = bgOnlySpanPixels > 0
+            ? static_cast<double>(bgOnlyBatchedPixels) / static_cast<double>(bgOnlySpanPixels)
+                * 100.0
+            : 0.0;
+        const double bgOnlyAvgBatchesPerCall = bgOnlySpanCalls > 0
+            ? static_cast<double>(bgOnlyBatchedCalls) / static_cast<double>(bgOnlySpanCalls)
+            : 0.0;
 
         fprintf(
             stderr,
@@ -170,6 +200,13 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             "    Prefetch:            %8.1f ms  (%5.1f%% of PPU)\n"
             "    Non-visible scans:   %8.1f ms  (%5.1f%% of PPU)\n"
             "    Other:               %8.1f ms  (%5.1f%% of PPU)\n"
+            "\n"
+            "Background-only visible spans:\n"
+            "  Span calls:            %8llu\n"
+            "  Avg span length:       %8.2f pixels\n"
+            "  Scalar pixels:         %8llu  (%5.1f%%)\n"
+            "  Batched pixels:        %8llu  (%5.1f%%)\n"
+            "  Avg 8px batches/call: %8.2f\n"
             "\n"
             "Outside frame execution:\n"
             "  Frame submit:          %8.1f ms\n"
@@ -201,6 +238,13 @@ TEST_P(SmolnesPpuPerformance, Run1000Frames)
             ppuNonVisibleScanlinesPct,
             ppuOtherEstMs,
             ppuOtherPct,
+            static_cast<unsigned long long>(bgOnlySpanCalls),
+            bgOnlyAvgSpanPixels,
+            static_cast<unsigned long long>(bgOnlyScalarPixels),
+            bgOnlyScalarPixelsPct,
+            static_cast<unsigned long long>(bgOnlyBatchedPixels),
+            bgOnlyBatchedPixelsPct,
+            bgOnlyAvgBatchesPerCall,
             frameSubmitMs,
             presentMs,
             memCopyMs);

--- a/apps/src/core/scenarios/tests/SmolnesRuntime_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesRuntime_test.cpp
@@ -1,0 +1,263 @@
+#include "core/scenarios/nes/SmolnesRuntime.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace DirtSim;
+
+namespace {
+
+constexpr uint16_t kProgramStart = 0x8000u;
+constexpr uint16_t kSpriteHitResultAddr = 0x0000u;
+constexpr uint8_t kSpritePaletteIndex = 0x02u;
+constexpr uint8_t kSpriteScreenX = 32u;
+constexpr uint8_t kSpriteScreenY = 32u;
+constexpr uint8_t kSpriteOamY = kSpriteScreenY - 1u;
+
+class TestRomAssembler {
+public:
+    void bytes(std::initializer_list<uint8_t> bytesToAppend)
+    {
+        bytes_.insert(bytes_.end(), bytesToAppend.begin(), bytesToAppend.end());
+    }
+
+    void label(std::string_view name) { labels_[std::string(name)] = pc(); }
+
+    void ldaAbsXLabel(std::string_view labelName)
+    {
+        bytes({ 0xBDu, 0x00u, 0x00u });
+        unresolvedAbsolute_.push_back(
+            AbsolutePatch{ .operandOffset = bytes_.size() - 2u, .label = std::string(labelName) });
+    }
+
+    void ldaImmStaAbs(uint8_t value, uint16_t addr)
+    {
+        bytes({ 0xA9u, value, 0x8Du, lowByte(addr), highByte(addr) });
+    }
+
+    void branchToLabel(uint8_t opcode, std::string_view labelName)
+    {
+        bytes({ opcode, 0x00u });
+        unresolvedRelative_.push_back(
+            RelativePatch{ .operandOffset = bytes_.size() - 1u, .label = std::string(labelName) });
+    }
+
+    void jmpLabel(std::string_view labelName)
+    {
+        bytes({ 0x4Cu, 0x00u, 0x00u });
+        unresolvedAbsolute_.push_back(
+            AbsolutePatch{ .operandOffset = bytes_.size() - 2u, .label = std::string(labelName) });
+    }
+
+    std::vector<uint8_t> build() const
+    {
+        std::vector<uint8_t> output = bytes_;
+
+        for (const AbsolutePatch& patch : unresolvedAbsolute_) {
+            const auto labelIt = labels_.find(patch.label);
+            EXPECT_NE(labelIt, labels_.end());
+            if (labelIt == labels_.end()) {
+                return output;
+            }
+            const uint16_t target = labelIt->second;
+            output[patch.operandOffset] = lowByte(target);
+            output[patch.operandOffset + 1u] = highByte(target);
+        }
+
+        for (const RelativePatch& patch : unresolvedRelative_) {
+            const auto labelIt = labels_.find(patch.label);
+            EXPECT_NE(labelIt, labels_.end());
+            if (labelIt == labels_.end()) {
+                return output;
+            }
+            const int32_t target = static_cast<int32_t>(labelIt->second);
+            const int32_t nextPc = static_cast<int32_t>(
+                kProgramStart + static_cast<uint16_t>(patch.operandOffset + 1u));
+            const int32_t offset = target - nextPc;
+            EXPECT_GE(offset, -128);
+            EXPECT_LE(offset, 127);
+            if (offset < -128 || offset > 127) {
+                return output;
+            }
+            output[patch.operandOffset] = static_cast<uint8_t>(static_cast<int8_t>(offset));
+        }
+
+        return output;
+    }
+
+private:
+    struct AbsolutePatch {
+        size_t operandOffset = 0;
+        std::string label;
+    };
+
+    struct RelativePatch {
+        size_t operandOffset = 0;
+        std::string label;
+    };
+
+    static uint8_t highByte(uint16_t value) { return static_cast<uint8_t>(value >> 8); }
+    static uint8_t lowByte(uint16_t value) { return static_cast<uint8_t>(value & 0xFFu); }
+
+    uint16_t pc() const { return kProgramStart + static_cast<uint16_t>(bytes_.size()); }
+
+    std::vector<uint8_t> bytes_;
+    std::map<std::string, uint16_t, std::less<>> labels_;
+    std::vector<AbsolutePatch> unresolvedAbsolute_;
+    std::vector<RelativePatch> unresolvedRelative_;
+};
+
+std::array<uint8_t, 32> buildPaletteData()
+{
+    std::array<uint8_t, 32> palette{};
+    palette.fill(0x0Fu);
+    palette[0x01] = 0x01u;
+    palette[0x11] = kSpritePaletteIndex;
+    return palette;
+}
+
+std::filesystem::path writeSpriteMaskTestRom(const char* stem, bool spritesEnabled)
+{
+    TestRomAssembler assembler;
+    assembler.bytes({ 0x78u, 0xD8u, 0xA2u, 0xFFu, 0x9Au });
+    assembler.ldaImmStaAbs(0x00u, 0x2000u);
+    assembler.ldaImmStaAbs(0x00u, 0x2001u);
+    assembler.ldaImmStaAbs(0x00u, kSpriteHitResultAddr);
+    assembler.ldaImmStaAbs(0x00u, 0x2003u);
+    assembler.ldaImmStaAbs(kSpriteOamY, 0x2004u);
+    assembler.ldaImmStaAbs(0x01u, 0x2004u);
+    assembler.ldaImmStaAbs(0x00u, 0x2004u);
+    assembler.ldaImmStaAbs(kSpriteScreenX, 0x2004u);
+    assembler.ldaImmStaAbs(0x3Fu, 0x2006u);
+    assembler.ldaImmStaAbs(0x00u, 0x2006u);
+    assembler.bytes({ 0xA2u, 0x00u });
+    assembler.label("paletteLoop");
+    assembler.ldaAbsXLabel("paletteData");
+    assembler.bytes({ 0x8Du, 0x07u, 0x20u, 0xE8u, 0xE0u, 0x20u });
+    assembler.branchToLabel(0xD0u, "paletteLoop");
+    assembler.ldaImmStaAbs(spritesEnabled ? 0x18u : 0x08u, 0x2001u);
+    assembler.label("waitNextVblank");
+    assembler.bytes({ 0x2Cu, 0x02u, 0x20u });
+    assembler.branchToLabel(0x10u, "waitNextVblank");
+    assembler.label("monitorFrame");
+    assembler.bytes({ 0x2Cu, 0x02u, 0x20u });
+    assembler.branchToLabel(0x70u, "spriteHit");
+    assembler.branchToLabel(0x30u, "noSpriteHit");
+    assembler.jmpLabel("monitorFrame");
+    assembler.label("spriteHit");
+    assembler.ldaImmStaAbs(0x01u, kSpriteHitResultAddr);
+    assembler.jmpLabel("done");
+    assembler.label("noSpriteHit");
+    assembler.ldaImmStaAbs(0x00u, kSpriteHitResultAddr);
+    assembler.jmpLabel("done");
+    assembler.label("done");
+    assembler.jmpLabel("done");
+    assembler.label("paletteData");
+    const auto palette = buildPaletteData();
+    for (uint8_t value : palette) {
+        assembler.bytes({ value });
+    }
+
+    std::vector<uint8_t> prg = assembler.build();
+    prg.resize(16u * 1024u, 0xEAu);
+    prg[0x3FFAu] = static_cast<uint8_t>(kProgramStart & 0xFFu);
+    prg[0x3FFBu] = static_cast<uint8_t>(kProgramStart >> 8);
+    prg[0x3FFCu] = static_cast<uint8_t>(kProgramStart & 0xFFu);
+    prg[0x3FFDu] = static_cast<uint8_t>(kProgramStart >> 8);
+    prg[0x3FFEu] = static_cast<uint8_t>(kProgramStart & 0xFFu);
+    prg[0x3FFFu] = static_cast<uint8_t>(kProgramStart >> 8);
+
+    std::vector<uint8_t> chr(8u * 1024u, 0x00u);
+    for (int row = 0; row < 8; ++row) {
+        chr[row] = 0xFFu;
+        chr[16u + static_cast<size_t>(row)] = 0xFFu;
+    }
+
+    const std::filesystem::path romPath =
+        std::filesystem::path(::testing::TempDir()) / (std::string(stem) + ".nes");
+    std::ofstream stream(romPath, std::ios::binary | std::ios::trunc);
+    EXPECT_TRUE(stream.is_open());
+
+    const std::array<uint8_t, 16> header = {
+        'N',   'E',   'S',   0x1A,  0x01u, 0x01u, 0x00u, 0x00u,
+        0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u,
+    };
+    stream.write(
+        reinterpret_cast<const char*>(header.data()), static_cast<std::streamsize>(header.size()));
+    stream.write(
+        reinterpret_cast<const char*>(prg.data()), static_cast<std::streamsize>(prg.size()));
+    stream.write(
+        reinterpret_cast<const char*>(chr.data()), static_cast<std::streamsize>(chr.size()));
+    EXPECT_TRUE(stream.good());
+    return romPath;
+}
+
+struct SpriteMaskObservation {
+    bool sawSpritePalette = false;
+    uint8_t spriteHitResult = 0u;
+};
+
+SpriteMaskObservation runSpriteMaskRom(const std::filesystem::path& romPath)
+{
+    SmolnesRuntime runtime;
+    if (!runtime.start(romPath.string())) {
+        ADD_FAILURE() << "Failed to start runtime for " << romPath;
+        return {};
+    }
+    runtime.setApuEnabled(false);
+    if (!runtime.runFrames(3u, 2000u)) {
+        ADD_FAILURE() << "Failed to run frames for " << romPath << ": " << runtime.getLastError();
+        runtime.stop();
+        return {};
+    }
+
+    const auto paletteFrame = runtime.copyLatestPaletteFrame();
+    if (!paletteFrame.has_value()) {
+        ADD_FAILURE() << "Missing palette frame for " << romPath;
+        runtime.stop();
+        return {};
+    }
+    const auto memorySnapshot = runtime.copyMemorySnapshot();
+    if (!memorySnapshot.has_value()) {
+        ADD_FAILURE() << "Missing memory snapshot for " << romPath;
+        runtime.stop();
+        return {};
+    }
+    runtime.stop();
+
+    EXPECT_LT(static_cast<size_t>(kSpriteHitResultAddr), memorySnapshot->cpuRam.size());
+
+    return SpriteMaskObservation{
+        .sawSpritePalette =
+            std::find(
+                paletteFrame->indices.begin(), paletteFrame->indices.end(), kSpritePaletteIndex)
+            != paletteFrame->indices.end(),
+        .spriteHitResult = memorySnapshot->cpuRam[kSpriteHitResultAddr],
+    };
+}
+
+} // namespace
+
+TEST(SmolnesRuntimeTest, SpriteMaskDisablesSpritePixelsAndSpriteZeroHit)
+{
+    const std::filesystem::path spritesDisabledRom =
+        writeSpriteMaskTestRom("smolnes_sprite_mask_disabled", false);
+    const std::filesystem::path spritesEnabledRom =
+        writeSpriteMaskTestRom("smolnes_sprite_mask_enabled", true);
+
+    const SpriteMaskObservation spritesDisabled = runSpriteMaskRom(spritesDisabledRom);
+    const SpriteMaskObservation spritesEnabled = runSpriteMaskRom(spritesEnabledRom);
+
+    EXPECT_FALSE(spritesDisabled.sawSpritePalette);
+    EXPECT_EQ(spritesDisabled.spriteHitResult, 0u);
+    EXPECT_TRUE(spritesEnabled.sawSpritePalette);
+    EXPECT_EQ(spritesEnabled.spriteHitResult, 1u);
+}

--- a/apps/src/server/evolution/EvaluationExecutor.cpp
+++ b/apps/src/server/evolution/EvaluationExecutor.cpp
@@ -260,6 +260,7 @@ std::optional<EvaluationPassResult> runEvaluationPass(
         .brainRegistry = brainRegistry,
         .duckClockSpawnLeftFirst = duckClockSpawnLeftFirst,
         .duckClockSpawnRngSeed = std::nullopt,
+        .nesRgbaOutputEnabled = visibleHandle != nullptr,
         .scenarioConfigOverride = scenarioConfigOverride,
     };
     TrainingRunner runner(

--- a/apps/src/server/tests/EvaluationExecutor_test.cpp
+++ b/apps/src/server/tests/EvaluationExecutor_test.cpp
@@ -4,12 +4,15 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/scenarios/tests/NesTestRomPath.h"
 #include "server/evolution/EvaluationExecutor.h"
 #include "server/evolution/FitnessModelBundle.h"
 #include "server/tests/TestStateMachineFixture.h"
 
+#include <algorithm>
 #include <chrono>
 #include <gtest/gtest.h>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -482,4 +485,94 @@ TEST(EvaluationExecutorTest, BackgroundEvaluationsDoNotCompleteWhilePaused)
     }
 
     EXPECT_EQ(completedAfterResume, 2);
+}
+
+TEST(EvaluationExecutorTest, NesVisibleEvaluationProducesNonEmptyVideoFrame)
+{
+    const auto romPath = DirtSim::Test::resolveFlappyRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing for NES visible evaluation test.";
+    }
+
+    TestStateMachineFixture fixture;
+
+    TrainingSpec trainingSpec;
+    trainingSpec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    trainingSpec.organismType = OrganismType::NES_DUCK;
+    PopulationSpec population;
+    population.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
+    population.count = 1;
+    population.randomCount = 1;
+    trainingSpec.population.push_back(population);
+
+    EvaluationExecutor executor =
+        makeExecutor(trainingSpec, fixture.stateMachine->getGenomeRepository());
+    const EvolutionConfig evolutionConfig = makeEvolutionConfig(1, 1.0);
+
+    Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
+        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
+    nesConfig.romPath = romPath.value().string();
+    nesConfig.requireSmolnesMapper = true;
+
+    std::mt19937 rng(42);
+    const std::vector<EvaluationRequest> requests{
+        EvaluationRequest{
+            .taskType = EvaluationTaskType::GenerationEval,
+            .index = 0,
+            .individual =
+                EvaluationIndividual{
+                    .brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2,
+                    .brainVariant = std::nullopt,
+                    .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+                    .genome = DuckNeuralNetRecurrentBrainV2::randomGenome(rng),
+                },
+        },
+    };
+
+    executor.start(1);
+    executor.generationBatchSubmit(requests, evolutionConfig, ScenarioConfig{ nesConfig });
+
+    std::optional<VisibleRenderFrame> frame;
+    std::optional<uint64_t> lastFrameId = std::nullopt;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline && !frame.has_value()) {
+        const auto tick = executor.visibleTick(std::chrono::steady_clock::now(), 0);
+        if (tick.frame.has_value() && tick.frame->scenarioVideoFrame.has_value()) {
+            const auto& candidate = tick.frame->scenarioVideoFrame.value();
+            lastFrameId = candidate.frame_id;
+            const bool allZero =
+                std::all_of(candidate.pixels.begin(), candidate.pixels.end(), [](std::byte b) {
+                    return b == std::byte{ 0 };
+                });
+            if (!allZero) {
+                frame = tick.frame;
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ASSERT_TRUE(frame.has_value())
+        << "No non-zero visible frame produced within timeout. Last frame_id="
+        << lastFrameId.value_or(0);
+    ASSERT_TRUE(frame->scenarioVideoFrame.has_value())
+        << "Visible frame missing ScenarioVideoFrame.";
+
+    const auto& videoFrame = frame->scenarioVideoFrame.value();
+    fprintf(
+        stderr,
+        "NES visible frame: %ux%u, frame_id=%lu, pixels=%zu bytes\n",
+        videoFrame.width,
+        videoFrame.height,
+        static_cast<unsigned long>(videoFrame.frame_id),
+        videoFrame.pixels.size());
+    EXPECT_GT(videoFrame.width, 0);
+    EXPECT_GT(videoFrame.height, 0);
+    EXPECT_FALSE(videoFrame.pixels.empty()) << "ScenarioVideoFrame has no pixel data.";
+
+    const bool allZero =
+        std::all_of(videoFrame.pixels.begin(), videoFrame.pixels.end(), [](std::byte b) {
+            return b == std::byte{ 0 };
+        });
+    EXPECT_FALSE(allZero) << "ScenarioVideoFrame pixels are all zero (RGBA output not working).";
 }


### PR DESCRIPTION
## Summary
- speed up NES training/runtime paths by disabling unused APU work for training and adding palette-only output where appropriate while preserving visible evaluation/best-playback behavior
- add a sampled SmolNES perf harness plus low-overhead phase and deferred-flush telemetry so PPU hot spots can be measured without dominating runtime
- optimize the SmolNES PPU hot path with visible-span batching, sprite-cache/background-loop cleanups, safe deferred visible spans, and a small non-visible batch, including a correctness fix for batched fetch sequencing
- add regression coverage for NES training/evaluation output paths and keep the SMB RAM-probe oracle green during the renderer changes

## Highlights
- `TrainingRunner`/evaluation plumbing now applies NES speed flags safely across setup/restart paths and keeps visible evaluation RGBA output enabled
- `SmolnesPpuPerformance_test` now covers profiled and throughput variants, phase breakdowns, and deferred flush reasons
- deferred visible-span flush telemetry shows SMB is now mostly limited by dot-256 boundaries and `$2002` polling rather than mapper writes or OAM DMA
- the batched fetch sequencing regression that caused SMB foreground tile streaking was fixed before landing the renderer work

## Representative Release Perf
From the current `NesRoms/SmolnesPpuPerformance` release run on this branch:
- `SuperMarioBros_Profiled`: wall `404.4 ms`, frame execution `381.4 ms`
  - CPU `116.5 ms` (`30.5%`)
  - APU `109.3 ms` (`28.7%`)
  - PPU `155.5 ms` (`40.8%`)
  - PPU visible pixels `75.9 ms`, post-visible `29.0 ms`, prefetch `23.7 ms`
- `SuperMarioBros_Profiled_NoApu_PaletteOnly`: wall `281.0 ms`, frame execution `269.1 ms`
  - CPU `115.5 ms`
  - PPU `153.6 ms`
- `SuperMarioBros_Throughput_NoApu_PaletteOnly`: wall `262.8 ms / 1000 frames` (`3804.8 fps`)

## Testing
- `cd apps && ./build-release/bin/dirtsim-tests-diagnostic --gtest_filter='NesRoms/SmolnesPpuPerformance*'`
- `cd apps && ./build-release/bin/dirtsim-tests --gtest_filter='NesSmolnesScenarioDriverTest.*:TrainingRunnerTest.Nes*:EvaluationExecutorTest.NesVisibleEvaluationProducesNonEmptyVideoFrame'`
- `cd apps && ./build-release/bin/dirtsim-tests --gtest_filter='NesSuperMarioBrosRamProbeTest.ScriptedBaseline_EnemyWindowsMatchGoombaProgression'`
