### PR TITLE
Add self-view coordinates to duck sensory input

### DIFF
--- a/apps/src/core/organisms/Duck.cpp
+++ b/apps/src/core/organisms/Duck.cpp
@@ -47,6 +47,15 @@ static constexpr float SPARKLE_GRAVITY = 20.0f;        // Gravity acceleration (
 static constexpr float SPARKLE_BOUNCE = 0.7f;          // Velocity retained after bounce (0-1).
 static constexpr float MOVE_INPUT_DEADZONE = 0.01f;    // Ignore tiny input as no movement.
 
+double normalizeFrameCoordinate(double position, double origin, double extent)
+{
+    if (extent <= 0.0) {
+        return 0.5;
+    }
+
+    return std::clamp((position - origin) / extent, 0.0, 1.0);
+}
+
 std::string duckCommandSignature(const DirtSim::DuckInput& input, bool onGround)
 {
     std::string signature;
@@ -661,9 +670,24 @@ DuckSensoryData Duck::gatherSensoryData(const World& world, double deltaTime) co
     const WorldData& world_data = world.getData();
     if (world_data.inBounds(anchor_cell_.x, anchor_cell_.y)) {
         const Cell& cell = world_data.at(anchor_cell_.x, anchor_cell_.y);
+        const double duckWorldX =
+            static_cast<double>(anchor_cell_.x) + ((static_cast<double>(cell.com.x) + 1.0) / 2.0);
+        const double duckWorldY =
+            static_cast<double>(anchor_cell_.y) + ((static_cast<double>(cell.com.y) + 1.0) / 2.0);
+
+        data.self_view_x = static_cast<float>(normalizeFrameCoordinate(
+            duckWorldX,
+            static_cast<double>(data.world_offset.x),
+            static_cast<double>(data.actual_width)));
+        data.self_view_y = static_cast<float>(normalizeFrameCoordinate(
+            duckWorldY,
+            static_cast<double>(data.world_offset.y),
+            static_cast<double>(data.actual_height)));
         data.velocity = cell.velocity;
     }
     else {
+        data.self_view_x = 0.5f;
+        data.self_view_y = 0.5f;
         data.velocity = Vector2d{ 0.0, 0.0 };
     }
 

--- a/apps/src/core/organisms/DuckSensoryData.h
+++ b/apps/src/core/organisms/DuckSensoryData.h
@@ -29,8 +29,13 @@ struct DuckSensoryData {
     double scale_factor = 1.0;
     Vector2i world_offset;
 
-    // Duck's current position in world coordinates.
+    // Coarse integer position in scenario coordinates.
+    // World ducks use anchor-cell coordinates; NES adapters typically pin this to view center.
     Vector2i position;
+
+    // Body reference point inside the current visual frame, normalized to [0,1].
+    float self_view_x = 0.5f;
+    float self_view_y = 0.5f;
 
     // Physics state.
     Vector2d velocity;
@@ -57,7 +62,7 @@ struct DuckSensoryData {
 
     double delta_time_seconds = 0.0;
 
-    using serialize = zpp::bits::members<17>;
+    using serialize = zpp::bits::members<19>;
 };
 
 void to_json(nlohmann::json& j, const DuckSensoryData& data);

--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
@@ -19,7 +19,9 @@ constexpr int SPECIAL_SENSE_COUNT = DuckSensoryData::SPECIAL_SENSE_COUNT;
 
 constexpr int INPUT_HISTOGRAM_SIZE = GRID_SIZE * GRID_SIZE * NUM_MATERIALS;
 constexpr int CONTROL_FEEDBACK_INPUT_SIZE = 4;
-constexpr int SCALAR_INPUT_SIZE = 4 + CONTROL_FEEDBACK_INPUT_SIZE + SPECIAL_SENSE_COUNT + 2;
+constexpr int BODY_STATE_INPUT_SIZE = 6;
+constexpr int SCALAR_INPUT_SIZE =
+    BODY_STATE_INPUT_SIZE + CONTROL_FEEDBACK_INPUT_SIZE + SPECIAL_SENSE_COUNT + 2;
 constexpr int INPUT_SIZE = INPUT_HISTOGRAM_SIZE + SCALAR_INPUT_SIZE;
 constexpr int H1_SIZE = 64;
 constexpr int H2_SIZE = 32;
@@ -233,6 +235,8 @@ struct DuckNeuralNetRecurrentBrainV2::Impl {
         input_buffer[index++] =
             sensory.on_ground ? static_cast<WeightType>(1.0f) : static_cast<WeightType>(0.0f);
         input_buffer[index++] = static_cast<WeightType>(sensory.facing_x);
+        input_buffer[index++] = static_cast<WeightType>(sensory.self_view_x);
+        input_buffer[index++] = static_cast<WeightType>(sensory.self_view_y);
         input_buffer[index++] = static_cast<WeightType>(sensory.previous_control_x);
         input_buffer[index++] = static_cast<WeightType>(sensory.previous_control_y);
         input_buffer[index++] =

--- a/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
+++ b/apps/src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp
@@ -35,9 +35,10 @@ constexpr const char* kBenchmarkRepeatsEnv = "DIRTSIM_DUCK_RNN_BENCH_REPEATS";
 constexpr const char* kBenchmarkWarmupIterationsEnv = "DIRTSIM_DUCK_RNN_BENCH_WARMUP_ITERATIONS";
 constexpr int kInputHistogramSize =
     DuckSensoryData::GRID_SIZE * DuckSensoryData::GRID_SIZE * DuckSensoryData::NUM_MATERIALS;
+constexpr int kBodyStateInputSize = 6;
 constexpr int kControlFeedbackInputSize = 4;
-constexpr int kInputSize =
-    kInputHistogramSize + 4 + kControlFeedbackInputSize + DuckSensoryData::SPECIAL_SENSE_COUNT + 2;
+constexpr int kInputSize = kInputHistogramSize + kBodyStateInputSize + kControlFeedbackInputSize
+    + DuckSensoryData::SPECIAL_SENSE_COUNT + 2;
 constexpr int kH1Size = 64;
 constexpr int kH2Size = 32;
 constexpr int kOutputSize = 4;
@@ -57,7 +58,8 @@ constexpr float kStrongPositiveLogit = 4.0f;
 size_t energyInputIndex()
 {
     return static_cast<size_t>(
-        kInputHistogramSize + 4 + kControlFeedbackInputSize + DuckSensoryData::SPECIAL_SENSE_COUNT);
+        kInputHistogramSize + kBodyStateInputSize + kControlFeedbackInputSize
+        + DuckSensoryData::SPECIAL_SENSE_COUNT);
 }
 
 size_t wXh1Index(size_t inputIndex, size_t hiddenIndex)
@@ -261,6 +263,8 @@ DuckSensoryData makeBenchmarkSensory(const Duck& duck, const World& world)
     sensory.previous_control_y = -1.0f;
     sensory.previous_jump = true;
     sensory.previous_run = false;
+    sensory.self_view_x = 0.25f;
+    sensory.self_view_y = 0.75f;
     sensory.velocity = Vector2d{ 1.5, -0.75 };
     for (int i = 0; i < DuckSensoryData::SPECIAL_SENSE_COUNT; ++i) {
         sensory.special_senses[static_cast<size_t>(i)] = static_cast<double>((i % 7) - 3) / 3.0;
@@ -272,7 +276,8 @@ double consumeSensoryData(const DuckSensoryData& sensory)
 {
     constexpr int center = DuckSensoryData::GRID_SIZE / 2;
     return sensory.energy + sensory.health + sensory.facing_x + sensory.velocity.x
-        + sensory.velocity.y + sensory.previous_control_x + sensory.previous_control_y
+        + sensory.velocity.y + sensory.self_view_x + sensory.self_view_y
+        + sensory.previous_control_x + sensory.previous_control_y
         + (sensory.previous_jump ? 1.0 : 0.0) + (sensory.previous_run ? 1.0 : 0.0)
         + sensory.special_senses[0] + sensory.special_senses[7]
         + sensory.special_senses[DuckSensoryData::SPECIAL_SENSE_COUNT - 1]
@@ -399,7 +404,7 @@ TEST(DuckNeuralNetRecurrentBrainV2Test, GenomeLayoutUsesCoarseMutationDomains)
 
     ASSERT_EQ(layout.segments.size(), 5u);
     EXPECT_EQ(layout.segments[0].name, "input_h1");
-    EXPECT_EQ(layout.segments[0].size, 284928);
+    EXPECT_EQ(layout.segments[0].size, 285056);
     EXPECT_EQ(layout.segments[1].name, "h1_recurrent");
     EXPECT_EQ(layout.segments[1].size, 4225);
     EXPECT_EQ(layout.segments[2].name, "h1_to_h2");

--- a/apps/src/core/organisms/tests/OrganismSensoryData_test.cpp
+++ b/apps/src/core/organisms/tests/OrganismSensoryData_test.cpp
@@ -397,6 +397,36 @@ TEST(DuckSensoryDataTest, GatherSensoryDataIncludesPreviousAppliedControlChannel
     EXPECT_TRUE(sensory.previous_run);
 }
 
+TEST(DuckSensoryDataTest, GatherSensoryDataIncludesNormalizedSelfViewCoordinates)
+{
+    auto world = std::make_unique<World>(15, 15);
+    for (uint32_t y = 0; y < 15; y++) {
+        for (uint32_t x = 0; x < 15; x++) {
+            world->getData().at(x, y) = Cell();
+        }
+    }
+
+    const OrganismId duckId = world->getOrganismManager().createDuck(*world, 7, 12);
+    Duck* duck = world->getOrganismManager().getDuck(duckId);
+    ASSERT_NE(duck, nullptr);
+
+    const Vector2i anchor = duck->getAnchorCell();
+    world->getData().at(anchor.x, anchor.y).setCOM(0.5f, -0.5f);
+
+    const DuckSensoryData sensory = duck->gatherSensoryData(*world, 0.016);
+
+    const int halfWindow = DuckSensoryData::GRID_SIZE / 2;
+    const double expectedX =
+        (static_cast<double>(halfWindow) + ((static_cast<double>(0.5f) + 1.0) / 2.0))
+        / static_cast<double>(DuckSensoryData::GRID_SIZE);
+    const double expectedY =
+        (static_cast<double>(halfWindow) + ((static_cast<double>(-0.5f) + 1.0) / 2.0))
+        / static_cast<double>(DuckSensoryData::GRID_SIZE);
+
+    EXPECT_NEAR(sensory.self_view_x, expectedX, 1e-6);
+    EXPECT_NEAR(sensory.self_view_y, expectedY, 1e-6);
+}
+
 /**
  * Test that Duck::gatherSensoryData correctly samples environment.
  */

--- a/apps/src/core/scenarios/nes/NesDuckSensoryBuilder.cpp
+++ b/apps/src/core/scenarios/nes/NesDuckSensoryBuilder.cpp
@@ -108,6 +108,8 @@ DuckSensoryData makeNesDuckSensoryData(
     double deltaTimeSeconds,
     const std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT>& specialSenses,
     float facingX,
+    float selfViewX,
+    float selfViewY,
     uint8_t controllerMask)
 {
     DuckSensoryData sensory{};
@@ -117,6 +119,8 @@ DuckSensoryData makeNesDuckSensoryData(
     }
 
     sensory.facing_x = facingX;
+    sensory.self_view_x = selfViewX;
+    sensory.self_view_y = selfViewY;
     setPreviousControlFromControllerMask(sensory, controllerMask);
     sensory.special_senses = specialSenses;
     return sensory;

--- a/apps/src/core/scenarios/nes/NesDuckSensoryBuilder.h
+++ b/apps/src/core/scenarios/nes/NesDuckSensoryBuilder.h
@@ -17,6 +17,8 @@ DuckSensoryData makeNesDuckSensoryData(
     double deltaTimeSeconds,
     const std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT>& specialSenses,
     float facingX = 0.0f,
+    float selfViewX = 0.5f,
+    float selfViewY = 0.5f,
     uint8_t controllerMask = 0u);
 
 } // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesFlappyParatroopaGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesFlappyParatroopaGameAdapter.cpp
@@ -10,6 +10,9 @@
 namespace DirtSim {
 
 namespace {
+constexpr float kFlappyBirdCenterXPx = 64.0f;
+constexpr float kFlappyFrameHeightPx = 240.0f;
+constexpr float kFlappyFrameWidthPx = 256.0f;
 constexpr uint8_t kNesStateTitle = 0;
 constexpr uint8_t kNesStateWaiting = 1;
 constexpr uint8_t kNesStateGameOver = 7;
@@ -31,6 +34,20 @@ constexpr size_t kFlappyFeatureBirdVelocityNormalized = 2;
 constexpr size_t kFlappyFeatureScrollXNormalized = 7;
 constexpr size_t kFlappyFeatureScrollNt = 8;
 constexpr size_t kFlappyFeatureScoreNormalized = 10;
+
+float computeFlappyBirdCenterYPx(const NesFlappyBirdState& state)
+{
+    return state.birdY + 8.0f + (state.birdYFraction / 256.0f);
+}
+
+float normalizeViewCoordinate(float value, float extent)
+{
+    if (extent <= 0.0f) {
+        return 0.5f;
+    }
+
+    return std::clamp(value / extent, 0.0f, 1.0f);
+}
 
 std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> makeFlappySpecialSenses(
     const std::array<float, NesPolicyLayout::InputCount>& ramFeatures)
@@ -61,6 +78,8 @@ public:
         startPulseFrameCounter_ = 0;
         waitingFlapPulseFrameCounter_ = 0;
         cachedSpecialSenses_.fill(0.0);
+        cachedSelfViewX_ = 0.5f;
+        cachedSelfViewY_ = 0.5f;
     }
 
     NesGameAdapterControllerOutput resolveControllerMask(
@@ -101,6 +120,8 @@ public:
         }
 
         cachedSpecialSenses_.fill(0.0);
+        cachedSelfViewX_ = 0.5f;
+        cachedSelfViewY_ = 0.5f;
 
         NesGameAdapterFrameOutput output;
         if (!extractor_.has_value() || !evaluator_.has_value() || !extractor_->isSupported()) {
@@ -121,6 +142,9 @@ public:
         const NesFlappyBirdEvaluatorOutput evaluation =
             evaluator_->evaluate(evaluatorInput.value());
         cachedSpecialSenses_ = makeFlappySpecialSenses(evaluation.features);
+        cachedSelfViewX_ = normalizeViewCoordinate(kFlappyBirdCenterXPx, kFlappyFrameWidthPx);
+        cachedSelfViewY_ = normalizeViewCoordinate(
+            computeFlappyBirdCenterYPx(evaluatorInput->state), kFlappyFrameHeightPx);
         output.done = evaluation.done;
         output.gameState = evaluation.gameState;
         output.rewardDelta = evaluation.rewardDelta;
@@ -135,6 +159,8 @@ public:
             input.deltaTimeSeconds,
             cachedSpecialSenses_,
             0.0f,
+            cachedSelfViewX_,
+            cachedSelfViewY_,
             input.controllerMask);
     }
 
@@ -145,6 +171,8 @@ private:
     uint32_t startPulseFrameCounter_ = 0;
     uint32_t waitingFlapPulseFrameCounter_ = 0;
     std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> cachedSpecialSenses_{};
+    float cachedSelfViewX_ = 0.5f;
+    float cachedSelfViewY_ = 0.5f;
 };
 
 } // namespace

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
@@ -14,6 +14,9 @@ namespace DirtSim {
 
 namespace {
 
+constexpr double kNesFrameHeight = 240.0;
+constexpr double kNesFrameWidth = 256.0;
+
 double normalizeSmb(double value, double maxValue)
 {
     return std::clamp(value / maxValue, 0.0, 1.0);
@@ -22,6 +25,15 @@ double normalizeSmb(double value, double maxValue)
 double normalizeSmbSigned(double value, double maxMagnitude)
 {
     return std::clamp(value / maxMagnitude, -1.0, 1.0);
+}
+
+float normalizeViewCoordinate(double value, double extent)
+{
+    if (extent <= 0.0) {
+        return 0.5f;
+    }
+
+    return static_cast<float>(std::clamp(value / extent, 0.0, 1.0));
 }
 
 std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> makeSmbSpecialSenses(
@@ -98,6 +110,8 @@ public:
         advancedFrameCount_ += input.advancedFrames;
         cachedFacingX_ = 0.0f;
         cachedSpecialSenses_.fill(0.0);
+        cachedSelfViewX_ = 0.5f;
+        cachedSelfViewY_ = 0.5f;
 
         NesGameAdapterFrameOutput output;
         if (!input.memorySnapshot.has_value()) {
@@ -142,6 +156,10 @@ public:
         if (state.phase == SmbPhase::Gameplay) {
             cachedFacingX_ = state.facingX;
             cachedSpecialSenses_ = makeSmbSpecialSenses(state);
+            cachedSelfViewX_ =
+                normalizeViewCoordinate(static_cast<double>(state.playerXScreen), kNesFrameWidth);
+            cachedSelfViewY_ =
+                normalizeViewCoordinate(static_cast<double>(state.playerYScreen), kNesFrameHeight);
         }
 
         const NesSuperMarioBrosEvaluatorInput evaluatorInput{
@@ -163,6 +181,8 @@ public:
             input.deltaTimeSeconds,
             cachedSpecialSenses_,
             cachedFacingX_,
+            cachedSelfViewX_,
+            cachedSelfViewY_,
             input.controllerMask);
     }
 
@@ -173,6 +193,8 @@ private:
     uint64_t advancedFrameCount_ = 0;
     std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> cachedSpecialSenses_{};
     float cachedFacingX_ = 0.0f;
+    float cachedSelfViewX_ = 0.5f;
+    float cachedSelfViewY_ = 0.5f;
     bool setupFailureLogged_ = false;
 };
 

--- a/apps/src/core/scenarios/nes/NesSuperTiltBroGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperTiltBroGameAdapter.cpp
@@ -49,6 +49,8 @@ public:
         lastPlayerAStocks_.reset();
         lastPlayerBStocks_.reset();
         cachedSpecialSenses_.fill(0.0);
+        cachedSelfViewX_ = 0.5f;
+        cachedSelfViewY_ = 0.5f;
     }
 
     NesGameAdapterControllerOutput resolveControllerMask(
@@ -74,6 +76,8 @@ public:
 
         advancedFrameCount_ += input.advancedFrames;
         cachedSpecialSenses_.fill(0.0);
+        cachedSelfViewX_ = 0.5f;
+        cachedSelfViewY_ = 0.5f;
 
         NesGameAdapterFrameOutput output;
         output.rewardDelta += static_cast<double>(input.advancedFrames);
@@ -154,6 +158,8 @@ public:
             input.deltaTimeSeconds,
             cachedSpecialSenses_,
             0.0f,
+            cachedSelfViewX_,
+            cachedSelfViewY_,
             input.controllerMask);
     }
 
@@ -183,6 +189,8 @@ private:
     std::optional<uint8_t> lastPlayerAStocks_ = std::nullopt;
     std::optional<uint8_t> lastPlayerBStocks_ = std::nullopt;
     std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> cachedSpecialSenses_{};
+    float cachedSelfViewX_ = 0.5f;
+    float cachedSelfViewY_ = 0.5f;
 };
 
 } // namespace

--- a/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
+++ b/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
@@ -166,6 +166,8 @@ TEST(NesGameAdapterSpecialSensesTest, FlappyAdapterExposesCuratedSpecialSenses)
     EXPECT_NEAR(sensory.special_senses[1], static_cast<double>(birdVelNorm), 1e-6);
     EXPECT_NEAR(sensory.special_senses[2], static_cast<double>(scoreNorm), 1e-6);
     EXPECT_NEAR(sensory.special_senses[3], progress, 1e-6);
+    EXPECT_NEAR(sensory.self_view_x, 64.0 / 256.0, 1e-6);
+    EXPECT_NEAR(sensory.self_view_y, (100.0 + 8.0) / 240.0, 1e-6);
 }
 
 TEST(NesGameAdapterSpecialSensesTest, SuperTiltBroAdapterExposesCuratedSpecialSenses)
@@ -195,6 +197,8 @@ TEST(NesGameAdapterSpecialSensesTest, SuperTiltBroAdapterExposesCuratedSpecialSe
     EXPECT_NEAR(sensory.special_senses[1], 1.0 / 5.0, 1e-6);
     EXPECT_NEAR(sensory.special_senses[2], 64.0 / 255.0, 1e-6);
     EXPECT_NEAR(sensory.special_senses[3], 200.0 / 255.0, 1e-6);
+    EXPECT_NEAR(sensory.self_view_x, 0.5, 1e-6);
+    EXPECT_NEAR(sensory.self_view_y, 0.5, 1e-6);
 }
 
 TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesCuratedSpecialSenses)
@@ -258,6 +262,8 @@ TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesCuratedSpecial
     EXPECT_NEAR(sensory.special_senses[15], 1.0 / 7.0, 1e-6);
     EXPECT_NEAR(sensory.special_senses[16], 2.0 / 3.0, 1e-6);
     EXPECT_NEAR(sensory.special_senses[17], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.self_view_x, 128.0 / 256.0, 1e-6);
+    EXPECT_NEAR(sensory.self_view_y, 120.0 / 240.0, 1e-6);
 
     for (int i = 18; i < DuckSensoryData::SPECIAL_SENSE_COUNT; ++i) {
         EXPECT_EQ(sensory.special_senses[i], 0.0) << "slot " << i << " should be zero";


### PR DESCRIPTION
## Summary
- add generic `self_view_x` and `self_view_y` fields to `DuckSensoryData`
- populate them from anchor+COM for world ducks and from screen-space body position for NES adapters
- feed the new coordinates into `DuckNeuralNetRecurrentBrainV2` and update the related tests and layout expectations

## Notes
- this is a stacked PR on top of #142
- the recurrent input layout changes, so existing duck RNN v2 genomes are not compatible and should be retrained
- Super Tilt Bro currently defaults `self_view_x/y` to `0.5` because that adapter does not expose player coordinates yet

## Testing
- `cd apps && make test ARGS='--gtest_filter=DuckSensoryDataTest.*:NesGameAdapterSpecialSensesTest.*:DuckNeuralNetRecurrentBrainV2Test.GenomeRoundTripPreservesWeights:DuckNeuralNetRecurrentBrainV2Test.GenomeCompatibilityRejectsWrongSize:DuckNeuralNetRecurrentBrainV2Test.GenomeLayoutMatchesRandomGenomeSize:DuckNeuralNetRecurrentBrainV2Test.GenomeLayoutUsesCoarseMutationDomains:DuckNeuralNetRecurrentBrainV2Test.NegativeSignalPropagatesThroughBothHiddenLayers'`