### PR TITLE
Nes tile embedding brain

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -453,6 +453,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
+    src/core/scenarios/nes/NesTileSensoryBuilder.cpp
     src/core/scenarios/nes/NesTileSensoryData.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
@@ -963,6 +964,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp
     src/core/scenarios/tests/NesTileSensoryData_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -457,6 +457,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesTileSensoryBuilder.cpp
     src/core/scenarios/nes/NesTileSensoryData.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
+    src/core/scenarios/nes/NesTileTokenizerBootstrapper.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
     src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
@@ -970,6 +971,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp
     src/core/scenarios/tests/NesTileSensoryData_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp
+    src/core/scenarios/tests/NesTileTokenizerBootstrapper_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp
     src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -451,6 +451,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseProbe.cpp
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
+    src/core/scenarios/nes/NesTileFrame.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
     src/core/scenarios/nes/NesRamProbe.cpp
     src/core/scenarios/nes/NesRomValidation.cpp
@@ -956,6 +957,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesGameAdapterRegistry_test.cpp
     src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
+    src/core/scenarios/tests/NesTileFrame_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp
     src/core/scenarios/tests/NesSmolnesScenarioDriver_test.cpp
     src/core/scenarios/tests/NesSuperMarioBrosEvaluator_test.cpp
@@ -1064,6 +1066,7 @@ target_compile_options(dirtsim-tests-slow-physics PRIVATE ${DIRTSIM_WARNINGS})
 add_executable(dirtsim-tests-diagnostic
     src/tests/DiagonalWaterLeveling_test.cpp
     src/core/scenarios/tests/NesSuperMarioBrosRamProbe_test.cpp
+    src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
     src/core/scenarios/tests/SmolnesPpuPerformance_test.cpp
     src/core/organisms/tests/DuckHealth_test.cpp
     src/core/organisms/tests/DuckNeuralNetRecurrentBrainV2_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -453,6 +453,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
+    src/core/scenarios/nes/NesTileRecurrentBrain.cpp
     src/core/scenarios/nes/NesTileSensoryBuilder.cpp
     src/core/scenarios/nes/NesTileSensoryData.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
@@ -964,6 +965,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
     src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp
     src/core/scenarios/tests/NesTileSensoryData_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -453,6 +453,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesSuperMarioBrosTilePosition.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
+    src/core/scenarios/nes/NesTileBrainMetadata.cpp
     src/core/scenarios/nes/NesTileDebugRenderer.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
     src/core/scenarios/nes/NesTileRecurrentBrain.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -453,6 +453,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
+    src/core/scenarios/nes/NesTileSensoryData.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
@@ -962,6 +963,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileSensoryData_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -451,7 +451,9 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseProbe.cpp
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
+    src/core/scenarios/nes/NesSuperMarioBrosTilePosition.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
+    src/core/scenarios/nes/NesTileDebugRenderer.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
     src/core/scenarios/nes/NesTileRecurrentBrain.cpp
     src/core/scenarios/nes/NesTileSensoryBuilder.cpp
@@ -966,6 +968,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileDebugRenderer_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
     src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
     src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -452,6 +452,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
+    src/core/scenarios/nes/NesTileTokenizer.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
     src/core/scenarios/nes/NesRamProbe.cpp
     src/core/scenarios/nes/NesRomValidation.cpp
@@ -958,6 +959,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileTokenizer_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp
     src/core/scenarios/tests/NesSmolnesScenarioDriver_test.cpp
     src/core/scenarios/tests/NesSuperMarioBrosEvaluator_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -451,6 +451,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseProbe.cpp
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
+    src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
@@ -959,6 +960,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesGameAdapterRegistry_test.cpp
     src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
+    src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -452,6 +452,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
     src/core/scenarios/nes/NesTileFrame.cpp
+    src/core/scenarios/nes/NesTileTokenFrame.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
     src/core/scenarios/nes/NesRamProbe.cpp
@@ -959,6 +960,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
     src/core/scenarios/tests/NesPaletteClusterer_test.cpp
     src/core/scenarios/tests/NesTileFrame_test.cpp
+    src/core/scenarios/tests/NesTileTokenFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp
     src/core/scenarios/tests/NesSmolnesScenarioDriver_test.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -458,6 +458,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesTileSensoryData.cpp
     src/core/scenarios/nes/NesTileTokenFrame.cpp
     src/core/scenarios/nes/NesTileTokenizer.cpp
+    src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
     src/core/scenarios/nes/NesPaletteClusterer.cpp
     src/core/scenarios/nes/NesRamProbe.cpp
     src/core/scenarios/nes/NesRomValidation.cpp
@@ -970,6 +971,7 @@ add_executable(dirtsim-tests
     src/core/scenarios/tests/NesTileSensoryData_test.cpp
     src/core/scenarios/tests/NesTileTokenFrame_test.cpp
     src/core/scenarios/tests/NesTileTokenizer_test.cpp
+    src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
     src/core/scenarios/tests/NesRamProbe_test.cpp
     src/core/scenarios/tests/NesSmolnesScenarioDriver_test.cpp
     src/core/scenarios/tests/NesSuperMarioBrosEvaluator_test.cpp

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -246,13 +246,19 @@ the 896 visible tile positions.
   tile tokens using a persistent tokenizer.
 - Added `NesPlayerRelativeTileFrame`, which maps the visible 32x28 token frame into a
   lossless 63x55 player-relative token frame.
+- Added `NesTileSensoryBuilder`, which composes tile extraction, deterministic tokenization,
+  player-relative remapping, controller feedback, and scalar fields into `NesTileSensoryData`.
+- Added a `NesGameAdapter` tile-sensory input seam so game-specific RAM-derived player
+  position and scalar fields can be reused by tile observations.
 - Added `NesTileSensoryData`, a NES-only sensory container that carries tile visuals and
   scalar/controller/RAM inputs without carrying the legacy palette histogram grid.
 - Extracted a shared `ControllerOutput` type so the existing palette RNN and the planned
   NES tile RNN can return the same controller-shaped output.
 - Added focused unit tests for tile extraction, deterministic tokenization, token-frame
-  conversion, lossless player-relative remapping, and NES tile sensory scalar/controller
-  fields.
+  conversion, lossless player-relative remapping, NES tile sensory construction, and NES tile
+  sensory scalar/controller fields.
+- Added adapter-level tests proving SMB RAM-derived player position and scalar fields can feed
+  the tile sensory builder.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -268,6 +268,15 @@ the 896 visible tile positions.
   `ControllerOutput` to NES controller bits.
 - Added the NES tile sensory inference path, which builds `NesTileSensoryData` from the latest
   PPU snapshot and fails loudly unless a frozen tile tokenizer is supplied.
+- Handled the NES runtime's first pre-snapshot frame by issuing an idle input until the first PPU
+  snapshot exists, while still failing loudly on tokenizer misconfiguration.
+- Added `NesTileVocabularyBuilder`, which builds and freezes deterministic tile tokenizers from
+  sampled `NesTileFrame` or `NesPpuSnapshot` data.
+- Wired `EvaluationExecutor` to bootstrap one shared frozen tile tokenizer for queued
+  `NesTileRecurrent` generation and robustness evaluations, then pass it into each
+  `TrainingRunner`.
+- Added a ROM-gated executor test proving the tile brain advances through the normal visible
+  evaluation path without manual tokenizer injection.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -301,26 +310,27 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Add a training/evaluation vocabulary bootstrap step. The tile brain now requires a frozen
-tokenizer at inference time, but callers still need a deterministic way to build that tokenizer
-before running a NES tile-brain evaluation.
+Make `NesTileRecurrent` selectable and playable through the normal NES training state. The executor
+can now run tile-brain evaluation requests, but the state/UI path and best-playback path still need
+to construct tile-brain requests and supply compatible tokenizer bootstrap.
 
 Planned pieces:
 
-- Introduce a reusable NES tile vocabulary builder that samples one or more NES PPU snapshots and
-  populates `NesTileTokenizer` deterministically.
-- Freeze the tokenizer before passing it into `TrainingRunner`.
-- Keep tokenizer ownership outside `TrainingRunner` so a training run can reuse the same token IDs
-  across all individuals and generations.
+- Expose `NesTileRecurrent` as a NES brain choice while keeping the palette RNN v2 path available
+  for comparison.
+- Ensure best-playback runners for tile-brain genomes bootstrap or reuse a frozen tokenizer before
+  constructing `TrainingRunner`.
+- Keep brain input/output metadata reusable so future NES brain variants can share controller
+  outputs and typed sensory containers where appropriate.
 - Preserve the existing palette RNN v2 path for comparison runs.
 
 ### Tests For Next Step
 
-- Vocabulary bootstrap assigns deterministic token IDs from equivalent snapshot samples.
-- Vocabulary bootstrap freezes the tokenizer before it is used for tile-brain inference.
-- Tile-brain NES evaluation with a frozen tokenizer advances at least one real NES frame and
-  records inferred-controller telemetry.
-- Missing or unfrozen tokenizer configuration fails loudly before silent fallback can occur.
+- NES training setup can select `NesTileRecurrent` and generate evaluation requests with matching
+  genomes.
+- Best playback for a saved tile-brain NES genome advances at least one real NES frame with a
+  frozen tokenizer.
+- Palette RNN v2 remains selectable and does not create a tile tokenizer.
 - Existing palette RNN v2 NES tests continue to pass unchanged.
 
 ### Open Decisions

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -1,0 +1,236 @@
+# NES Tile Embedding Brain
+
+## Motivation
+
+The current RNN v2 brain observes the NES screen via palette-index histograms: each cell in
+a 21x21 grid holds a distribution over 10 color clusters. This works well when the palette
+is consistent (Mario beats 1-1), but fails when the game changes palettes (1-2 uses a
+different underground palette). The network learned to associate specific colors with terrain
+features, so a palette change breaks those associations.
+
+Tile data solves this. The NES PPU renders backgrounds from a 32x30 grid of tile IDs stored
+in nametable RAM. The actual tile graphics (8x8 pixel patterns) are stored in CHR ROM/RAM
+and are palette-independent. By hashing the CHR pattern bytes for each tile, we derive a
+token that represents what the tile looks like regardless of palette or CHR bank state. For
+SMB, pattern-hashed tile tokens remove palette dependence entirely while staying stable
+across any tile-ID remapping. More generally, they are invariant to palette and CHR bank
+remapping, though genuinely new CHR patterns still need training exposure.
+
+## NES Tile Architecture
+
+The PPU uses a fixed tile-based rendering pipeline. This is universal across all NES games.
+
+```
+Pattern Tables (CHR ROM/RAM)         Nametables (VRAM, 2KB)
+┌──────────────────────────┐         ┌────────────────────────────┐
+│ 256 tiles per bank       │         │ 32x30 grid of tile IDs     │
+│ 8x8 pixels, 2bpp each   │         │ Each byte = index into     │
+│ 16 bytes per tile        │◀────────│ pattern table              │
+│ Two banks (left/right)   │  lookup │                            │
+└──────────────────────────┘         │ + 64-byte attribute table  │
+                                     │   (palette per 2x2 group)  │
+                                     └────────────────────────────┘
+
+OAM (256 bytes)                      Scroll Registers
+┌──────────────────────────┐         ┌────────────────────────────┐
+│ 64 sprites, 4 bytes each │         │ V register (15-bit)        │
+│ Y, tile ID, attrs, X     │         │  - coarse X/Y scroll       │
+│ Player, enemies, items   │         │  - nametable select        │
+└──────────────────────────┘         │  - fine Y scroll           │
+                                     │ fine_x (3-bit)             │
+                                     └────────────────────────────┘
+```
+
+**What lives where for SMB:**
+- Ground, pipes, bricks, question blocks, stairs: nametable (background tiles).
+- Mario, enemies, mushrooms, fireballs: OAM (sprites).
+
+## Design
+
+### What Changes
+
+Replace the palette-histogram visual input (21x21x10 = 4,410 floats) with a tile-embedding
+visual input derived from the nametable.
+
+### What Stays the Same
+
+- RNN v2 hidden layers (H1=64, H2=32, recurrent with learned leak alpha).
+- Controller feedback inputs (previous control x/y, previous A/B).
+- Body state inputs (facing, self-view position, velocity, on_ground).
+- `special_senses[32]` for RAM-derived features (enemy proximity, speed, powerup, etc.).
+- Output layer (4 outputs: x, y, A, B).
+- Evolutionary training (genome = flat weight array, mutation-only).
+
+### Observation
+
+The visual observation is a 32x28 grid of tile tokens, derived from the nametable and
+pattern table.
+
+The visible NES screen is 256x224 pixels = 32x28 tiles. The nametable stores tile IDs for
+each position. Each tile ID is resolved through the current CHR bank state to its 16-byte
+pattern, then hashed to produce a stable token (see Tile Tokenization below). Using the
+scroll registers (V, fine_x) and the player's screen position from RAM, the grid is indexed
+relative to the player:
+
+```
+     Mario at tile column 16, tile row 20
+     ┌──────────────────────────────────────┐
+     │          32 columns                  │
+     │     ┌─────────┐                      │
+     │     │  Mario  │                      │
+     │     │ (16,20) │ 28 rows              │
+     │     └─────────┘                      │
+     │                                      │
+     └──────────────────────────────────────┘
+             ↓ re-index relative to Mario
+     ┌──────────────────────────────────────┐
+     │  column 0 = 16 tiles left of Mario  │
+     │  column 31 = 15 tiles right of Mario│
+     │  row 0 = 20 tiles above Mario       │
+     │  row 27 = 7 tiles below Mario       │
+     └──────────────────────────────────────┘
+```
+
+Tiles outside the nametable map to a reserved "void" token (token 0).
+
+### Tile Tokenization
+
+Raw tile IDs (0-255) are not used directly as tokens because they are unstable across CHR
+bank switches. Games using mappers with bank switching (MMC1, MMC3, etc.) can change which
+pattern data a tile ID points to at any time.
+
+Instead, each tile ID is resolved to its actual CHR pattern and hashed:
+
+```
+nametable tile ID
+    │
+    ▼ resolve through current CHR bank state
+16-byte CHR pattern (two 8-byte bitplanes)
+    │
+    ▼ hash
+tile token (0 to TILE_VOCAB_SIZE-1)
+    │
+    ▼ embedding lookup
+D-dimensional float vector
+```
+
+A typical NES game uses 100-300 visually unique tile patterns across all its CHR banks. A
+vocabulary of 512 entries covers any game comfortably. Token 0 is reserved for "void" (tiles
+outside the nametable).
+
+**Implementation:** Maintain a 256-entry remap table (`tile_id → token`) for the current
+bank state. Recompute it when CHR banks change (infrequent — level transitions, area
+changes). Per-frame cost is a single array lookup per tile position.
+
+### Tile Embedding
+
+Each tile token (0 to TILE_VOCAB_SIZE-1) is mapped to a D-dimensional float vector via a
+learned embedding table. The table is part of the genome and evolved alongside all other
+weights.
+
+```
+tile_embedding[TILE_VOCAB_SIZE][D]    (TILE_VOCAB_SIZE = 512, D = 4 initially)
+
+token 42  → [0.2, -0.8, 0.1, 0.5]   ← learned: "solid ground"
+token 187 → [0.3, -0.7, 0.0, 0.6]   ← learned: "also solid"
+token 3   → [-0.9, 0.4, 0.8, -0.2]  ← learned: "empty sky"
+```
+
+The network discovers tile semantics from training reward alone. No game-specific tile
+classification is needed. Because tokens are derived from CHR patterns, the same visual
+tile always gets the same token regardless of tile ID, CHR bank state, or palette.
+
+### Network Architecture
+
+```
+Tile tokens [28][32]
+    │
+    ▼ embedding lookup (tile_embedding[512][D])
+Embedded grid [28][32][D]
+    │
+    ▼ flatten
+Visual input (28 * 32 * D = 3,584 floats at D=4)
+    │
+    ├── + body state (6 floats)
+    ├── + control feedback (4 floats)
+    ├── + special_senses (32 floats)
+    ├── + energy, health (2 floats)
+    │
+    ▼
+Input buffer (3,628 floats)
+    │
+    ▼ W_xh1 (3,628 x 64) + W_h1h1 (64 x 64) + b_h1
+H1 state (64, recurrent, learned leak alpha, learned leaky ReLU)
+    │
+    ▼ W_h1h2 (64 x 32) + W_h2h2 (32 x 32) + b_h2
+H2 state (32, recurrent, learned leak alpha, learned leaky ReLU)
+    │
+    ▼ W_h2o (32 x 4) + b_o
+Output (4: x, y, A, B)
+```
+
+### Genome Layout
+
+The embedding table is a separate segment so mutation can target tile semantics independently
+from spatial connection weights.
+
+```cpp
+return GenomeLayout{
+    .segments = {
+        { "tile_embedding", TILE_VOCAB_SIZE * EMBED_DIM },
+        { "input_h1", EMBEDDED_INPUT_SIZE * H1_SIZE },
+        { "h1_recurrent", W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE + 1 },
+        { "h1_to_h2", W_H1H2_SIZE },
+        { "h2_recurrent", W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE + 1 },
+        { "output", W_H2O_SIZE + B_O_SIZE },
+    },
+};
+```
+
+### Parameter Count
+
+| Component | Current (V2) | Tile Embedding |
+|-----------|-------------|----------------|
+| Visual input | 4,410 (21x21x10 histogram) | 3,584 (32x28x4 embedded) |
+| Embedding table | -- | 2,048 (512 x 4) |
+| Scalar inputs | 44 | 44 |
+| W_xh1 | 285,056 (4,454 x 64) | 232,192 (3,628 x 64) |
+| Rest of network | ~7,494 | ~7,494 |
+| **Total genome** | **~292,550** | **~241,734** |
+
+## Enemies
+
+For v1, enemies are not represented in the tile map. Enemy information comes through the
+existing `special_senses` channel, which carries RAM-derived data including nearest enemy
+dx/dy, enemy presence flags, and other game-specific state from
+`NesSuperMarioBrosRamExtractor`.
+
+The tile map provides static terrain structure. The special senses provide dynamic actor
+information. The recurrent state lets the network integrate both over time.
+
+## Data Extraction
+
+The nametable data, CHR pattern data, scroll registers, and PPU control need to be exposed
+from the SmolNES runtime backend. These are existing global variables in `deobfuscated.c`.
+Extraction is a memcpy under the existing snapshot lock, alongside the current CPU RAM and
+palette frame copies.
+
+New runtime backend additions:
+- `vram[2048]`: nametable RAM (background tile IDs + attribute tables).
+- `chrrom` + `chr[8]` + `chrbits`: CHR pattern data and current bank mapping. Needed to
+  resolve tile IDs to their 16-byte patterns for hashing.
+- `V` (uint16_t): scroll position register.
+- `fine_x` (uint8_t): fine X scroll offset.
+- `ppuctrl` (uint8_t): pattern table selection, sprite size.
+
+The tile-ID-to-token remap table (256 entries) is computed from the CHR bank state. It can
+be recomputed whenever CHR banks change, or lazily rebuilt each frame (256 tile lookups +
+hashes is negligible). The per-frame observation then just indexes this table for each of
+the 896 visible tile positions.
+
+## Future Work
+
+### Sprite Overlay
+
+Add sprite occupancy and/or sprite tile embeddings to the spatial grid, giving the network
+direct spatial awareness of enemy positions rather than routing through special_senses.

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -254,11 +254,15 @@ the 896 visible tile positions.
   scalar/controller/RAM inputs without carrying the legacy palette histogram grid.
 - Extracted a shared `ControllerOutput` type so the existing palette RNN and the planned
   NES tile RNN can return the same controller-shaped output.
+- Added standalone `NesTileRecurrentBrain`, which consumes `NesTileSensoryData`, uses a
+  learned tile-embedding segment, and returns shared `ControllerOutput`.
 - Added focused unit tests for tile extraction, deterministic tokenization, token-frame
   conversion, lossless player-relative remapping, NES tile sensory construction, and NES tile
   sensory scalar/controller fields.
 - Added adapter-level tests proving SMB RAM-derived player position and scalar fields can feed
   the tile sensory builder.
+- Added focused unit tests for NES tile brain genome layout, random genome sizing,
+  compatibility checks, embedding lookup, and deterministic controller output.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -292,13 +296,13 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Add the NES-only recurrent tile brain that consumes `NesTileSensoryData`. This keeps
-non-NES scenarios on the existing `DuckSensoryData` and `DuckNeuralNetRecurrentBrainV2`
-path while allowing NES scenarios to use tile-specific inputs and genome layouts.
+Register and wire the NES-only recurrent tile brain so NES training can select it explicitly.
+This keeps non-NES scenarios on the existing `DuckSensoryData` and
+`DuckNeuralNetRecurrentBrainV2` path while allowing NES scenarios to use tile-specific inputs
+and genome layouts.
 
 Planned pieces:
 
-- Add a NES-only recurrent tile brain variant with an embedding-table genome segment.
 - Register the new brain kind separately in `TrainingBrainRegistry`.
 - Wire NES training to select the NES tile brain explicitly, without changing the existing
   palette RNN v2 brain.
@@ -306,15 +310,12 @@ Planned pieces:
 
 ### Tests For Next Step
 
-- Genome layout reports the expected named segments and total size.
-- Random genome generation exactly matches the layout size.
-- Incompatible genome sizes fail compatibility checks.
-- Token embedding lookup maps token 0 to the void embedding and non-zero tokens to their
-  expected embedding rows.
-- A hand-authored tiny genome produces deterministic controller outputs from a synthetic
-  NES tile observation.
 - NES training registry can construct the new brain kind without affecting existing brain
   kinds.
+- TrainingRunner can instantiate the tile brain for NES scenario-driven evaluation.
+- Tile-brain NES inference builds `NesTileSensoryData` from the latest PPU snapshot and adapter
+  builder input, then maps shared `ControllerOutput` to controller buttons.
+- Existing palette RNN v2 NES tests continue to pass unchanged.
 
 ### Open Decisions
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -246,6 +246,8 @@ the 896 visible tile positions.
   lossless 63x55 player-relative token frame.
 - Added `NesTileSensoryData`, a NES-only sensory container that carries tile visuals and
   scalar/controller/RAM inputs without carrying the legacy palette histogram grid.
+- Extracted a shared `ControllerOutput` type so the existing palette RNN and the planned
+  NES tile RNN can return the same controller-shaped output.
 - Added focused unit tests for tile extraction, tokenization, token-frame conversion,
   lossless player-relative remapping, and NES tile sensory scalar/controller fields.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -277,6 +277,12 @@ the 896 visible tile positions.
   `TrainingRunner`.
 - Added a ROM-gated executor test proving the tile brain advances through the normal visible
   evaluation path without manual tokenizer injection.
+- Extracted `NesTileTokenizerBootstrapper` so tokenizer bootstrap can be reused outside the
+  executor.
+- Wired best playback to bootstrap or reuse a frozen tile tokenizer for `NesTileRecurrent`
+  runners, and to rebuild it after scenario config changes.
+- Added a ROM-gated state test proving NES tile best playback advances through `Evolution::tick`
+  with a frozen tokenizer.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -310,16 +316,14 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Make `NesTileRecurrent` selectable and playable through the normal NES training state. The executor
-can now run tile-brain evaluation requests, but the state/UI path and best-playback path still need
-to construct tile-brain requests and supply compatible tokenizer bootstrap.
+Make `NesTileRecurrent` selectable through the normal NES training setup. The evaluator and
+best-playback paths can now run tile-brain requests, but the UI/state setup still defaults NES
+training to the palette RNN v2 path.
 
 Planned pieces:
 
 - Expose `NesTileRecurrent` as a NES brain choice while keeping the palette RNN v2 path available
   for comparison.
-- Ensure best-playback runners for tile-brain genomes bootstrap or reuse a frozen tokenizer before
-  constructing `TrainingRunner`.
 - Keep brain input/output metadata reusable so future NES brain variants can share controller
   outputs and typed sensory containers where appropriate.
 - Preserve the existing palette RNN v2 path for comparison runs.
@@ -328,8 +332,6 @@ Planned pieces:
 
 - NES training setup can select `NesTileRecurrent` and generate evaluation requests with matching
   genomes.
-- Best playback for a saved tile-brain NES genome advances at least one real NES frame with a
-  frozen tokenizer.
 - Palette RNN v2 remains selectable and does not create a tile tokenizer.
 - Existing palette RNN v2 NES tests continue to pass unchanged.
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -240,6 +240,8 @@ the 896 visible tile positions.
 - Added `NesTileFrame`, which extracts visible 32x28 background tile IDs, pattern hashes,
   and grayscale pattern pixels.
 - Added `NesTileTokenizer`, which maps stable tile-pattern hashes to bounded token IDs.
+- Extended `NesTileTokenizer` with deterministic vocabulary builds and frozen-mode failures
+  so token IDs can remain stable for learned embedding rows.
 - Added `NesTileTokenFrame`, which converts a screen-space tile frame into screen-space
   tile tokens using a persistent tokenizer.
 - Added `NesPlayerRelativeTileFrame`, which maps the visible 32x28 token frame into a
@@ -248,8 +250,9 @@ the 896 visible tile positions.
   scalar/controller/RAM inputs without carrying the legacy palette histogram grid.
 - Extracted a shared `ControllerOutput` type so the existing palette RNN and the planned
   NES tile RNN can return the same controller-shaped output.
-- Added focused unit tests for tile extraction, tokenization, token-frame conversion,
-  lossless player-relative remapping, and NES tile sensory scalar/controller fields.
+- Added focused unit tests for tile extraction, deterministic tokenization, token-frame
+  conversion, lossless player-relative remapping, and NES tile sensory scalar/controller
+  fields.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -272,6 +272,8 @@ the 896 visible tile positions.
   snapshot exists, while still failing loudly on tokenizer misconfiguration.
 - Added `NesTileVocabularyBuilder`, which builds and freezes deterministic tile tokenizers from
   sampled `NesTileFrame` or `NesPpuSnapshot` data.
+- Extended PPU-snapshot vocabulary sampling to include the full current 256-entry background
+  pattern table, so a valid tile can become visible later without crashing a frozen tokenizer.
 - Wired `EvaluationExecutor` to bootstrap one shared frozen tile tokenizer for queued
   `NesTileRecurrent` generation and robustness evaluations, then pass it into each
   `TrainingRunner`.
@@ -283,6 +285,10 @@ the 896 visible tile positions.
   runners, and to rebuild it after scenario config changes.
 - Added a ROM-gated state test proving NES tile best playback advances through `Evolution::tick`
   with a frozen tokenizer.
+- Made `NesTileRecurrent` selectable for NES training while keeping the palette RNN v2 brain
+  available for comparison.
+- Added an SMB-specific default so empty-population SMB NES training starts with
+  `NesTileRecurrent`; other NES scenarios still default to the palette RNN v2 brain.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -316,24 +322,24 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Make `NesTileRecurrent` selectable through the normal NES training setup. The evaluator and
-best-playback paths can now run tile-brain requests, but the UI/state setup still defaults NES
-training to the palette RNN v2 path.
+Run short SMB training sessions with the tile brain as the default, then compare behavior against
+the palette RNN v2 path.
 
 Planned pieces:
 
-- Expose `NesTileRecurrent` as a NES brain choice while keeping the palette RNN v2 path available
-  for comparison.
+- Use idle auto-start or the training UI to launch SMB tile-brain runs without hand-written
+  `EvolutionStart` commands.
+- Capture training progress, best playback, and diagnostic PNGs for early runs.
 - Keep brain input/output metadata reusable so future NES brain variants can share controller
   outputs and typed sensory containers where appropriate.
 - Preserve the existing palette RNN v2 path for comparison runs.
 
 ### Tests For Next Step
 
-- NES training setup can select `NesTileRecurrent` and generate evaluation requests with matching
-  genomes.
-- Palette RNN v2 remains selectable and does not create a tile tokenizer.
-- Existing palette RNN v2 NES tests continue to pass unchanged.
+- SMB tile-brain training starts from the normal UI/server path and reaches at least one completed
+  evaluation.
+- Best playback advances for the best SMB tile-brain candidate after training.
+- Existing palette RNN v2 NES tests continue to pass unchanged as the comparison path.
 
 ### Open Decisions
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -244,8 +244,10 @@ the 896 visible tile positions.
   tile tokens using a persistent tokenizer.
 - Added `NesPlayerRelativeTileFrame`, which maps the visible 32x28 token frame into a
   lossless 63x55 player-relative token frame.
-- Added focused unit tests for tile extraction, tokenization, token-frame conversion, and
-  lossless player-relative remapping.
+- Added `NesTileSensoryData`, a NES-only sensory container that carries tile visuals and
+  scalar/controller/RAM inputs without carrying the legacy palette histogram grid.
+- Added focused unit tests for tile extraction, tokenization, token-frame conversion,
+  lossless player-relative remapping, and NES tile sensory scalar/controller fields.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -279,14 +281,12 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Split the NES tile observation and brain path away from generic duck sensory data. This
-keeps non-NES scenarios on the existing `DuckSensoryData` and
-`DuckNeuralNetRecurrentBrainV2` path while allowing NES scenarios to use tile-specific
-inputs and genome layouts.
+Add the NES-only recurrent tile brain that consumes `NesTileSensoryData`. This keeps
+non-NES scenarios on the existing `DuckSensoryData` and `DuckNeuralNetRecurrentBrainV2`
+path while allowing NES scenarios to use tile-specific inputs and genome layouts.
 
 Planned pieces:
 
-- Add a NES-only observation type that carries the 63x55 token frame and scalar NES inputs.
 - Add a NES-only recurrent tile brain variant with an embedding-table genome segment.
 - Register the new brain kind separately in `TrainingBrainRegistry`.
 - Wire NES training to select the NES tile brain explicitly, without changing the existing

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -263,6 +263,11 @@ the 896 visible tile positions.
   the tile sensory builder.
 - Added focused unit tests for NES tile brain genome layout, random genome sizing,
   compatibility checks, embedding lookup, and deterministic controller output.
+- Registered `NesTileRecurrent` as a NES-only scenario-driven training brain.
+- Wired `TrainingRunner` to construct the NES tile recurrent brain and map its shared
+  `ControllerOutput` to NES controller bits.
+- Added the NES tile sensory inference path, which builds `NesTileSensoryData` from the latest
+  PPU snapshot and fails loudly unless a frozen tile tokenizer is supplied.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
 
@@ -296,25 +301,26 @@ Each PNG currently has four panels:
 
 ### Next Step
 
-Register and wire the NES-only recurrent tile brain so NES training can select it explicitly.
-This keeps non-NES scenarios on the existing `DuckSensoryData` and
-`DuckNeuralNetRecurrentBrainV2` path while allowing NES scenarios to use tile-specific inputs
-and genome layouts.
+Add a training/evaluation vocabulary bootstrap step. The tile brain now requires a frozen
+tokenizer at inference time, but callers still need a deterministic way to build that tokenizer
+before running a NES tile-brain evaluation.
 
 Planned pieces:
 
-- Register the new brain kind separately in `TrainingBrainRegistry`.
-- Wire NES training to select the NES tile brain explicitly, without changing the existing
-  palette RNN v2 brain.
-- Keep the palette RNN v2 path available for comparison runs and for non-NES scenarios.
+- Introduce a reusable NES tile vocabulary builder that samples one or more NES PPU snapshots and
+  populates `NesTileTokenizer` deterministically.
+- Freeze the tokenizer before passing it into `TrainingRunner`.
+- Keep tokenizer ownership outside `TrainingRunner` so a training run can reuse the same token IDs
+  across all individuals and generations.
+- Preserve the existing palette RNN v2 path for comparison runs.
 
 ### Tests For Next Step
 
-- NES training registry can construct the new brain kind without affecting existing brain
-  kinds.
-- TrainingRunner can instantiate the tile brain for NES scenario-driven evaluation.
-- Tile-brain NES inference builds `NesTileSensoryData` from the latest PPU snapshot and adapter
-  builder input, then maps shared `ControllerOutput` to controller buttons.
+- Vocabulary bootstrap assigns deterministic token IDs from equivalent snapshot samples.
+- Vocabulary bootstrap freezes the tokenizer before it is used for tile-brain inference.
+- Tile-brain NES evaluation with a frozen tokenizer advances at least one real NES frame and
+  records inferred-controller telemetry.
+- Missing or unfrozen tokenizer configuration fails loudly before silent fallback can occur.
 - Existing palette RNN v2 NES tests continue to pass unchanged.
 
 ### Open Decisions

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -63,17 +63,19 @@ visual input derived from the nametable.
 
 ### Observation
 
-The visual observation is a 32x28 grid of tile tokens, derived from the nametable and
-pattern table.
+The visible NES screen first produces a 32x28 screen-space grid of tile tokens, derived
+from the nametable and pattern table. The player-relative observation copies those tokens
+into a larger 63x55 grid so every visible tile can be represented no matter where the
+player is on screen.
 
 The visible NES screen is 256x224 pixels = 32x28 tiles. The nametable stores tile IDs for
 each position. Each tile ID is resolved through the current CHR bank state to its 16-byte
 pattern, then hashed to produce a stable token (see Tile Tokenization below). Using the
-scroll registers (V, fine_x) and the player's screen position from RAM, the grid is indexed
-relative to the player:
+scroll registers (V, fine_x) and the player's screen position from RAM, visible screen
+tiles are re-indexed relative to the player:
 
 ```
-     Mario at tile column 16, tile row 20
+     Screen-space tokens, Mario at tile column 16, tile row 20
      ┌──────────────────────────────────────┐
      │          32 columns                  │
      │     ┌─────────┐                      │
@@ -83,15 +85,17 @@ relative to the player:
      │                                      │
      └──────────────────────────────────────┘
              ↓ re-index relative to Mario
-     ┌──────────────────────────────────────┐
-     │  column 0 = 16 tiles left of Mario  │
-     │  column 31 = 15 tiles right of Mario│
-     │  row 0 = 20 tiles above Mario       │
-     │  row 27 = 7 tiles below Mario       │
-     └──────────────────────────────────────┘
+     ┌────────────────────────────────────────────────────────┐
+     │  63 columns, 55 rows                                  │
+     │  anchor column 31, row 27 = Mario                     │
+     │  relative column = 31 + screen_column - player_column │
+     │  relative row    = 27 + screen_row    - player_row    │
+     └────────────────────────────────────────────────────────┘
 ```
 
-Tiles outside the nametable map to a reserved "void" token (token 0).
+Cells in the 63x55 relative grid that do not correspond to a visible screen tile map to a
+reserved "void" token (token 0). This is larger than the visible screen, but it preserves
+all visible tiles even if the player is at an edge or corner.
 
 ### Tile Tokenization
 
@@ -143,13 +147,13 @@ tile always gets the same token regardless of tile ID, CHR bank state, or palett
 ### Network Architecture
 
 ```
-Tile tokens [28][32]
+Tile tokens [55][63]
     │
     ▼ embedding lookup (tile_embedding[512][D])
-Embedded grid [28][32][D]
+Embedded grid [55][63][D]
     │
     ▼ flatten
-Visual input (28 * 32 * D = 3,584 floats at D=4)
+Visual input (55 * 63 * D = 13,860 floats at D=4)
     │
     ├── + body state (6 floats)
     ├── + control feedback (4 floats)
@@ -157,9 +161,9 @@ Visual input (28 * 32 * D = 3,584 floats at D=4)
     ├── + energy, health (2 floats)
     │
     ▼
-Input buffer (3,628 floats)
+Input buffer (13,904 floats)
     │
-    ▼ W_xh1 (3,628 x 64) + W_h1h1 (64 x 64) + b_h1
+    ▼ W_xh1 (13,904 x 64) + W_h1h1 (64 x 64) + b_h1
 H1 state (64, recurrent, learned leak alpha, learned leaky ReLU)
     │
     ▼ W_h1h2 (64 x 32) + W_h2h2 (32 x 32) + b_h2
@@ -191,12 +195,12 @@ return GenomeLayout{
 
 | Component | Current (V2) | Tile Embedding |
 |-----------|-------------|----------------|
-| Visual input | 4,410 (21x21x10 histogram) | 3,584 (32x28x4 embedded) |
+| Visual input | 4,410 (21x21x10 histogram) | 13,860 (63x55x4 embedded) |
 | Embedding table | -- | 2,048 (512 x 4) |
 | Scalar inputs | 44 | 44 |
-| W_xh1 | 285,056 (4,454 x 64) | 232,192 (3,628 x 64) |
+| W_xh1 | 285,056 (4,454 x 64) | 889,856 (13,904 x 64) |
 | Rest of network | ~7,494 | ~7,494 |
-| **Total genome** | **~292,550** | **~241,734** |
+| **Total genome** | **~292,550** | **~899,398** |
 
 ## Enemies
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -71,8 +71,8 @@ player is on screen.
 The visible NES screen is 256x224 pixels = 32x28 tiles. The nametable stores tile IDs for
 each position. Each tile ID is resolved through the current CHR bank state to its 16-byte
 pattern, then hashed to produce a stable token (see Tile Tokenization below). Using the
-scroll registers (V, fine_x) and the player's screen position from RAM, visible screen
-tiles are re-indexed relative to the player:
+scroll registers (V, fine_x) and a game-adapter-provided player position in the same visible
+screen coordinate space, visible screen tiles are re-indexed relative to the player:
 
 ```
      Screen-space tokens, Mario at tile column 16, tile row 20
@@ -96,6 +96,11 @@ tiles are re-indexed relative to the player:
 Cells in the 63x55 relative grid that do not correspond to a visible screen tile map to a
 reserved "void" token (token 0). This is larger than the visible screen, but it preserves
 all visible tiles even if the player is at an edge or corner.
+
+For SMB specifically, the player-relative X anchor is derived from the player's absolute
+world X minus the tile frame's PPU-derived `scrollX`, wrapped across the 512-pixel nametable
+period. The raw SMB `playerXScreen` byte is page-local and can wrap while Mario remains
+visually centered, which would make the player-relative tile view slide and jump.
 
 ### Tile Tokenization
 
@@ -291,6 +296,13 @@ the 896 visible tile positions.
   `NesTileRecurrent`; other NES scenarios still default to the palette RNN v2 brain.
 - Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
   grayscale pattern pixels, screen-space tokens, and player-relative tokens.
+- Extracted a reusable `NesTileDebugRenderer` with normal-video, pattern-pixel,
+  screen-token, player-relative-token, and comparison views, plus unit tests for deterministic
+  colors, dimensions, RGB565 conversion, and missing-input failures.
+- Added SMB player tile-position derivation from absolute X and tile-frame scroll, then wired it
+  through training, live debug rendering, and the PNG diagnostic.
+- Added tests for SMB 512-pixel scroll wrapping and a ROM-gated regression proving frames 400 and
+  500 keep a stable player-relative X anchor.
 
 ### Current Diagnostic
 
@@ -313,12 +325,40 @@ It writes:
 /tmp/nes_smb_tile_probe_899.png
 ```
 
-Each PNG currently has four panels:
+Each PNG is generated through `NesTileDebugRenderer` and currently has four panels:
 
 - Normal RGB565 video frame.
 - Palette-independent grayscale background pattern pixels.
 - Screen-space tile-token rendering.
 - Expanded 63x55 player-relative tile-token rendering.
+
+### Live Training Visualization
+
+Training settings now include `UiTrainingConfig::nesTileDebugView`, persisted with the rest of
+the user settings. Both the idle training config panel and active training stream panel expose a
+`NES View` selector. The selector is sent through `TrainingStreamConfigChangedEvent` and persisted
+with `UserSettingsPatch`.
+
+Best playback keeps using the normal scenario video frame by default. When the selected view is a
+tile debug view, `Evolution::stepBestPlayback` asks `TrainingRunner` to build the selected debug
+`ScenarioVideoFrame` from the current NES PPU snapshot and broadcasts it through the existing
+`TrainingBestPlaybackFrame` path. Rendering failures are logged and fall back to the normal frame
+when one is available.
+
+Covered views:
+
+- Normal video.
+- Pattern pixels.
+- Screen-space tile tokens.
+- Player-relative tile tokens.
+- Four-panel comparison.
+
+Tests for this step:
+
+- UI state preserves and sends the selected NES tile debug view.
+- User settings backfill legacy configs and sanitize invalid debug-view enum values.
+- Server best-playback updates include the selected debug video frame for `NesTileRecurrent`.
+- Existing disabled PNG diagnostics keep using the same renderer as the live path.
 
 ### Next Step
 

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -232,6 +232,90 @@ be recomputed whenever CHR banks change, or lazily rebuilt each frame (256 tile 
 hashes is negligible). The per-frame observation then just indexes this table for each of
 the 896 visible tile positions.
 
+## Implementation Status
+
+### Completed
+
+- Added PPU snapshot extraction from the SmolNES runtime backend.
+- Added `NesTileFrame`, which extracts visible 32x28 background tile IDs, pattern hashes,
+  and grayscale pattern pixels.
+- Added `NesTileTokenizer`, which maps stable tile-pattern hashes to bounded token IDs.
+- Added `NesTileTokenFrame`, which converts a screen-space tile frame into screen-space
+  tile tokens using a persistent tokenizer.
+- Added `NesPlayerRelativeTileFrame`, which maps the visible 32x28 token frame into a
+  lossless 63x55 player-relative token frame.
+- Added focused unit tests for tile extraction, tokenization, token-frame conversion, and
+  lossless player-relative remapping.
+- Added a disabled SMB diagnostic test that writes PNG comparisons for normal pixels,
+  grayscale pattern pixels, screen-space tokens, and player-relative tokens.
+
+### Current Diagnostic
+
+Run the SMB diagnostic with:
+
+```bash
+cd apps
+./build-debug/bin/dirtsim-tests-diagnostic \
+  --gtest_also_run_disabled_tests \
+  --gtest_filter='NesSuperMarioBrosTileProbeTest.DISABLED_SavesTileComparisonPngs'
+```
+
+It writes:
+
+```text
+/tmp/nes_smb_tile_probe_300.png
+/tmp/nes_smb_tile_probe_400.png
+/tmp/nes_smb_tile_probe_500.png
+/tmp/nes_smb_tile_probe_700.png
+/tmp/nes_smb_tile_probe_899.png
+```
+
+Each PNG currently has four panels:
+
+- Normal RGB565 video frame.
+- Palette-independent grayscale background pattern pixels.
+- Screen-space tile-token rendering.
+- Expanded 63x55 player-relative tile-token rendering.
+
+### Next Step
+
+Split the NES tile observation and brain path away from generic duck sensory data. This
+keeps non-NES scenarios on the existing `DuckSensoryData` and
+`DuckNeuralNetRecurrentBrainV2` path while allowing NES scenarios to use tile-specific
+inputs and genome layouts.
+
+Planned pieces:
+
+- Add a NES-only observation type that carries the 63x55 token frame and scalar NES inputs.
+- Add a NES-only recurrent tile brain variant with an embedding-table genome segment.
+- Register the new brain kind separately in `TrainingBrainRegistry`.
+- Wire NES training to select the NES tile brain explicitly, without changing the existing
+  palette RNN v2 brain.
+- Keep the palette RNN v2 path available for comparison runs and for non-NES scenarios.
+
+### Tests For Next Step
+
+- Genome layout reports the expected named segments and total size.
+- Random genome generation exactly matches the layout size.
+- Incompatible genome sizes fail compatibility checks.
+- Token embedding lookup maps token 0 to the void embedding and non-zero tokens to their
+  expected embedding rows.
+- A hand-authored tiny genome produces deterministic controller outputs from a synthetic
+  NES tile observation.
+- NES training registry can construct the new brain kind without affecting existing brain
+  kinds.
+
+### Open Decisions
+
+- Initial implementation will use the dense option: `63 * 55 * 4 = 13,860` embedded visual
+  inputs directly into H1.
+- Initial embedding dimension is 4.
+- Token vocabulary size remains 512 with token 0 reserved for void.
+- Sprites are not represented in the tile grid for v1; dynamic actors remain in
+  `special_senses`.
+- If dense training is too slow or unstable, revisit shared encoders or region pooling as a
+  later brain variant rather than blocking the first end-to-end implementation.
+
 ## Future Work
 
 ### Sprite Overlay

--- a/apps/src/cli/GenomeDbBenchmark.cpp
+++ b/apps/src/cli/GenomeDbBenchmark.cpp
@@ -91,6 +91,8 @@ std::string GenomeDbBenchmark::runCorrectnessTests()
             .brainKind = std::nullopt,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
 
         const auto result =
@@ -154,6 +156,8 @@ std::string GenomeDbBenchmark::runCorrectnessTests()
             .brainKind = std::nullopt,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
 
         const auto result =
@@ -264,6 +268,8 @@ void GenomeDbBenchmark::runPerformanceTests(int count, GenomeDbBenchmarkResults&
                 .brainKind = std::nullopt,
                 .brainVariant = std::nullopt,
                 .trainingSessionId = std::nullopt,
+                .genomePoolId = GenomePoolId::DirtSim,
+                .nesTileBrainCompatibility = std::nullopt,
             };
 
             const auto result =
@@ -322,6 +328,8 @@ void GenomeDbBenchmark::runPerformanceTests(int count, GenomeDbBenchmarkResults&
                 .brainKind = std::nullopt,
                 .brainVariant = std::nullopt,
                 .trainingSessionId = std::nullopt,
+                .genomePoolId = GenomePoolId::DirtSim,
+                .nesTileBrainCompatibility = std::nullopt,
             };
 
             const auto result =

--- a/apps/src/core/organisms/brains/ControllerOutput.h
+++ b/apps/src/core/organisms/brains/ControllerOutput.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace DirtSim {
+
+struct ControllerOutput {
+    float x = 0.0f;
+    float y = 0.0f;
+    bool a = false;
+    bool b = false;
+    float xRaw = 0.0f;
+    float yRaw = 0.0f;
+    float aRaw = 0.0f;
+    float bRaw = 0.0f;
+};
+
+} // namespace DirtSim

--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.cpp
@@ -395,8 +395,8 @@ DuckInput DuckNeuralNetRecurrentBrainV2::inferInput(const DuckSensoryData& senso
     return duckInput;
 }
 
-DuckNeuralNetRecurrentBrainV2::ControllerOutput DuckNeuralNetRecurrentBrainV2::
-    inferControllerOutput(const DuckSensoryData& sensory)
+ControllerOutput DuckNeuralNetRecurrentBrainV2::inferControllerOutput(
+    const DuckSensoryData& sensory)
 {
     const auto& input = impl_->flattenSensoryData(sensory);
     const auto& output = impl_->forward(input);

--- a/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.h
+++ b/apps/src/core/organisms/brains/DuckNeuralNetRecurrentBrainV2.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/organisms/DuckBrain.h"
+#include "core/organisms/brains/ControllerOutput.h"
 #include "core/organisms/brains/Genome.h"
 #include "core/organisms/evolution/GenomeLayout.h"
 
@@ -13,17 +14,6 @@ class Duck;
 
 class DuckNeuralNetRecurrentBrainV2 : public DuckBrain {
 public:
-    struct ControllerOutput {
-        float x = 0.0f;
-        float y = 0.0f;
-        bool a = false;
-        bool b = false;
-        float xRaw = 0.0f;
-        float yRaw = 0.0f;
-        float aRaw = 0.0f;
-        float bRaw = 0.0f;
-    };
-
     DuckNeuralNetRecurrentBrainV2();
     explicit DuckNeuralNetRecurrentBrainV2(const Genome& genome);
     explicit DuckNeuralNetRecurrentBrainV2(uint32_t seed);

--- a/apps/src/core/organisms/evolution/GenomeMetadata.h
+++ b/apps/src/core/organisms/evolution/GenomeMetadata.h
@@ -4,6 +4,7 @@
 #include "core/ScenarioId.h"
 #include "core/UUID.h"
 #include "core/organisms/OrganismType.h"
+#include "core/scenarios/nes/NesTileBrainMetadata.h"
 
 #include <cstdint>
 #include <nlohmann/json_fwd.hpp>
@@ -37,8 +38,9 @@ struct GenomeMetadata {
     std::optional<std::string> brainVariant;
     std::optional<UUID> trainingSessionId;
     GenomePoolId genomePoolId = GenomePoolId::DirtSim;
+    std::optional<NesTileBrainCompatibilityMetadata> nesTileBrainCompatibility;
 
-    using serialize = zpp::bits::members<14>;
+    using serialize = zpp::bits::members<15>;
 };
 
 void to_json(nlohmann::json& j, const GenomeMetadata& meta);

--- a/apps/src/core/organisms/evolution/GenomeRepository.cpp
+++ b/apps/src/core/organisms/evolution/GenomeRepository.cpp
@@ -166,6 +166,9 @@ GenomeMetadata mergeMetadata(const GenomeMetadata& existingRaw, const GenomeMeta
     if (!merged.trainingSessionId.has_value()) {
         merged.trainingSessionId = existing.trainingSessionId;
     }
+    if (!merged.nesTileBrainCompatibility.has_value()) {
+        merged.nesTileBrainCompatibility = existing.nesTileBrainCompatibility;
+    }
     if (merged.createdTimestamp == 0) {
         merged.createdTimestamp = existing.createdTimestamp;
     }
@@ -389,6 +392,22 @@ std::string GenomeRepository::computeContentHash(const Genome& genome, const Gen
     hashValue(hash, organismType);
     hashString(hash, meta.brainKind.value_or(""));
     hashString(hash, meta.brainVariant.value_or(""));
+    const bool hasNesTileCompatibility = meta.nesTileBrainCompatibility.has_value();
+    hashValue(hash, hasNesTileCompatibility);
+    if (hasNesTileCompatibility) {
+        const auto& compatibility = meta.nesTileBrainCompatibility.value();
+        hashValue(hash, compatibility.schemaVersion);
+        hashValue(hash, compatibility.tileVocabularySize);
+        hashValue(hash, compatibility.tileEmbeddingDim);
+        hashValue(hash, compatibility.relativeTileColumns);
+        hashValue(hash, compatibility.relativeTileRows);
+        hashValue(hash, compatibility.scalarInputSize);
+        hashValue(hash, compatibility.h1Size);
+        hashValue(hash, compatibility.h2Size);
+        hashValue(hash, compatibility.outputSize);
+        hashValue(hash, compatibility.voidTokenId);
+        hashString(hash, compatibility.tokenizerVocabularyHash);
+    }
 
     const uint64_t weightCount = genome.weights.size();
     hashValue(hash, weightCount);

--- a/apps/src/core/organisms/evolution/TrainingBrainRegistry.cpp
+++ b/apps/src/core/organisms/evolution/TrainingBrainRegistry.cpp
@@ -8,6 +8,7 @@
 #include "core/organisms/brains/NeuralNetBrain.h"
 #include "core/organisms/brains/RuleBased2Brain.h"
 #include "core/organisms/brains/RuleBasedBrain.h"
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
 
 namespace DirtSim {
 
@@ -230,6 +231,24 @@ TrainingBrainRegistry TrainingBrainRegistry::createDefault()
                     return DuckNeuralNetRecurrentBrainV2::isGenomeCompatible(genome);
                 },
             .getGenomeLayout = []() { return DuckNeuralNetRecurrentBrainV2::getGenomeLayout(); },
+        });
+
+    registry.registerBrain(
+        OrganismType::NES_DUCK,
+        TrainingBrainKind::NesTileRecurrent,
+        "",
+        BrainRegistryEntry{
+            .controlMode = BrainRegistryEntry::ControlMode::ScenarioDriven,
+            .requiresGenome = true,
+            .allowsMutation = true,
+            .spawn = nullptr,
+            .createRandomGenome =
+                [](std::mt19937& rng) { return NesTileRecurrentBrain::randomGenome(rng); },
+            .isGenomeCompatible =
+                [](const Genome& genome) {
+                    return NesTileRecurrentBrain::isGenomeCompatible(genome);
+                },
+            .getGenomeLayout = []() { return NesTileRecurrentBrain::getGenomeLayout(); },
         });
 
     return registry;

--- a/apps/src/core/organisms/evolution/TrainingBrainRegistry.cpp
+++ b/apps/src/core/organisms/evolution/TrainingBrainRegistry.cpp
@@ -12,6 +12,25 @@
 
 namespace DirtSim {
 
+std::string defaultTrainingBrainKind(OrganismType organismType, Scenario::EnumType scenarioId)
+{
+    switch (organismType) {
+        case OrganismType::TREE:
+            return TrainingBrainKind::NeuralNet;
+        case OrganismType::DUCK:
+            return TrainingBrainKind::DuckNeuralNetRecurrentV2;
+        case OrganismType::NES_DUCK:
+            if (scenarioId == Scenario::EnumType::NesSuperMarioBros) {
+                return TrainingBrainKind::NesTileRecurrent;
+            }
+            return TrainingBrainKind::DuckNeuralNetRecurrentV2;
+        case OrganismType::GOOSE:
+            return TrainingBrainKind::Random;
+        default:
+            return TrainingBrainKind::Random;
+    }
+}
+
 void TrainingBrainRegistry::registerBrain(
     OrganismType organismType,
     const std::string& brainKind,

--- a/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
+++ b/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
@@ -21,6 +21,7 @@ inline constexpr const char* Random = "Random";
 inline constexpr const char* WallBouncing = "WallBouncing";
 inline constexpr const char* DuckBrain2 = "DuckBrain2";
 inline constexpr const char* DuckNeuralNetRecurrentV2 = "DuckNeuralNetRecurrentV2";
+inline constexpr const char* NesTileRecurrent = "NesTileRecurrent";
 } // namespace TrainingBrainKind
 
 struct BrainRegistryKey {

--- a/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
+++ b/apps/src/core/organisms/evolution/TrainingBrainRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "GenomeLayout.h"
+#include "core/ScenarioId.h"
 #include "core/organisms/OrganismType.h"
 #include "core/organisms/brains/Genome.h"
 
@@ -23,6 +24,8 @@ inline constexpr const char* DuckBrain2 = "DuckBrain2";
 inline constexpr const char* DuckNeuralNetRecurrentV2 = "DuckNeuralNetRecurrentV2";
 inline constexpr const char* NesTileRecurrent = "NesTileRecurrent";
 } // namespace TrainingBrainKind
+
+std::string defaultTrainingBrainKind(OrganismType organismType, Scenario::EnumType scenarioId);
 
 struct BrainRegistryKey {
     OrganismType organismType = OrganismType::TREE;

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -15,10 +15,14 @@
 #include "core/scenarios/clock_scenario/DoorEntrySpawn.h"
 #include "core/scenarios/clock_scenario/DoorManager.h"
 #include "core/scenarios/nes/NesGameAdapter.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
 #include "core/scenarios/nes/NesScenarioRuntime.h"
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesTileDebugRenderer.h"
+#include "core/scenarios/nes/NesTileFrame.h"
 #include "core/scenarios/nes/NesTileRecurrentBrain.h"
 #include "core/scenarios/nes/NesTileSensoryBuilder.h"
+#include "core/scenarios/nes/NesTileTokenFrame.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
 #include <algorithm>
 #include <cmath>
@@ -677,6 +681,99 @@ const std::vector<OrganismId>* TrainingRunner::getOrganismGrid() const
     return nullptr;
 }
 
+Result<ScenarioVideoFrame, std::string> TrainingRunner::makeNesTileDebugScenarioVideoFrame(
+    NesTileDebugView view) const
+{
+    if (!isNesTileDebugViewValid(view)) {
+        return Result<ScenarioVideoFrame, std::string>::error(
+            "TrainingRunner: Unknown NES tile debug view");
+    }
+
+    if (view == NesTileDebugView::NormalVideo) {
+        if (!nesScenarioVideoFrame_.has_value()) {
+            return Result<ScenarioVideoFrame, std::string>::error(
+                "TrainingRunner: NES tile debug normal video requires a video frame");
+        }
+        return Result<ScenarioVideoFrame, std::string>::okay(nesScenarioVideoFrame_.value());
+    }
+
+    if (!nesDriver_) {
+        return Result<ScenarioVideoFrame, std::string>::error(
+            "TrainingRunner: NES tile debug rendering requires a NES driver");
+    }
+
+    const auto ppuSnapshot = nesDriver_->copyRuntimePpuSnapshot();
+    if (!ppuSnapshot.has_value()) {
+        return Result<ScenarioVideoFrame, std::string>::error(
+            "TrainingRunner: NES tile debug rendering requires a PPU snapshot");
+    }
+
+    const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
+    std::optional<NesTileTokenFrame> tokenFrame;
+    std::optional<NesPlayerRelativeTileFrame> relativeFrame;
+
+    const bool needsTokenFrame = view == NesTileDebugView::ScreenTokens
+        || view == NesTileDebugView::PlayerRelativeTokens || view == NesTileDebugView::Comparison;
+    const bool needsRelativeFrame =
+        view == NesTileDebugView::PlayerRelativeTokens || view == NesTileDebugView::Comparison;
+
+    if (needsTokenFrame) {
+        if (!nesTileTokenizer_) {
+            return Result<ScenarioVideoFrame, std::string>::error(
+                "TrainingRunner: NES tile debug rendering requires a tile tokenizer");
+        }
+        if (nesTileTokenizer_->getMode() != NesTileTokenizer::Mode::Frozen) {
+            return Result<ScenarioVideoFrame, std::string>::error(
+                "TrainingRunner: NES tile debug rendering requires a frozen tile tokenizer");
+        }
+
+        auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, *nesTileTokenizer_);
+        if (tokenFrameResult.isError()) {
+            return Result<ScenarioVideoFrame, std::string>::error(
+                "TrainingRunner: Failed to tokenize NES tile debug frame: "
+                + tokenFrameResult.errorValue());
+        }
+        tokenFrame = std::move(tokenFrameResult).value();
+    }
+
+    if (needsRelativeFrame) {
+        if (!nesGameAdapter_) {
+            return Result<ScenarioVideoFrame, std::string>::error(
+                "TrainingRunner: NES tile debug rendering requires a game adapter");
+        }
+
+        const NesGameAdapterSensoryInput sensoryInput{
+            .controllerMask = nesControllerMask_,
+            .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
+            .lastGameState = nesLastGameState_,
+            .deltaTimeSeconds = TIMESTEP,
+            .tileFrameScrollX = tileFrame.scrollX,
+        };
+        const NesTileSensoryBuilderInput tileInput =
+            nesGameAdapter_->makeNesTileSensoryBuilderInput(sensoryInput);
+        relativeFrame = makeNesPlayerRelativeTileFrame(
+            tokenFrame.value(), tileInput.playerScreenX, tileInput.playerScreenY);
+    }
+
+    const NesTileDebugRenderInput renderInput{
+        .videoFrame =
+            nesScenarioVideoFrame_.has_value() ? &nesScenarioVideoFrame_.value() : nullptr,
+        .tileFrame = &tileFrame,
+        .tokenFrame = tokenFrame.has_value() ? &tokenFrame.value() : nullptr,
+        .relativeFrame = relativeFrame.has_value() ? &relativeFrame.value() : nullptr,
+    };
+    auto imageResult = makeNesTileDebugRenderImage(view, renderInput);
+    if (imageResult.isError()) {
+        return Result<ScenarioVideoFrame, std::string>::error(
+            "TrainingRunner: Failed to render NES tile debug frame: " + imageResult.errorValue());
+    }
+
+    const uint64_t frameId =
+        nesScenarioVideoFrame_.has_value() ? nesScenarioVideoFrame_->frame_id : tileFrame.frameId;
+    return Result<ScenarioVideoFrame, std::string>::okay(
+        DirtSim::makeNesTileDebugScenarioVideoFrame(imageResult.value(), frameId));
+}
+
 const Timers* TrainingRunner::getTimers() const
 {
     if (world_) {
@@ -1050,16 +1147,18 @@ NesTileSensoryData TrainingRunner::makeNesTileSensoryData() const
     DIRTSIM_ASSERT(
         ppuSnapshot.has_value(), "TrainingRunner: NES tile sensory requires a PPU snapshot");
 
+    const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
     const NesGameAdapterSensoryInput sensoryInput{
         .controllerMask = nesControllerMask_,
         .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
         .lastGameState = nesLastGameState_,
         .deltaTimeSeconds = TIMESTEP,
+        .tileFrameScrollX = tileFrame.scrollX,
     };
     const NesTileSensoryBuilderInput tileInput =
         nesGameAdapter_->makeNesTileSensoryBuilderInput(sensoryInput);
     auto sensoryResult =
-        makeNesTileSensoryDataFromPpuSnapshot(ppuSnapshot.value(), *nesTileTokenizer_, tileInput);
+        makeNesTileSensoryDataFromTileFrame(tileFrame, *nesTileTokenizer_, tileInput);
     DIRTSIM_ASSERT(
         sensoryResult.isValue(),
         "TrainingRunner: Failed to build NES tile sensory data: " + sensoryResult.errorValue());

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -1004,8 +1004,7 @@ uint8_t TrainingRunner::inferNesControllerMask()
     uint8_t mask = 0;
     if (individual_.brain.brainKind == TrainingBrainKind::DuckNeuralNetRecurrentV2
         && nesDuckBrainV2_) {
-        const DuckNeuralNetRecurrentBrainV2::ControllerOutput output =
-            nesDuckBrainV2_->inferControllerOutput(sensory);
+        const ControllerOutput output = nesDuckBrainV2_->inferControllerOutput(sensory);
 
         if (output.a) {
             mask |= NesPolicyLayout::ButtonA;

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -1155,7 +1155,8 @@ NesTileSensoryData TrainingRunner::makeNesTileSensoryData()
 
     const NesTileFrame tileFrame = [this, &ppuSnapshot]() {
         ScopeTimer timer(nesTimers_, "nes_tile_frame_extract");
-        return makeNesTileFrame(ppuSnapshot.value());
+        const NesTileFrameBuildOptions options{ .includePatternPixels = false };
+        return makeNesTileFrame(ppuSnapshot.value(), options, &nesTimers_);
     }();
     const NesTileSensoryBuilderInput tileInput = [this, &tileFrame]() {
         ScopeTimer timer(nesTimers_, "nes_tile_adapter_input");

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -4,6 +4,7 @@
 #include "GenomeRepository.h"
 #include "core/Assert.h"
 #include "core/LoggingChannels.h"
+#include "core/ScopeTimer.h"
 #include "core/World.h"
 #include "core/WorldData.h"
 #include "core/organisms/Duck.h"
@@ -1132,8 +1133,10 @@ DuckSensoryData TrainingRunner::makeNesDuckSensoryData() const
     return nesGameAdapter_->makeDuckSensoryData(sensoryInput);
 }
 
-NesTileSensoryData TrainingRunner::makeNesTileSensoryData() const
+NesTileSensoryData TrainingRunner::makeNesTileSensoryData()
 {
+    ScopeTimer totalTimer(nesTimers_, "nes_tile_sensory_total");
+
     DIRTSIM_ASSERT(
         nesGameAdapter_ != nullptr, "TrainingRunner: NES tile sensory requires a game adapter");
     DIRTSIM_ASSERT(nesDriver_ != nullptr, "TrainingRunner: NES tile sensory requires a NES driver");
@@ -1143,22 +1146,32 @@ NesTileSensoryData TrainingRunner::makeNesTileSensoryData() const
         nesTileTokenizer_->getMode() == NesTileTokenizer::Mode::Frozen,
         "TrainingRunner: NES tile sensory requires a frozen tile tokenizer");
 
-    const auto ppuSnapshot = nesDriver_->copyRuntimePpuSnapshot();
+    const auto ppuSnapshot = [this]() {
+        ScopeTimer timer(nesTimers_, "nes_tile_copy_ppu_snapshot");
+        return nesDriver_->copyRuntimePpuSnapshot();
+    }();
     DIRTSIM_ASSERT(
         ppuSnapshot.has_value(), "TrainingRunner: NES tile sensory requires a PPU snapshot");
 
-    const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
-    const NesGameAdapterSensoryInput sensoryInput{
-        .controllerMask = nesControllerMask_,
-        .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
-        .lastGameState = nesLastGameState_,
-        .deltaTimeSeconds = TIMESTEP,
-        .tileFrameScrollX = tileFrame.scrollX,
-    };
-    const NesTileSensoryBuilderInput tileInput =
-        nesGameAdapter_->makeNesTileSensoryBuilderInput(sensoryInput);
-    auto sensoryResult =
-        makeNesTileSensoryDataFromTileFrame(tileFrame, *nesTileTokenizer_, tileInput);
+    const NesTileFrame tileFrame = [this, &ppuSnapshot]() {
+        ScopeTimer timer(nesTimers_, "nes_tile_frame_extract");
+        return makeNesTileFrame(ppuSnapshot.value());
+    }();
+    const NesTileSensoryBuilderInput tileInput = [this, &tileFrame]() {
+        ScopeTimer timer(nesTimers_, "nes_tile_adapter_input");
+        const NesGameAdapterSensoryInput sensoryInput{
+            .controllerMask = nesControllerMask_,
+            .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
+            .lastGameState = nesLastGameState_,
+            .deltaTimeSeconds = TIMESTEP,
+            .tileFrameScrollX = tileFrame.scrollX,
+        };
+        return nesGameAdapter_->makeNesTileSensoryBuilderInput(sensoryInput);
+    }();
+    auto sensoryResult = [this, &tileFrame, &tileInput]() {
+        ScopeTimer timer(nesTimers_, "nes_tile_build_sensory");
+        return makeNesTileSensoryDataFromTileFrame(tileFrame, *nesTileTokenizer_, tileInput);
+    }();
     DIRTSIM_ASSERT(
         sensoryResult.isValue(),
         "TrainingRunner: Failed to build NES tile sensory data: " + sensoryResult.errorValue());
@@ -1183,6 +1196,7 @@ uint8_t TrainingRunner::inferNesControllerMask()
 
     if (individual_.brain.brainKind == TrainingBrainKind::DuckNeuralNetRecurrentV2
         && nesDuckBrainV2_) {
+        ScopeTimer timer(nesTimers_, "nes_palette_controller_infer_total");
         const DuckSensoryData sensory = makeNesDuckSensoryData();
         const ControllerOutput output = nesDuckBrainV2_->inferControllerOutput(sensory);
         const uint8_t mask = nesControllerMaskFromOutput(output);
@@ -1191,6 +1205,7 @@ uint8_t TrainingRunner::inferNesControllerMask()
     }
 
     if (individual_.brain.brainKind == TrainingBrainKind::NesTileRecurrent && nesTileBrain_) {
+        ScopeTimer timer(nesTimers_, "nes_tile_controller_infer_total");
         DIRTSIM_ASSERT(
             nesTileTokenizer_ != nullptr,
             "TrainingRunner: NES tile sensory requires a tile tokenizer");
@@ -1202,7 +1217,10 @@ uint8_t TrainingRunner::inferNesControllerMask()
             return 0;
         }
         const NesTileSensoryData sensory = makeNesTileSensoryData();
-        const ControllerOutput output = nesTileBrain_->inferControllerOutput(sensory);
+        const ControllerOutput output = [this, &sensory]() {
+            ScopeTimer brainTimer(nesTimers_, "nes_tile_brain_infer");
+            return nesTileBrain_->inferControllerOutput(sensory);
+        }();
         const uint8_t mask = nesControllerMaskFromOutput(output);
         recordTelemetry(output, mask);
         return mask;

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -17,6 +17,9 @@
 #include "core/scenarios/nes/NesGameAdapter.h"
 #include "core/scenarios/nes/NesScenarioRuntime.h"
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
+#include "core/scenarios/nes/NesTileSensoryBuilder.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -96,6 +99,33 @@ std::string buildNesCommandSignature(uint8_t controllerMask)
     }
 
     return signature;
+}
+
+uint8_t nesControllerMaskFromOutput(const ControllerOutput& output)
+{
+    uint8_t mask = 0;
+    if (output.a) {
+        mask |= NesPolicyLayout::ButtonA;
+    }
+    if (output.b) {
+        mask |= NesPolicyLayout::ButtonB;
+    }
+
+    if (output.x <= -kNesDuckMoveThreshold) {
+        mask |= NesPolicyLayout::ButtonLeft;
+    }
+    else if (output.x >= kNesDuckMoveThreshold) {
+        mask |= NesPolicyLayout::ButtonRight;
+    }
+
+    if (output.y <= -kNesDuckMoveThreshold) {
+        mask |= NesPolicyLayout::ButtonUp;
+    }
+    else if (output.y >= kNesDuckMoveThreshold) {
+        mask |= NesPolicyLayout::ButtonDown;
+    }
+
+    return mask;
 }
 
 Vector2i findSpawnCell(World& world)
@@ -188,6 +218,7 @@ TrainingRunner::TrainingRunner(
       maxTime_(evolutionConfig.maxSimulationTime),
       brainRegistry_(runnerConfig.brainRegistry),
       nesGameAdapterRegistry_(runnerConfig.nesGameAdapterRegistry),
+      nesTileTokenizer_(runnerConfig.nesTileTokenizer),
       duckClockSpawnLeftFirst_(runnerConfig.duckClockSpawnLeftFirst),
       spawnRng_(runnerConfig.duckClockSpawnRngSeed.value_or(
           static_cast<uint32_t>(std::random_device{}()))),
@@ -283,6 +314,7 @@ TrainingRunner::TrainingRunner(
     nesPaletteFrame_.reset();
     nesFitnessDetails_ = std::monostate{};
     nesDuckBrainV2_.reset();
+    nesTileBrain_.reset();
     nesLastControllerOutput_.reset();
     nesLastControllerTelemetry_.reset();
     nesLastDebugState_.reset();
@@ -293,6 +325,12 @@ TrainingRunner::TrainingRunner(
                 "TrainingRunner: NES duck recurrent V2 controller requires a genome");
             nesDuckBrainV2_ =
                 std::make_unique<DuckNeuralNetRecurrentBrainV2>(individual_.genome.value());
+        }
+        else if (individual_.brain.brainKind == TrainingBrainKind::NesTileRecurrent) {
+            DIRTSIM_ASSERT(
+                individual_.genome.has_value(),
+                "TrainingRunner: NES tile recurrent controller requires a genome");
+            nesTileBrain_ = std::make_unique<NesTileRecurrentBrain>(individual_.genome.value());
         }
     }
 
@@ -997,36 +1035,41 @@ DuckSensoryData TrainingRunner::makeNesDuckSensoryData() const
     return nesGameAdapter_->makeDuckSensoryData(sensoryInput);
 }
 
+NesTileSensoryData TrainingRunner::makeNesTileSensoryData() const
+{
+    DIRTSIM_ASSERT(
+        nesGameAdapter_ != nullptr, "TrainingRunner: NES tile sensory requires a game adapter");
+    DIRTSIM_ASSERT(nesDriver_ != nullptr, "TrainingRunner: NES tile sensory requires a NES driver");
+    DIRTSIM_ASSERT(
+        nesTileTokenizer_ != nullptr, "TrainingRunner: NES tile sensory requires a tile tokenizer");
+    DIRTSIM_ASSERT(
+        nesTileTokenizer_->getMode() == NesTileTokenizer::Mode::Frozen,
+        "TrainingRunner: NES tile sensory requires a frozen tile tokenizer");
+
+    const auto ppuSnapshot = nesDriver_->copyRuntimePpuSnapshot();
+    DIRTSIM_ASSERT(
+        ppuSnapshot.has_value(), "TrainingRunner: NES tile sensory requires a PPU snapshot");
+
+    const NesGameAdapterSensoryInput sensoryInput{
+        .controllerMask = nesControllerMask_,
+        .paletteFrame = nesPaletteFrame_.has_value() ? &nesPaletteFrame_.value() : nullptr,
+        .lastGameState = nesLastGameState_,
+        .deltaTimeSeconds = TIMESTEP,
+    };
+    const NesTileSensoryBuilderInput tileInput =
+        nesGameAdapter_->makeNesTileSensoryBuilderInput(sensoryInput);
+    auto sensoryResult =
+        makeNesTileSensoryDataFromPpuSnapshot(ppuSnapshot.value(), *nesTileTokenizer_, tileInput);
+    DIRTSIM_ASSERT(
+        sensoryResult.isValue(),
+        "TrainingRunner: Failed to build NES tile sensory data: " + sensoryResult.errorValue());
+    return sensoryResult.value();
+}
+
 uint8_t TrainingRunner::inferNesControllerMask()
 {
     nesLastControllerTelemetry_.reset();
-    const DuckSensoryData sensory = makeNesDuckSensoryData();
-    uint8_t mask = 0;
-    if (individual_.brain.brainKind == TrainingBrainKind::DuckNeuralNetRecurrentV2
-        && nesDuckBrainV2_) {
-        const ControllerOutput output = nesDuckBrainV2_->inferControllerOutput(sensory);
-
-        if (output.a) {
-            mask |= NesPolicyLayout::ButtonA;
-        }
-        if (output.b) {
-            mask |= NesPolicyLayout::ButtonB;
-        }
-
-        if (output.x <= -kNesDuckMoveThreshold) {
-            mask |= NesPolicyLayout::ButtonLeft;
-        }
-        else if (output.x >= kNesDuckMoveThreshold) {
-            mask |= NesPolicyLayout::ButtonRight;
-        }
-
-        if (output.y <= -kNesDuckMoveThreshold) {
-            mask |= NesPolicyLayout::ButtonUp;
-        }
-        else if (output.y >= kNesDuckMoveThreshold) {
-            mask |= NesPolicyLayout::ButtonDown;
-        }
-
+    const auto recordTelemetry = [this](const ControllerOutput& output, uint8_t mask) {
         nesLastControllerTelemetry_ = NesControllerTelemetry{
             .aRaw = output.aRaw,
             .bRaw = output.bRaw,
@@ -1037,6 +1080,22 @@ uint8_t TrainingRunner::inferNesControllerMask()
             .controllerSource = NesGameAdapterControllerSource::InferredPolicy,
             .controllerSourceFrameIndex = std::nullopt,
         };
+    };
+
+    if (individual_.brain.brainKind == TrainingBrainKind::DuckNeuralNetRecurrentV2
+        && nesDuckBrainV2_) {
+        const DuckSensoryData sensory = makeNesDuckSensoryData();
+        const ControllerOutput output = nesDuckBrainV2_->inferControllerOutput(sensory);
+        const uint8_t mask = nesControllerMaskFromOutput(output);
+        recordTelemetry(output, mask);
+        return mask;
+    }
+
+    if (individual_.brain.brainKind == TrainingBrainKind::NesTileRecurrent && nesTileBrain_) {
+        const NesTileSensoryData sensory = makeNesTileSensoryData();
+        const ControllerOutput output = nesTileBrain_->inferControllerOutput(sensory);
+        const uint8_t mask = nesControllerMaskFromOutput(output);
+        recordTelemetry(output, mask);
         return mask;
     }
 

--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -1092,6 +1092,16 @@ uint8_t TrainingRunner::inferNesControllerMask()
     }
 
     if (individual_.brain.brainKind == TrainingBrainKind::NesTileRecurrent && nesTileBrain_) {
+        DIRTSIM_ASSERT(
+            nesTileTokenizer_ != nullptr,
+            "TrainingRunner: NES tile sensory requires a tile tokenizer");
+        DIRTSIM_ASSERT(
+            nesTileTokenizer_->getMode() == NesTileTokenizer::Mode::Frozen,
+            "TrainingRunner: NES tile sensory requires a frozen tile tokenizer");
+        if (nesDriver_ && nesDriver_->getRuntimeRenderedFrameCount() == 0
+            && !nesDriver_->copyRuntimePpuSnapshot().has_value()) {
+            return 0;
+        }
         const NesTileSensoryData sensory = makeNesTileSensoryData();
         const ControllerOutput output = nesTileBrain_->inferControllerOutput(sensory);
         const uint8_t mask = nesControllerMaskFromOutput(output);

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -204,7 +204,7 @@ private:
     void resolveBrainEntry();
     NesFrameTrace runScenarioDrivenStep();
     DuckSensoryData makeNesDuckSensoryData() const;
-    NesTileSensoryData makeNesTileSensoryData() const;
+    NesTileSensoryData makeNesTileSensoryData();
     uint8_t inferNesControllerMask();
     std::optional<DuckEvaluationArtifacts> buildDuckEvaluationArtifacts(const Duck& duck) const;
     void snapshotDuckEvaluationArtifacts();

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -40,6 +40,7 @@ class NesGameAdapter;
 class NesScenarioRuntime;
 class NesSmolnesScenarioDriver;
 class NesTileRecurrentBrain;
+enum class NesTileDebugView : uint8_t;
 struct NesTileSensoryData;
 class NesTileTokenizer;
 namespace Organism {
@@ -161,6 +162,8 @@ public:
     {
         return nesScenarioVideoFrame_;
     }
+    Result<ScenarioVideoFrame, std::string> makeNesTileDebugScenarioVideoFrame(
+        NesTileDebugView view) const;
     const WorldData* getWorldData() const;
     const std::vector<OrganismId>* getOrganismGrid() const;
     const Timers* getTimers() const;

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -39,6 +39,9 @@ class GenomeRepository;
 class NesGameAdapter;
 class NesScenarioRuntime;
 class NesSmolnesScenarioDriver;
+class NesTileRecurrentBrain;
+struct NesTileSensoryData;
+class NesTileTokenizer;
 namespace Organism {
 class Body;
 }
@@ -118,6 +121,7 @@ public:
     struct Config {
         TrainingBrainRegistry brainRegistry;
         NesGameAdapterRegistry nesGameAdapterRegistry = NesGameAdapterRegistry::createDefault();
+        std::shared_ptr<NesTileTokenizer> nesTileTokenizer = nullptr;
         std::optional<bool> duckClockSpawnLeftFirst = std::nullopt;
         std::optional<uint32_t> duckClockSpawnRngSeed = std::nullopt;
         FrameTraceSink frameTraceSink = nullptr;
@@ -197,6 +201,7 @@ private:
     void resolveBrainEntry();
     NesFrameTrace runScenarioDrivenStep();
     DuckSensoryData makeNesDuckSensoryData() const;
+    NesTileSensoryData makeNesTileSensoryData() const;
     uint8_t inferNesControllerMask();
     std::optional<DuckEvaluationArtifacts> buildDuckEvaluationArtifacts(const Duck& duck) const;
     void snapshotDuckEvaluationArtifacts();
@@ -226,6 +231,7 @@ private:
     State state_ = State::Running;
     TrainingBrainRegistry brainRegistry_;
     NesGameAdapterRegistry nesGameAdapterRegistry_;
+    std::shared_ptr<NesTileTokenizer> nesTileTokenizer_ = nullptr;
     std::optional<bool> duckClockSpawnLeftFirst_ = std::nullopt;
     std::mt19937 spawnRng_;
     EvolutionConfig evolutionConfig_;
@@ -240,6 +246,7 @@ private:
     uint8_t nesControllerMask_ = 0;
     std::optional<NesPaletteFrame> nesPaletteFrame_ = std::nullopt;
     std::unique_ptr<DuckNeuralNetRecurrentBrainV2> nesDuckBrainV2_;
+    std::unique_ptr<NesTileRecurrentBrain> nesTileBrain_;
     std::optional<NesGameAdapterControllerOutput> nesLastControllerOutput_ = std::nullopt;
     std::optional<NesControllerTelemetry> nesLastControllerTelemetry_ = std::nullopt;
     std::optional<NesGameAdapterDebugState> nesLastDebugState_ = std::nullopt;

--- a/apps/src/core/organisms/evolution/tests/GenomeRepository_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/GenomeRepository_test.cpp
@@ -35,6 +35,8 @@ protected:
             .brainKind = std::nullopt,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
     }
 
@@ -273,6 +275,38 @@ TEST_F(GenomeRepositoryTest, StoreOrUpdateByHashKeepsPeakRobustFitnessWithoutSam
     EXPECT_TRUE(metadata->robustFitnessSamples.empty());
 }
 
+TEST_F(GenomeRepositoryTest, StoreOrUpdateByHashSeparatesNesTileCompatibilityMetadata)
+{
+    const auto genome = createTestGenome(0.91);
+    auto firstMeta = createTestMetadata("tile_a", 1.0);
+    firstMeta.organismType = OrganismType::NES_DUCK;
+    firstMeta.brainKind = "NesTileRecurrent";
+    firstMeta.nesTileBrainCompatibility = NesTileBrainCompatibilityMetadata{
+        .schemaVersion = NesTileBrainCompatibilityMetadata::CurrentSchemaVersion,
+        .tileVocabularySize = 512,
+        .tileEmbeddingDim = 4,
+        .relativeTileColumns = 63,
+        .relativeTileRows = 55,
+        .scalarInputSize = 44,
+        .h1Size = 64,
+        .h2Size = 32,
+        .outputSize = 4,
+        .voidTokenId = 0,
+        .tokenizerVocabularyHash = "first",
+    };
+    auto secondMeta = firstMeta;
+    secondMeta.name = "tile_b";
+    secondMeta.nesTileBrainCompatibility->tokenizerVocabularyHash = "second";
+
+    const auto first = repo.storeOrUpdateByHash(genome, firstMeta);
+    const auto second = repo.storeOrUpdateByHash(genome, secondMeta);
+
+    EXPECT_EQ(repo.count(), 2u);
+    EXPECT_TRUE(first.inserted);
+    EXPECT_TRUE(second.inserted);
+    EXPECT_NE(first.id, second.id);
+}
+
 TEST_F(GenomeRepositoryTest, PruneManagedByFitnessKeepsBestId)
 {
     const GenomeId idLow = UUID::generate();
@@ -489,6 +523,8 @@ protected:
             .brainKind = std::nullopt,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
     }
 };
@@ -510,6 +546,19 @@ TEST_F(GenomeRepositoryPersistenceTest, GenomePersistsAcrossReopen)
     GenomeId id = UUID::generate();
     auto genome = createTestGenome(0.42f);
     auto meta = createTestMetadata("persistent_genome", 3.14);
+    meta.nesTileBrainCompatibility = NesTileBrainCompatibilityMetadata{
+        .schemaVersion = NesTileBrainCompatibilityMetadata::CurrentSchemaVersion,
+        .tileVocabularySize = 512,
+        .tileEmbeddingDim = 4,
+        .relativeTileColumns = 63,
+        .relativeTileRows = 55,
+        .scalarInputSize = 44,
+        .h1Size = 64,
+        .h2Size = 32,
+        .outputSize = 4,
+        .voidTokenId = 0,
+        .tokenizerVocabularyHash = "persistent-hash",
+    };
 
     // Store in first instance.
     {
@@ -538,6 +587,9 @@ TEST_F(GenomeRepositoryPersistenceTest, GenomePersistsAcrossReopen)
         EXPECT_DOUBLE_EQ(retrievedMeta->fitness, 3.14);
         EXPECT_EQ(retrievedMeta->generation, 42);
         EXPECT_EQ(retrievedMeta->notes, "test notes");
+        ASSERT_TRUE(retrievedMeta->nesTileBrainCompatibility.has_value());
+        EXPECT_EQ(
+            retrievedMeta->nesTileBrainCompatibility->tokenizerVocabularyHash, "persistent-hash");
     }
 }
 

--- a/apps/src/core/organisms/evolution/tests/TrainingRunnerTraceHarness_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunnerTraceHarness_test.cpp
@@ -603,6 +603,8 @@ TEST(TrainingRunnerTraceHarnessTest, ResolveConfiguredGenomeSelectionLoadsReposi
                 .brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2,
                 .brainVariant = std::nullopt,
                 .trainingSessionId = std::nullopt,
+                .genomePoolId = GenomePoolId::Smb,
+                .nesTileBrainCompatibility = std::nullopt,
             });
     }
 

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -237,6 +237,15 @@ public:
         return sensory;
     }
 
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .controllerMask = input.controllerMask,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
+    }
+
 private:
     int* controllerCallCount_ = nullptr;
     int* evaluateCallCount_ = nullptr;
@@ -285,6 +294,15 @@ public:
         sensory.position = { DuckSensoryData::GRID_SIZE / 2, DuckSensoryData::GRID_SIZE / 2 };
         sensory.delta_time_seconds = input.deltaTimeSeconds;
         return sensory;
+    }
+
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .controllerMask = input.controllerMask,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
     }
 
 private:
@@ -339,6 +357,15 @@ public:
         sensory.position = { DuckSensoryData::GRID_SIZE / 2, DuckSensoryData::GRID_SIZE / 2 };
         sensory.delta_time_seconds = input.deltaTimeSeconds;
         return sensory;
+    }
+
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .controllerMask = input.controllerMask,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
     }
 };
 

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -433,6 +433,29 @@ TEST_F(TrainingRunnerTest, TrainingBrainRegistryIncludesNesScenarioDrivenEntry)
     EXPECT_TRUE(entry->isGenomeCompatible(genome));
 }
 
+TEST_F(TrainingRunnerTest, TrainingBrainRegistryIncludesNesTileRecurrentEntry)
+{
+    TrainingBrainRegistry registry = TrainingBrainRegistry::createDefault();
+    const BrainRegistryEntry* entry =
+        registry.find(OrganismType::NES_DUCK, TrainingBrainKind::NesTileRecurrent, "");
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->controlMode, BrainRegistryEntry::ControlMode::ScenarioDriven);
+    EXPECT_TRUE(entry->requiresGenome);
+    EXPECT_TRUE(entry->allowsMutation);
+    ASSERT_TRUE(entry->createRandomGenome);
+    ASSERT_TRUE(entry->isGenomeCompatible);
+    ASSERT_TRUE(entry->getGenomeLayout);
+
+    const Genome genome = entry->createRandomGenome(rng_);
+    const GenomeLayout layout = entry->getGenomeLayout();
+
+    EXPECT_TRUE(entry->isGenomeCompatible(genome));
+    EXPECT_EQ(genome.weights.size(), static_cast<size_t>(layout.totalSize()));
+    EXPECT_NE(
+        registry.find(OrganismType::NES_DUCK, TrainingBrainKind::DuckNeuralNetRecurrentV2, ""),
+        nullptr);
+}
+
 TEST_F(TrainingRunnerTest, TrainingBrainRegistryDoesNotIncludeLegacyDuckNeuralNetEntry)
 {
     TrainingBrainRegistry registry = TrainingBrainRegistry::createDefault();
@@ -464,6 +487,64 @@ TEST_F(TrainingRunnerTest, NesFlappyScenarioDrivenRunnerDoesNotSpawnOrganism)
     EXPECT_EQ(runner.getOrganism(), nullptr);
     EXPECT_EQ(status.nesFramesSurvived, 0u);
     EXPECT_DOUBLE_EQ(status.nesRewardTotal, 0.0);
+}
+
+TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerConstructsWithoutSpawningOrganism)
+{
+    TrainingSpec spec;
+    spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    spec.organismType = OrganismType::NES_DUCK;
+
+    TrainingBrainRegistry registry = TrainingBrainRegistry::createDefault();
+    const BrainRegistryEntry* entry =
+        registry.find(OrganismType::NES_DUCK, TrainingBrainKind::NesTileRecurrent, "");
+    ASSERT_NE(entry, nullptr);
+    ASSERT_TRUE(entry->createRandomGenome);
+
+    TrainingRunner::Individual individual;
+    individual.brain.brainKind = TrainingBrainKind::NesTileRecurrent;
+    individual.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    individual.genome = entry->createRandomGenome(rng_);
+
+    TrainingRunner runner(spec, individual, config_, genomeRepository_);
+    const auto status = runner.step(0);
+
+    EXPECT_EQ(runner.getOrganism(), nullptr);
+    EXPECT_EQ(status.nesFramesSurvived, 0u);
+    EXPECT_DOUBLE_EQ(status.nesRewardTotal, 0.0);
+}
+
+TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerFailsLoudlyWithoutTokenizer)
+{
+    const std::optional<std::filesystem::path> romPath = resolveNesFixtureRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing. Run 'cd apps && make fetch-nes-test-rom' or set "
+                        "DIRTSIM_NES_TEST_ROM_PATH.";
+    }
+
+    config_.maxSimulationTime = 1.0;
+
+    TrainingSpec spec;
+    spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    spec.organismType = OrganismType::NES_DUCK;
+
+    TrainingBrainRegistry registry = TrainingBrainRegistry::createDefault();
+    const BrainRegistryEntry* entry =
+        registry.find(OrganismType::NES_DUCK, TrainingBrainKind::NesTileRecurrent, "");
+    ASSERT_NE(entry, nullptr);
+    ASSERT_TRUE(entry->createRandomGenome);
+
+    TrainingRunner::Individual individual;
+    individual.brain.brainKind = TrainingBrainKind::NesTileRecurrent;
+    individual.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    individual.genome = entry->createRandomGenome(rng_);
+
+    TrainingRunner runner(spec, individual, config_, genomeRepository_);
+
+    const std::string previousDeathTestStyle = ::testing::FLAGS_gtest_death_test_style;
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_DEATH({ static_cast<void>(runner.step(1)); }, ".*");
+    ::testing::FLAGS_gtest_death_test_style = previousDeathTestStyle;
 }
 
 TEST_F(TrainingRunnerTest, NesFlappyScenarioDrivenRunnerTerminatesBeforeInfiniteLoop)

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -21,12 +21,16 @@
 #include "core/scenarios/clock_scenario/ObstacleManager.h"
 #include "core/scenarios/nes/NesGameAdapter.h"
 #include "core/scenarios/nes/NesGameAdapterRegistry.h"
+#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
 #include <random>
 
 namespace DirtSim {
@@ -545,6 +549,72 @@ TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerFailsLoudlyWithoutTokenizer)
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     EXPECT_DEATH({ static_cast<void>(runner.step(1)); }, ".*");
     ::testing::FLAGS_gtest_death_test_style = previousDeathTestStyle;
+}
+
+TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerAdvancesWithBootstrappedTokenizer)
+{
+    const std::optional<std::filesystem::path> romPath = resolveNesFixtureRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing. Run 'cd apps && make fetch-nes-test-rom' or set "
+                        "DIRTSIM_NES_TEST_ROM_PATH.";
+    }
+
+    config_.maxSimulationTime = 1.0;
+
+    NesSmolnesScenarioDriver bootstrapDriver(Scenario::EnumType::NesFlappyParatroopa);
+    const auto setupResult = bootstrapDriver.setup();
+    ASSERT_TRUE(setupResult.isValue()) << setupResult.errorValue();
+    Timers bootstrapTimers;
+    const auto bootstrapStep = bootstrapDriver.step(bootstrapTimers, 0u);
+    ASSERT_GT(bootstrapStep.advancedFrames, 0u);
+    const auto ppuSnapshot = bootstrapDriver.copyRuntimePpuSnapshot();
+    ASSERT_TRUE(ppuSnapshot.has_value());
+
+    auto tokenizer = std::make_shared<NesTileTokenizer>();
+    NesTileVocabularyBuilder vocabularyBuilder;
+    vocabularyBuilder.addSnapshot(ppuSnapshot.value());
+    const auto vocabularyResult = vocabularyBuilder.buildFrozenTokenizer(*tokenizer);
+    ASSERT_TRUE(vocabularyResult.isValue()) << vocabularyResult.errorValue();
+    ASSERT_GT(vocabularyResult.value().uniquePatternCount, 0u);
+    EXPECT_EQ(tokenizer->getMode(), NesTileTokenizer::Mode::Frozen);
+
+    TrainingSpec spec;
+    spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    spec.organismType = OrganismType::NES_DUCK;
+
+    TrainingBrainRegistry registry = TrainingBrainRegistry::createDefault();
+    const BrainRegistryEntry* entry =
+        registry.find(OrganismType::NES_DUCK, TrainingBrainKind::NesTileRecurrent, "");
+    ASSERT_NE(entry, nullptr);
+    ASSERT_TRUE(entry->createRandomGenome);
+
+    TrainingRunner::Individual individual;
+    individual.brain.brainKind = TrainingBrainKind::NesTileRecurrent;
+    individual.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    individual.genome = entry->createRandomGenome(rng_);
+
+    TrainingRunner::Config runnerConfig{
+        .brainRegistry = TrainingBrainRegistry::createDefault(),
+        .nesTileTokenizer = tokenizer,
+    };
+    TrainingRunner runner(spec, individual, config_, genomeRepository_, runnerConfig);
+
+    TrainingRunner::Status status;
+    int steps = 0;
+    while (!runner.getNesLastControllerTelemetry().has_value()
+           && (status = runner.step(1)).state == TrainingRunner::State::Running) {
+        ++steps;
+        ASSERT_LT(steps, 10) << "Bootstrapped tile runner should produce telemetry promptly";
+    }
+
+    EXPECT_EQ(status.state, TrainingRunner::State::Running);
+    EXPECT_GT(status.nesFramesSurvived, 0u);
+    ASSERT_TRUE(runner.getNesLastControllerTelemetry().has_value());
+    const NesControllerTelemetry& telemetry = runner.getNesLastControllerTelemetry().value();
+    EXPECT_TRUE(std::isfinite(telemetry.xRaw));
+    EXPECT_TRUE(std::isfinite(telemetry.yRaw));
+    EXPECT_TRUE(std::isfinite(telemetry.aRaw));
+    EXPECT_TRUE(std::isfinite(telemetry.bRaw));
 }
 
 TEST_F(TrainingRunnerTest, NesFlappyScenarioDrivenRunnerTerminatesBeforeInfiniteLoop)

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -21,9 +21,8 @@
 #include "core/scenarios/clock_scenario/ObstacleManager.h"
 #include "core/scenarios/nes/NesGameAdapter.h"
 #include "core/scenarios/nes/NesGameAdapterRegistry.h"
-#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
-#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -561,22 +560,16 @@ TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerAdvancesWithBootstrappedTokeniz
 
     config_.maxSimulationTime = 1.0;
 
-    NesSmolnesScenarioDriver bootstrapDriver(Scenario::EnumType::NesFlappyParatroopa);
-    const auto setupResult = bootstrapDriver.setup();
-    ASSERT_TRUE(setupResult.isValue()) << setupResult.errorValue();
-    Timers bootstrapTimers;
-    const auto bootstrapStep = bootstrapDriver.step(bootstrapTimers, 0u);
-    ASSERT_GT(bootstrapStep.advancedFrames, 0u);
-    const auto ppuSnapshot = bootstrapDriver.copyRuntimePpuSnapshot();
-    ASSERT_TRUE(ppuSnapshot.has_value());
+    Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
+        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
+    nesConfig.romPath = romPath.value().string();
+    nesConfig.requireSmolnesMapper = true;
 
-    auto tokenizer = std::make_shared<NesTileTokenizer>();
-    NesTileVocabularyBuilder vocabularyBuilder;
-    vocabularyBuilder.addSnapshot(ppuSnapshot.value());
-    const auto vocabularyResult = vocabularyBuilder.buildFrozenTokenizer(*tokenizer);
-    ASSERT_TRUE(vocabularyResult.isValue()) << vocabularyResult.errorValue();
-    ASSERT_GT(vocabularyResult.value().uniquePatternCount, 0u);
-    EXPECT_EQ(tokenizer->getMode(), NesTileTokenizer::Mode::Frozen);
+    auto tokenizerResult = NesTileTokenizerBootstrapper::build(
+        Scenario::EnumType::NesFlappyParatroopa, ScenarioConfig{ nesConfig });
+    ASSERT_TRUE(tokenizerResult.isValue()) << tokenizerResult.errorValue();
+    ASSERT_NE(tokenizerResult.value(), nullptr);
+    EXPECT_EQ(tokenizerResult.value()->getMode(), NesTileTokenizer::Mode::Frozen);
 
     TrainingSpec spec;
     spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
@@ -595,7 +588,8 @@ TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerAdvancesWithBootstrappedTokeniz
 
     TrainingRunner::Config runnerConfig{
         .brainRegistry = TrainingBrainRegistry::createDefault(),
-        .nesTileTokenizer = tokenizer,
+        .nesTileTokenizer = tokenizerResult.value(),
+        .scenarioConfigOverride = ScenarioConfig{ nesConfig },
     };
     TrainingRunner runner(spec, individual, config_, genomeRepository_, runnerConfig);
 

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -609,6 +609,14 @@ TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerAdvancesWithBootstrappedTokeniz
     EXPECT_TRUE(std::isfinite(telemetry.yRaw));
     EXPECT_TRUE(std::isfinite(telemetry.aRaw));
     EXPECT_TRUE(std::isfinite(telemetry.bRaw));
+
+    const Timers* timers = runner.getTimers();
+    ASSERT_NE(timers, nullptr);
+    EXPECT_GT(timers->getCallCount("nes_tile_controller_infer_total"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_sensory_total"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_frame_extract"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_build_sensory"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_brain_infer"), 0u);
 }
 
 TEST_F(TrainingRunnerTest, NesFlappyScenarioDrivenRunnerTerminatesBeforeInfiniteLoop)

--- a/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
+++ b/apps/src/core/organisms/evolution/tests/TrainingRunner_test.cpp
@@ -615,6 +615,10 @@ TEST_F(TrainingRunnerTest, NesTileRecurrentRunnerAdvancesWithBootstrappedTokeniz
     EXPECT_GT(timers->getCallCount("nes_tile_controller_infer_total"), 0u);
     EXPECT_GT(timers->getCallCount("nes_tile_sensory_total"), 0u);
     EXPECT_GT(timers->getCallCount("nes_tile_frame_extract"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_frame_scroll_decode"), 0u);
+    EXPECT_EQ(timers->getCallCount("nes_tile_frame_pattern_pixels"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_frame_tile_ids"), 0u);
+    EXPECT_GT(timers->getCallCount("nes_tile_frame_tile_hashes"), 0u);
     EXPECT_GT(timers->getCallCount("nes_tile_build_sensory"), 0u);
     EXPECT_GT(timers->getCallCount("nes_tile_brain_infer"), 0u);
 }

--- a/apps/src/core/scenarios/nes/NesFlappyParatroopaGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesFlappyParatroopaGameAdapter.cpp
@@ -13,6 +13,9 @@ namespace {
 constexpr float kFlappyBirdCenterXPx = 64.0f;
 constexpr float kFlappyFrameHeightPx = 240.0f;
 constexpr float kFlappyFrameWidthPx = 256.0f;
+constexpr int16_t kFlappyDefaultTilePlayerScreenX = 128;
+constexpr int16_t kFlappyDefaultTilePlayerScreenY =
+    120 - static_cast<int16_t>(NesTileFrame::TopCropPixels);
 constexpr uint8_t kNesStateTitle = 0;
 constexpr uint8_t kNesStateWaiting = 1;
 constexpr uint8_t kNesStateGameOver = 7;
@@ -80,6 +83,8 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTilePlayerScreenX_ = kFlappyDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kFlappyDefaultTilePlayerScreenY;
     }
 
     NesGameAdapterControllerOutput resolveControllerMask(
@@ -122,6 +127,8 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTilePlayerScreenX_ = kFlappyDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kFlappyDefaultTilePlayerScreenY;
 
         NesGameAdapterFrameOutput output;
         if (!extractor_.has_value() || !evaluator_.has_value() || !extractor_->isSupported()) {
@@ -143,8 +150,12 @@ public:
             evaluator_->evaluate(evaluatorInput.value());
         cachedSpecialSenses_ = makeFlappySpecialSenses(evaluation.features);
         cachedSelfViewX_ = normalizeViewCoordinate(kFlappyBirdCenterXPx, kFlappyFrameWidthPx);
-        cachedSelfViewY_ = normalizeViewCoordinate(
-            computeFlappyBirdCenterYPx(evaluatorInput->state), kFlappyFrameHeightPx);
+        const float birdCenterYPx = computeFlappyBirdCenterYPx(evaluatorInput->state);
+        cachedSelfViewY_ = normalizeViewCoordinate(birdCenterYPx, kFlappyFrameHeightPx);
+        cachedTilePlayerScreenX_ = static_cast<int16_t>(kFlappyBirdCenterXPx);
+        cachedTilePlayerScreenY_ = static_cast<int16_t>(
+            static_cast<int16_t>(birdCenterYPx)
+            - static_cast<int16_t>(NesTileFrame::TopCropPixels));
         output.done = evaluation.done;
         output.gameState = evaluation.gameState;
         output.rewardDelta = evaluation.rewardDelta;
@@ -164,6 +175,21 @@ public:
             input.controllerMask);
     }
 
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .playerScreenX = cachedTilePlayerScreenX_,
+            .playerScreenY = cachedTilePlayerScreenY_,
+            .facingX = 0.0f,
+            .selfViewX = cachedSelfViewX_,
+            .selfViewY = cachedSelfViewY_,
+            .controllerMask = input.controllerMask,
+            .specialSenses = cachedSpecialSenses_,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
+    }
+
 private:
     std::optional<NesFlappyParatroopaRamExtractor> extractor_ = std::nullopt;
     std::optional<NesFlappyBirdEvaluator> evaluator_ = std::nullopt;
@@ -173,6 +199,8 @@ private:
     std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> cachedSpecialSenses_{};
     float cachedSelfViewX_ = 0.5f;
     float cachedSelfViewY_ = 0.5f;
+    int16_t cachedTilePlayerScreenX_ = kFlappyDefaultTilePlayerScreenX;
+    int16_t cachedTilePlayerScreenY_ = kFlappyDefaultTilePlayerScreenY;
 };
 
 } // namespace

--- a/apps/src/core/scenarios/nes/NesGameAdapter.h
+++ b/apps/src/core/scenarios/nes/NesGameAdapter.h
@@ -62,6 +62,7 @@ struct NesGameAdapterSensoryInput {
     const NesPaletteFrame* paletteFrame = nullptr;
     std::optional<uint8_t> lastGameState = std::nullopt;
     double deltaTimeSeconds = 0.0;
+    std::optional<uint16_t> tileFrameScrollX = std::nullopt;
 };
 
 /**

--- a/apps/src/core/scenarios/nes/NesGameAdapter.h
+++ b/apps/src/core/scenarios/nes/NesGameAdapter.h
@@ -5,6 +5,7 @@
 #include "core/scenarios/nes/NesControllerTelemetry.h"
 #include "core/scenarios/nes/NesFitnessDetails.h"
 #include "core/scenarios/nes/NesPaletteFrame.h"
+#include "core/scenarios/nes/NesTileSensoryBuilder.h"
 #include "core/scenarios/nes/SmolnesRuntime.h"
 
 #include <array>
@@ -75,6 +76,8 @@ public:
         const NesGameAdapterControllerInput& input) = 0;
     virtual NesGameAdapterFrameOutput evaluateFrame(const NesGameAdapterFrameInput& input) = 0;
     virtual DuckSensoryData makeDuckSensoryData(const NesGameAdapterSensoryInput& input) const = 0;
+    virtual NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const = 0;
 };
 
 std::unique_ptr<NesGameAdapter> createNesFlappyParatroopaGameAdapter();

--- a/apps/src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
@@ -1,0 +1,78 @@
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace DirtSim {
+
+namespace {
+
+int16_t tileCoordinateForPixel(int16_t pixel)
+{
+    if (pixel >= 0) {
+        return static_cast<int16_t>(pixel / NesPlayerRelativeTileFrame::TileSizePixels);
+    }
+
+    return static_cast<int16_t>(
+        -(((-pixel) + static_cast<int16_t>(NesPlayerRelativeTileFrame::TileSizePixels) - 1)
+          / NesPlayerRelativeTileFrame::TileSizePixels));
+}
+
+size_t relativeTileIndex(int16_t column, int16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::RelativeTileColumns
+        + static_cast<size_t>(column);
+}
+
+size_t screenTileIndex(int16_t column, int16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::ScreenTileColumns
+        + static_cast<size_t>(column);
+}
+
+} // namespace
+
+NesPlayerRelativeTileFrame makeNesPlayerRelativeTileFrame(
+    const NesTileTokenFrame& tokenFrame, int16_t playerScreenX, int16_t playerScreenY)
+{
+    NesPlayerRelativeTileFrame relativeFrame{
+        .frameId = tokenFrame.frameId,
+        .scrollX = tokenFrame.scrollX,
+        .scrollY = tokenFrame.scrollY,
+        .playerScreenX = playerScreenX,
+        .playerScreenY = playerScreenY,
+        .playerTileColumn = tileCoordinateForPixel(playerScreenX),
+        .playerTileRow = tileCoordinateForPixel(playerScreenY),
+    };
+    relativeFrame.tokens.fill(NesTileTokenizer::VoidToken);
+
+    for (int16_t screenRow = 0;
+         screenRow < static_cast<int16_t>(NesPlayerRelativeTileFrame::ScreenTileRows);
+         ++screenRow) {
+        for (int16_t screenColumn = 0;
+             screenColumn < static_cast<int16_t>(NesPlayerRelativeTileFrame::ScreenTileColumns);
+             ++screenColumn) {
+            const int16_t relativeColumn = static_cast<int16_t>(
+                static_cast<int16_t>(NesPlayerRelativeTileFrame::AnchorTileColumn) + screenColumn
+                - relativeFrame.playerTileColumn);
+            const int16_t relativeRow = static_cast<int16_t>(
+                static_cast<int16_t>(NesPlayerRelativeTileFrame::AnchorTileRow) + screenRow
+                - relativeFrame.playerTileRow);
+            if (relativeColumn < 0
+                || relativeColumn
+                    >= static_cast<int16_t>(NesPlayerRelativeTileFrame::RelativeTileColumns)
+                || relativeRow < 0
+                || relativeRow
+                    >= static_cast<int16_t>(NesPlayerRelativeTileFrame::RelativeTileRows)) {
+                continue;
+            }
+
+            relativeFrame.tokens[relativeTileIndex(relativeColumn, relativeRow)] =
+                tokenFrame.tokens[screenTileIndex(screenColumn, screenRow)];
+        }
+    }
+
+    return relativeFrame;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesPlayerRelativeTileFrame.h
+++ b/apps/src/core/scenarios/nes/NesPlayerRelativeTileFrame.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+
+#include <array>
+#include <cstdint>
+
+namespace DirtSim {
+
+struct NesPlayerRelativeTileFrame {
+    static constexpr uint16_t ScreenTileColumns = NesTileTokenFrame::VisibleTileColumns;
+    static constexpr uint16_t ScreenTileRows = NesTileTokenFrame::VisibleTileRows;
+    static constexpr uint16_t AnchorTileColumn = ScreenTileColumns - 1u;
+    static constexpr uint16_t AnchorTileRow = ScreenTileRows - 1u;
+    static constexpr uint16_t RelativeTileColumns = ScreenTileColumns * 2u - 1u;
+    static constexpr uint16_t RelativeTileRows = ScreenTileRows * 2u - 1u;
+    static constexpr uint16_t TileSizePixels = 8u;
+
+    uint64_t frameId = 0;
+    uint16_t scrollX = 0;
+    uint16_t scrollY = 0;
+    int16_t playerScreenX = 0;
+    int16_t playerScreenY = 0;
+    int16_t playerTileColumn = 0;
+    int16_t playerTileRow = 0;
+    std::array<NesTileTokenizer::TileToken, RelativeTileColumns * RelativeTileRows> tokens{};
+};
+
+NesPlayerRelativeTileFrame makeNesPlayerRelativeTileFrame(
+    const NesTileTokenFrame& tokenFrame, int16_t playerScreenX, int16_t playerScreenY);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesPpuSnapshot.h
+++ b/apps/src/core/scenarios/nes/NesPpuSnapshot.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace DirtSim {
+
+struct NesPpuSnapshot {
+    static constexpr size_t ChrBytes = 8192u;
+    static constexpr size_t OamBytes = 256u;
+    static constexpr size_t VramBytes = 2048u;
+
+    uint64_t frameId = 0;
+    uint16_t v = 0;
+    uint8_t fineX = 0;
+    uint8_t mirror = 0;
+    uint8_t ppuCtrl = 0;
+    uint8_t ppuMask = 0;
+    std::array<uint8_t, ChrBytes> chr{};
+    std::array<uint8_t, OamBytes> oam{};
+    std::array<uint8_t, VramBytes> vram{};
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.cpp
@@ -395,6 +395,14 @@ std::optional<SmolnesRuntime::MemorySnapshot> NesSmolnesScenarioDriver::copyRunt
     return runtime_->copyMemorySnapshot();
 }
 
+std::optional<NesPpuSnapshot> NesSmolnesScenarioDriver::copyRuntimePpuSnapshot() const
+{
+    if (!runtime_ || !runtime_->isRunning() || !runtime_->isHealthy()) {
+        return std::nullopt;
+    }
+    return runtime_->copyPpuSnapshot();
+}
+
 std::optional<SmolnesRuntime::ProfilingSnapshot> NesSmolnesScenarioDriver::
     copyRuntimeProfilingSnapshot() const
 {

--- a/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
+++ b/apps/src/core/scenarios/nes/NesSmolnesScenarioDriver.h
@@ -5,6 +5,7 @@
 #include "core/ScenarioId.h"
 #include "core/Timers.h"
 #include "core/scenarios/nes/NesControllerTelemetry.h"
+#include "core/scenarios/nes/NesPpuSnapshot.h"
 #include "core/scenarios/nes/NesRomValidation.h"
 #include "core/scenarios/nes/NesScenarioRuntime.h"
 #include "core/scenarios/nes/NesSuperMarioBrosResponseProbe.h"
@@ -77,6 +78,7 @@ public:
     std::optional<ScenarioVideoFrame> copyRuntimeFrameSnapshot() const override;
     std::optional<NesPaletteFrame> copyRuntimePaletteFrame() const override;
     std::optional<SmolnesRuntime::MemorySnapshot> copyRuntimeMemorySnapshot() const override;
+    std::optional<NesPpuSnapshot> copyRuntimePpuSnapshot() const;
     std::optional<SmolnesRuntime::ProfilingSnapshot> copyRuntimeProfilingSnapshot() const;
     std::optional<SmolnesRuntime::ApuSnapshot> copyRuntimeApuSnapshot() const;
     uint32_t copyRuntimeApuSamples(float* buffer, uint32_t maxSamples) const;

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
@@ -6,9 +6,11 @@
 #include "core/scenarios/nes/NesSuperMarioBrosEvaluator.h"
 #include "core/scenarios/nes/NesSuperMarioBrosRamExtractor.h"
 #include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
+#include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 
 namespace DirtSim {
 
@@ -85,6 +87,7 @@ public:
         cachedFacingX_ = 0.0f;
         evaluator_.reset();
         cachedSpecialSenses_.fill(0.0);
+        cachedTileGameplayState_ = std::nullopt;
         cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
         cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
         setupFailureLogged_ = false;
@@ -117,6 +120,7 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTileGameplayState_ = std::nullopt;
         cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
         cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
 
@@ -167,10 +171,9 @@ public:
                 normalizeViewCoordinate(static_cast<double>(state.playerXScreen), kNesFrameWidth);
             cachedSelfViewY_ =
                 normalizeViewCoordinate(static_cast<double>(state.playerYScreen), kNesFrameHeight);
+            cachedTileGameplayState_ = state;
             cachedTilePlayerScreenX_ = static_cast<int16_t>(state.playerXScreen);
-            cachedTilePlayerScreenY_ = static_cast<int16_t>(
-                static_cast<int16_t>(state.playerYScreen)
-                - static_cast<int16_t>(NesTileFrame::TopCropPixels));
+            cachedTilePlayerScreenY_ = makeNesSuperMarioBrosPlayerTileScreenY(state);
         }
 
         const NesSuperMarioBrosEvaluatorInput evaluatorInput{
@@ -200,9 +203,20 @@ public:
     NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
         const NesGameAdapterSensoryInput& input) const override
     {
+        int16_t playerScreenX = cachedTilePlayerScreenX_;
+        int16_t playerScreenY = cachedTilePlayerScreenY_;
+        if (cachedTileGameplayState_.has_value()) {
+            playerScreenY =
+                makeNesSuperMarioBrosPlayerTileScreenY(cachedTileGameplayState_.value());
+            if (input.tileFrameScrollX.has_value()) {
+                playerScreenX = makeNesSuperMarioBrosPlayerTileScreenX(
+                    cachedTileGameplayState_.value(), input.tileFrameScrollX.value());
+            }
+        }
+
         return NesTileSensoryBuilderInput{
-            .playerScreenX = cachedTilePlayerScreenX_,
-            .playerScreenY = cachedTilePlayerScreenY_,
+            .playerScreenX = playerScreenX,
+            .playerScreenY = playerScreenY,
             .facingX = cachedFacingX_,
             .selfViewX = cachedSelfViewX_,
             .selfViewY = cachedSelfViewY_,
@@ -221,6 +235,7 @@ private:
     float cachedFacingX_ = 0.0f;
     float cachedSelfViewX_ = 0.5f;
     float cachedSelfViewY_ = 0.5f;
+    std::optional<NesSuperMarioBrosState> cachedTileGameplayState_ = std::nullopt;
     int16_t cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
     int16_t cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
     bool setupFailureLogged_ = false;

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
@@ -16,6 +16,9 @@ namespace {
 
 constexpr double kNesFrameHeight = 240.0;
 constexpr double kNesFrameWidth = 256.0;
+constexpr int16_t kSmbDefaultTilePlayerScreenX = 128;
+constexpr int16_t kSmbDefaultTilePlayerScreenY =
+    120 - static_cast<int16_t>(NesTileFrame::TopCropPixels);
 
 double normalizeSmb(double value, double maxValue)
 {
@@ -82,6 +85,8 @@ public:
         cachedFacingX_ = 0.0f;
         evaluator_.reset();
         cachedSpecialSenses_.fill(0.0);
+        cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
         setupFailureLogged_ = false;
     }
 
@@ -112,6 +117,8 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
 
         NesGameAdapterFrameOutput output;
         if (!input.memorySnapshot.has_value()) {
@@ -160,6 +167,10 @@ public:
                 normalizeViewCoordinate(static_cast<double>(state.playerXScreen), kNesFrameWidth);
             cachedSelfViewY_ =
                 normalizeViewCoordinate(static_cast<double>(state.playerYScreen), kNesFrameHeight);
+            cachedTilePlayerScreenX_ = static_cast<int16_t>(state.playerXScreen);
+            cachedTilePlayerScreenY_ = static_cast<int16_t>(
+                static_cast<int16_t>(state.playerYScreen)
+                - static_cast<int16_t>(NesTileFrame::TopCropPixels));
         }
 
         const NesSuperMarioBrosEvaluatorInput evaluatorInput{
@@ -186,6 +197,21 @@ public:
             input.controllerMask);
     }
 
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .playerScreenX = cachedTilePlayerScreenX_,
+            .playerScreenY = cachedTilePlayerScreenY_,
+            .facingX = cachedFacingX_,
+            .selfViewX = cachedSelfViewX_,
+            .selfViewY = cachedSelfViewY_,
+            .controllerMask = input.controllerMask,
+            .specialSenses = cachedSpecialSenses_,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
+    }
+
 private:
     NesPaletteClusterer paletteClusterer_;
     NesSuperMarioBrosRamExtractor extractor_;
@@ -195,6 +221,8 @@ private:
     float cachedFacingX_ = 0.0f;
     float cachedSelfViewX_ = 0.5f;
     float cachedSelfViewY_ = 0.5f;
+    int16_t cachedTilePlayerScreenX_ = kSmbDefaultTilePlayerScreenX;
+    int16_t cachedTilePlayerScreenY_ = kSmbDefaultTilePlayerScreenY;
     bool setupFailureLogged_ = false;
 };
 

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosTilePosition.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosTilePosition.cpp
@@ -1,0 +1,41 @@
+#include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
+
+#include "core/scenarios/nes/NesTileFrame.h"
+
+#include <cstdint>
+
+namespace DirtSim {
+
+namespace {
+
+constexpr int16_t kSmbNametablePixelPeriod = 512;
+
+int16_t wrappedNametableDelta(uint16_t value, uint16_t origin)
+{
+    int16_t delta = static_cast<int16_t>(
+        static_cast<int32_t>(value & 0x01FFu) - static_cast<int32_t>(origin & 0x01FFu));
+    if (delta < -(kSmbNametablePixelPeriod / 2)) {
+        delta = static_cast<int16_t>(delta + kSmbNametablePixelPeriod);
+    }
+    if (delta > (kSmbNametablePixelPeriod / 2 - 1)) {
+        delta = static_cast<int16_t>(delta - kSmbNametablePixelPeriod);
+    }
+    return delta;
+}
+
+} // namespace
+
+int16_t makeNesSuperMarioBrosPlayerTileScreenX(
+    const NesSuperMarioBrosState& state, uint16_t tileFrameScrollX)
+{
+    return wrappedNametableDelta(state.absoluteX, tileFrameScrollX);
+}
+
+int16_t makeNesSuperMarioBrosPlayerTileScreenY(const NesSuperMarioBrosState& state)
+{
+    return static_cast<int16_t>(
+        static_cast<int16_t>(state.playerYScreen)
+        - static_cast<int16_t>(NesTileFrame::TopCropPixels));
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosTilePosition.h
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosTilePosition.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "core/scenarios/nes/NesSuperMarioBrosEvaluator.h"
+
+#include <cstdint>
+
+namespace DirtSim {
+
+int16_t makeNesSuperMarioBrosPlayerTileScreenX(
+    const NesSuperMarioBrosState& state, uint16_t tileFrameScrollX);
+int16_t makeNesSuperMarioBrosPlayerTileScreenY(const NesSuperMarioBrosState& state);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesSuperTiltBroGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperTiltBroGameAdapter.cpp
@@ -8,6 +8,9 @@
 namespace DirtSim {
 
 namespace {
+constexpr int16_t kDefaultTilePlayerScreenX = 128;
+constexpr int16_t kDefaultTilePlayerScreenY =
+    120 - static_cast<int16_t>(NesTileFrame::TopCropPixels);
 constexpr uint64_t kSetupScriptEndFrame = 1200;
 constexpr size_t kPlayerADamagesAddr = 0x48;
 constexpr size_t kPlayerBDamagesAddr = 0x49;
@@ -51,6 +54,8 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTilePlayerScreenX_ = kDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kDefaultTilePlayerScreenY;
     }
 
     NesGameAdapterControllerOutput resolveControllerMask(
@@ -78,6 +83,8 @@ public:
         cachedSpecialSenses_.fill(0.0);
         cachedSelfViewX_ = 0.5f;
         cachedSelfViewY_ = 0.5f;
+        cachedTilePlayerScreenX_ = kDefaultTilePlayerScreenX;
+        cachedTilePlayerScreenY_ = kDefaultTilePlayerScreenY;
 
         NesGameAdapterFrameOutput output;
         output.rewardDelta += static_cast<double>(input.advancedFrames);
@@ -163,6 +170,21 @@ public:
             input.controllerMask);
     }
 
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .playerScreenX = cachedTilePlayerScreenX_,
+            .playerScreenY = cachedTilePlayerScreenY_,
+            .facingX = 0.0f,
+            .selfViewX = cachedSelfViewX_,
+            .selfViewY = cachedSelfViewY_,
+            .controllerMask = input.controllerMask,
+            .specialSenses = cachedSpecialSenses_,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
+    }
+
 private:
     static constexpr double kDamageReward = 1.0;
     static constexpr double kStockReward = 600.0;
@@ -191,6 +213,8 @@ private:
     std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> cachedSpecialSenses_{};
     float cachedSelfViewX_ = 0.5f;
     float cachedSelfViewY_ = 0.5f;
+    int16_t cachedTilePlayerScreenX_ = kDefaultTilePlayerScreenX;
+    int16_t cachedTilePlayerScreenY_ = kDefaultTilePlayerScreenY;
 };
 
 } // namespace

--- a/apps/src/core/scenarios/nes/NesTileBrainMetadata.cpp
+++ b/apps/src/core/scenarios/nes/NesTileBrainMetadata.cpp
@@ -1,0 +1,107 @@
+#include "core/scenarios/nes/NesTileBrainMetadata.h"
+
+#include "core/ReflectSerializer.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <sstream>
+
+namespace DirtSim {
+
+namespace {
+
+template <typename T>
+std::string mismatchMessage(const char* field, const T& actual, const T& expected)
+{
+    std::ostringstream stream;
+    stream << "NES tile brain compatibility mismatch for " << field << ": checkpoint=" << actual
+           << ", current=" << expected;
+    return stream.str();
+}
+
+} // namespace
+
+NesTileBrainCompatibilityMetadata makeNesTileBrainCompatibilityMetadata(
+    const NesTileTokenizer& tokenizer)
+{
+    return NesTileBrainCompatibilityMetadata{
+        .schemaVersion = NesTileBrainCompatibilityMetadata::CurrentSchemaVersion,
+        .tileVocabularySize = NesTileRecurrentBrain::TileVocabularySize,
+        .tileEmbeddingDim = NesTileRecurrentBrain::TileEmbeddingDim,
+        .relativeTileColumns = NesPlayerRelativeTileFrame::RelativeTileColumns,
+        .relativeTileRows = NesPlayerRelativeTileFrame::RelativeTileRows,
+        .scalarInputSize = NesTileRecurrentBrain::ScalarInputSize,
+        .h1Size = NesTileRecurrentBrain::H1Size,
+        .h2Size = NesTileRecurrentBrain::H2Size,
+        .outputSize = NesTileRecurrentBrain::OutputSize,
+        .voidTokenId = NesTileTokenizer::VoidToken,
+        .tokenizerVocabularyHash = tokenizer.getVocabularyHash(),
+    };
+}
+
+Result<std::monostate, std::string> validateNesTileBrainCompatibilityMetadata(
+    const NesTileBrainCompatibilityMetadata& actual,
+    const NesTileBrainCompatibilityMetadata& expected)
+{
+    if (actual.schemaVersion != expected.schemaVersion) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("schemaVersion", actual.schemaVersion, expected.schemaVersion));
+    }
+    if (actual.tileVocabularySize != expected.tileVocabularySize) {
+        return Result<std::monostate, std::string>::error(mismatchMessage(
+            "tileVocabularySize", actual.tileVocabularySize, expected.tileVocabularySize));
+    }
+    if (actual.tileEmbeddingDim != expected.tileEmbeddingDim) {
+        return Result<std::monostate, std::string>::error(mismatchMessage(
+            "tileEmbeddingDim", actual.tileEmbeddingDim, expected.tileEmbeddingDim));
+    }
+    if (actual.relativeTileColumns != expected.relativeTileColumns) {
+        return Result<std::monostate, std::string>::error(mismatchMessage(
+            "relativeTileColumns", actual.relativeTileColumns, expected.relativeTileColumns));
+    }
+    if (actual.relativeTileRows != expected.relativeTileRows) {
+        return Result<std::monostate, std::string>::error(mismatchMessage(
+            "relativeTileRows", actual.relativeTileRows, expected.relativeTileRows));
+    }
+    if (actual.scalarInputSize != expected.scalarInputSize) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("scalarInputSize", actual.scalarInputSize, expected.scalarInputSize));
+    }
+    if (actual.h1Size != expected.h1Size) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("h1Size", actual.h1Size, expected.h1Size));
+    }
+    if (actual.h2Size != expected.h2Size) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("h2Size", actual.h2Size, expected.h2Size));
+    }
+    if (actual.outputSize != expected.outputSize) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("outputSize", actual.outputSize, expected.outputSize));
+    }
+    if (actual.voidTokenId != expected.voidTokenId) {
+        return Result<std::monostate, std::string>::error(
+            mismatchMessage("voidTokenId", actual.voidTokenId, expected.voidTokenId));
+    }
+    if (actual.tokenizerVocabularyHash != expected.tokenizerVocabularyHash) {
+        return Result<std::monostate, std::string>::error(mismatchMessage(
+            "tokenizerVocabularyHash",
+            actual.tokenizerVocabularyHash,
+            expected.tokenizerVocabularyHash));
+    }
+
+    return Result<std::monostate, std::string>::okay({});
+}
+
+void to_json(nlohmann::json& j, const NesTileBrainCompatibilityMetadata& metadata)
+{
+    j = ReflectSerializer::to_json(metadata);
+}
+
+void from_json(const nlohmann::json& j, NesTileBrainCompatibilityMetadata& metadata)
+{
+    metadata = ReflectSerializer::from_json<NesTileBrainCompatibilityMetadata>(j);
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileBrainMetadata.h
+++ b/apps/src/core/scenarios/nes/NesTileBrainMetadata.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "core/Result.h"
+
+#include <cstdint>
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include <variant>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+
+class NesTileTokenizer;
+
+struct NesTileBrainCompatibilityMetadata {
+    static constexpr int CurrentSchemaVersion = 1;
+
+    int schemaVersion = CurrentSchemaVersion;
+    int tileVocabularySize = 0;
+    int tileEmbeddingDim = 0;
+    int relativeTileColumns = 0;
+    int relativeTileRows = 0;
+    int scalarInputSize = 0;
+    int h1Size = 0;
+    int h2Size = 0;
+    int outputSize = 0;
+    uint16_t voidTokenId = 0;
+    std::string tokenizerVocabularyHash;
+
+    using serialize = zpp::bits::members<11>;
+};
+
+NesTileBrainCompatibilityMetadata makeNesTileBrainCompatibilityMetadata(
+    const NesTileTokenizer& tokenizer);
+
+Result<std::monostate, std::string> validateNesTileBrainCompatibilityMetadata(
+    const NesTileBrainCompatibilityMetadata& actual,
+    const NesTileBrainCompatibilityMetadata& expected);
+
+void to_json(nlohmann::json& j, const NesTileBrainCompatibilityMetadata& metadata);
+void from_json(const nlohmann::json& j, NesTileBrainCompatibilityMetadata& metadata);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileDebugRenderer.cpp
+++ b/apps/src/core/scenarios/nes/NesTileDebugRenderer.cpp
@@ -1,0 +1,388 @@
+#include "core/scenarios/nes/NesTileDebugRenderer.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <utility>
+
+namespace DirtSim {
+namespace {
+
+constexpr uint32_t kPanelGapPixels = 12u;
+constexpr uint32_t kOpaqueBlack = 0x000000FFu;
+constexpr uint32_t kPanelBackground = 0x121212FFu;
+
+template <size_t TokenCount>
+void drawTokenPanel(
+    NesTileDebugRenderImage& image,
+    uint32_t panelX,
+    uint16_t tileColumns,
+    uint16_t tileRows,
+    const std::array<NesTileTokenizer::TileToken, TokenCount>& tokens);
+
+Result<NesTileDebugRenderImage, std::string> makeComparisonImage(
+    const NesTileDebugRenderInput& input);
+Result<NesTileDebugRenderImage, std::string> makeNormalVideoImage(
+    const NesTileDebugRenderInput& input);
+Result<NesTileDebugRenderImage, std::string> makePatternPixelsImage(
+    const NesTileDebugRenderInput& input);
+Result<NesTileDebugRenderImage, std::string> makePlayerRelativeTokensImage(
+    const NesTileDebugRenderInput& input);
+Result<NesTileDebugRenderImage, std::string> makeScreenTokensImage(
+    const NesTileDebugRenderInput& input);
+
+uint16_t rgb565FromRgba(uint8_t red, uint8_t green, uint8_t blue)
+{
+    const uint16_t red5 = static_cast<uint16_t>(red >> 3u);
+    const uint16_t green6 = static_cast<uint16_t>(green >> 2u);
+    const uint16_t blue5 = static_cast<uint16_t>(blue >> 3u);
+    return static_cast<uint16_t>((red5 << 11u) | (green6 << 5u) | blue5);
+}
+
+std::array<uint8_t, 4> rgbaFromColor(uint32_t color)
+{
+    return {
+        static_cast<uint8_t>((color >> 24u) & 0xFFu),
+        static_cast<uint8_t>((color >> 16u) & 0xFFu),
+        static_cast<uint8_t>((color >> 8u) & 0xFFu),
+        static_cast<uint8_t>(color & 0xFFu),
+    };
+}
+
+std::array<uint8_t, 4> rgbaFromRgb565(uint16_t value)
+{
+    const uint8_t red5 = static_cast<uint8_t>((value >> 11u) & 0x1Fu);
+    const uint8_t green6 = static_cast<uint8_t>((value >> 5u) & 0x3Fu);
+    const uint8_t blue5 = static_cast<uint8_t>(value & 0x1Fu);
+
+    return {
+        static_cast<uint8_t>((red5 << 3u) | (red5 >> 2u)),
+        static_cast<uint8_t>((green6 << 2u) | (green6 >> 4u)),
+        static_cast<uint8_t>((blue5 << 3u) | (blue5 >> 2u)),
+        255u,
+    };
+}
+
+uint16_t readRgb565Pixel(const ScenarioVideoFrame& frame, size_t pixelIndex)
+{
+    const size_t offset = pixelIndex * 2u;
+    const uint8_t lo = std::to_integer<uint8_t>(frame.pixels[offset]);
+    const uint8_t hi = std::to_integer<uint8_t>(frame.pixels[offset + 1u]);
+    return static_cast<uint16_t>(lo | (static_cast<uint16_t>(hi) << 8u));
+}
+
+void setRgbaPixel(
+    NesTileDebugRenderImage& image,
+    uint32_t x,
+    uint32_t y,
+    uint8_t red,
+    uint8_t green,
+    uint8_t blue,
+    uint8_t alpha)
+{
+    const size_t offset = (static_cast<size_t>(y) * image.width + x) * 4u;
+    image.rgba[offset + 0u] = red;
+    image.rgba[offset + 1u] = green;
+    image.rgba[offset + 2u] = blue;
+    image.rgba[offset + 3u] = alpha;
+}
+
+void setRgbaPixel(NesTileDebugRenderImage& image, uint32_t x, uint32_t y, uint32_t color)
+{
+    const auto rgba = rgbaFromColor(color);
+    setRgbaPixel(image, x, y, rgba[0], rgba[1], rgba[2], rgba[3]);
+}
+
+NesTileDebugRenderImage makeImage(uint32_t width, uint32_t height, uint32_t fillColor)
+{
+    NesTileDebugRenderImage image{
+        .width = width,
+        .height = height,
+        .rgba = std::vector<uint8_t>(static_cast<size_t>(width) * height * 4u),
+    };
+
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            setRgbaPixel(image, x, y, fillColor);
+        }
+    }
+
+    return image;
+}
+
+Result<NesTileDebugRenderImage, std::string> errorMissingInput(const std::string& name)
+{
+    return Result<NesTileDebugRenderImage, std::string>::error(
+        "NesTileDebugRenderer: Missing " + name);
+}
+
+Result<NesTileDebugRenderImage, std::string> validateVideoFrame(
+    const ScenarioVideoFrame& videoFrame)
+{
+    if (videoFrame.width == 0u || videoFrame.height == 0u) {
+        return Result<NesTileDebugRenderImage, std::string>::error(
+            "NesTileDebugRenderer: Video frame dimensions must be non-zero");
+    }
+
+    const size_t expectedBytes =
+        static_cast<size_t>(videoFrame.width) * videoFrame.height * sizeof(uint16_t);
+    if (videoFrame.pixels.size() != expectedBytes) {
+        return Result<NesTileDebugRenderImage, std::string>::error(
+            "NesTileDebugRenderer: Video frame pixel byte size mismatch");
+    }
+
+    return Result<NesTileDebugRenderImage, std::string>::okay();
+}
+
+Result<NesTileDebugRenderImage, std::string> validateVisibleVideoFrame(
+    const ScenarioVideoFrame& videoFrame)
+{
+    auto validation = validateVideoFrame(videoFrame);
+    if (validation.isError()) {
+        return validation;
+    }
+
+    if (videoFrame.width != NesTileFrame::VisibleWidthPixels
+        || videoFrame.height != NesTileFrame::VisibleHeightPixels) {
+        return Result<NesTileDebugRenderImage, std::string>::error(
+            "NesTileDebugRenderer: NES tile comparison requires a visible 256x224 video frame");
+    }
+
+    return Result<NesTileDebugRenderImage, std::string>::okay();
+}
+
+void drawVideoPanel(
+    NesTileDebugRenderImage& image, const ScenarioVideoFrame& videoFrame, uint32_t panelX)
+{
+    for (uint32_t y = 0; y < videoFrame.height; ++y) {
+        const size_t rowBase = static_cast<size_t>(y) * videoFrame.width;
+        for (uint32_t x = 0; x < videoFrame.width; ++x) {
+            const auto rgba = rgbaFromRgb565(readRgb565Pixel(videoFrame, rowBase + x));
+            setRgbaPixel(image, panelX + x, y, rgba[0], rgba[1], rgba[2], rgba[3]);
+        }
+    }
+}
+
+void drawPatternPanel(
+    NesTileDebugRenderImage& image, const NesTileFrame& tileFrame, uint32_t panelX)
+{
+    for (uint32_t y = 0; y < NesTileFrame::VisibleHeightPixels; ++y) {
+        const size_t rowBase = static_cast<size_t>(y) * NesTileFrame::VisibleWidthPixels;
+        for (uint32_t x = 0; x < NesTileFrame::VisibleWidthPixels; ++x) {
+            const uint8_t shade = static_cast<uint8_t>(tileFrame.patternPixels[rowBase + x] * 85u);
+            setRgbaPixel(image, panelX + x, y, shade, shade, shade, 255u);
+        }
+    }
+}
+
+template <size_t TokenCount>
+void drawTokenPanel(
+    NesTileDebugRenderImage& image,
+    uint32_t panelX,
+    uint16_t tileColumns,
+    uint16_t tileRows,
+    const std::array<NesTileTokenizer::TileToken, TokenCount>& tokens)
+{
+    for (uint32_t gy = 0; gy < tileRows; ++gy) {
+        for (uint32_t gx = 0; gx < tileColumns; ++gx) {
+            const size_t cellIndex = static_cast<size_t>(gy) * tileColumns + gx;
+            const uint32_t color = nesTileDebugTokenColor(tokens[cellIndex]);
+            for (uint32_t py = 0; py < NesPlayerRelativeTileFrame::TileSizePixels; ++py) {
+                for (uint32_t px = 0; px < NesPlayerRelativeTileFrame::TileSizePixels; ++px) {
+                    setRgbaPixel(
+                        image,
+                        panelX + gx * NesPlayerRelativeTileFrame::TileSizePixels + px,
+                        gy * NesPlayerRelativeTileFrame::TileSizePixels + py,
+                        color);
+                }
+            }
+        }
+    }
+}
+
+Result<NesTileDebugRenderImage, std::string> makeComparisonImage(
+    const NesTileDebugRenderInput& input)
+{
+    if (input.videoFrame == nullptr) {
+        return errorMissingInput("video frame");
+    }
+    if (input.tileFrame == nullptr) {
+        return errorMissingInput("tile frame");
+    }
+    if (input.tokenFrame == nullptr) {
+        return errorMissingInput("token frame");
+    }
+    if (input.relativeFrame == nullptr) {
+        return errorMissingInput("player-relative tile frame");
+    }
+
+    auto validation = validateVisibleVideoFrame(*input.videoFrame);
+    if (validation.isError()) {
+        return validation;
+    }
+
+    const uint32_t panelWidth = NesTileFrame::VisibleWidthPixels;
+    const uint32_t panelHeight = NesTileFrame::VisibleHeightPixels;
+    const uint32_t relativePanelWidth = NesPlayerRelativeTileFrame::RelativeTileColumns
+        * NesPlayerRelativeTileFrame::TileSizePixels;
+    const uint32_t relativePanelHeight =
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels;
+    NesTileDebugRenderImage image = makeImage(
+        panelWidth * 3u + relativePanelWidth + kPanelGapPixels * 3u,
+        std::max(panelHeight, relativePanelHeight),
+        kPanelBackground);
+
+    const uint32_t patternPanelX = panelWidth + kPanelGapPixels;
+    const uint32_t tokenPanelX = patternPanelX + panelWidth + kPanelGapPixels;
+    const uint32_t relativePanelX = tokenPanelX + panelWidth + kPanelGapPixels;
+
+    drawVideoPanel(image, *input.videoFrame, 0u);
+    drawPatternPanel(image, *input.tileFrame, patternPanelX);
+    drawTokenPanel(
+        image,
+        tokenPanelX,
+        NesTileTokenFrame::VisibleTileColumns,
+        NesTileTokenFrame::VisibleTileRows,
+        input.tokenFrame->tokens);
+    drawTokenPanel(
+        image,
+        relativePanelX,
+        NesPlayerRelativeTileFrame::RelativeTileColumns,
+        NesPlayerRelativeTileFrame::RelativeTileRows,
+        input.relativeFrame->tokens);
+
+    return Result<NesTileDebugRenderImage, std::string>::okay(std::move(image));
+}
+
+Result<NesTileDebugRenderImage, std::string> makeNormalVideoImage(
+    const NesTileDebugRenderInput& input)
+{
+    if (input.videoFrame == nullptr) {
+        return errorMissingInput("video frame");
+    }
+
+    auto validation = validateVideoFrame(*input.videoFrame);
+    if (validation.isError()) {
+        return validation;
+    }
+
+    NesTileDebugRenderImage image =
+        makeImage(input.videoFrame->width, input.videoFrame->height, kOpaqueBlack);
+    drawVideoPanel(image, *input.videoFrame, 0u);
+    return Result<NesTileDebugRenderImage, std::string>::okay(std::move(image));
+}
+
+Result<NesTileDebugRenderImage, std::string> makePatternPixelsImage(
+    const NesTileDebugRenderInput& input)
+{
+    if (input.tileFrame == nullptr) {
+        return errorMissingInput("tile frame");
+    }
+
+    NesTileDebugRenderImage image = makeImage(
+        NesTileFrame::VisibleWidthPixels, NesTileFrame::VisibleHeightPixels, kOpaqueBlack);
+    drawPatternPanel(image, *input.tileFrame, 0u);
+    return Result<NesTileDebugRenderImage, std::string>::okay(std::move(image));
+}
+
+Result<NesTileDebugRenderImage, std::string> makePlayerRelativeTokensImage(
+    const NesTileDebugRenderInput& input)
+{
+    if (input.relativeFrame == nullptr) {
+        return errorMissingInput("player-relative tile frame");
+    }
+
+    NesTileDebugRenderImage image = makeImage(
+        NesPlayerRelativeTileFrame::RelativeTileColumns
+            * NesPlayerRelativeTileFrame::TileSizePixels,
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels,
+        kOpaqueBlack);
+    drawTokenPanel(
+        image,
+        0u,
+        NesPlayerRelativeTileFrame::RelativeTileColumns,
+        NesPlayerRelativeTileFrame::RelativeTileRows,
+        input.relativeFrame->tokens);
+    return Result<NesTileDebugRenderImage, std::string>::okay(std::move(image));
+}
+
+Result<NesTileDebugRenderImage, std::string> makeScreenTokensImage(
+    const NesTileDebugRenderInput& input)
+{
+    if (input.tokenFrame == nullptr) {
+        return errorMissingInput("token frame");
+    }
+
+    NesTileDebugRenderImage image = makeImage(
+        NesTileTokenFrame::VisibleTileColumns * NesPlayerRelativeTileFrame::TileSizePixels,
+        NesTileTokenFrame::VisibleTileRows * NesPlayerRelativeTileFrame::TileSizePixels,
+        kOpaqueBlack);
+    drawTokenPanel(
+        image,
+        0u,
+        NesTileTokenFrame::VisibleTileColumns,
+        NesTileTokenFrame::VisibleTileRows,
+        input.tokenFrame->tokens);
+    return Result<NesTileDebugRenderImage, std::string>::okay(std::move(image));
+}
+
+} // namespace
+
+Result<NesTileDebugRenderImage, std::string> makeNesTileDebugRenderImage(
+    NesTileDebugView view, const NesTileDebugRenderInput& input)
+{
+    switch (view) {
+        case NesTileDebugView::NormalVideo:
+            return makeNormalVideoImage(input);
+        case NesTileDebugView::PatternPixels:
+            return makePatternPixelsImage(input);
+        case NesTileDebugView::ScreenTokens:
+            return makeScreenTokensImage(input);
+        case NesTileDebugView::PlayerRelativeTokens:
+            return makePlayerRelativeTokensImage(input);
+        case NesTileDebugView::Comparison:
+            return makeComparisonImage(input);
+    }
+
+    return Result<NesTileDebugRenderImage, std::string>::error(
+        "NesTileDebugRenderer: Unknown debug view");
+}
+
+ScenarioVideoFrame makeNesTileDebugScenarioVideoFrame(
+    const NesTileDebugRenderImage& image, uint64_t frameId)
+{
+    ScenarioVideoFrame frame{
+        .width = static_cast<uint16_t>(image.width),
+        .height = static_cast<uint16_t>(image.height),
+        .frame_id = frameId,
+        .pixels = std::vector<std::byte>(static_cast<size_t>(image.width) * image.height * 2u),
+    };
+
+    for (size_t pixelIndex = 0; pixelIndex < static_cast<size_t>(image.width) * image.height;
+         ++pixelIndex) {
+        const size_t rgbaOffset = pixelIndex * 4u;
+        const uint16_t rgb565 = rgb565FromRgba(
+            image.rgba[rgbaOffset + 0u], image.rgba[rgbaOffset + 1u], image.rgba[rgbaOffset + 2u]);
+        const size_t frameOffset = pixelIndex * 2u;
+        frame.pixels[frameOffset + 0u] = static_cast<std::byte>(rgb565 & 0xFFu);
+        frame.pixels[frameOffset + 1u] = static_cast<std::byte>((rgb565 >> 8u) & 0xFFu);
+    }
+
+    return frame;
+}
+
+uint32_t nesTileDebugTokenColor(NesTileTokenizer::TileToken token)
+{
+    if (token == NesTileTokenizer::VoidToken) {
+        return kOpaqueBlack;
+    }
+
+    const uint32_t mixed = static_cast<uint32_t>(token) * 2654435761u;
+    const uint8_t red = static_cast<uint8_t>(64u + ((mixed >> 0u) & 0x7Fu));
+    const uint8_t green = static_cast<uint8_t>(64u + ((mixed >> 8u) & 0x7Fu));
+    const uint8_t blue = static_cast<uint8_t>(64u + ((mixed >> 16u) & 0x7Fu));
+    return (static_cast<uint32_t>(red) << 24u) | (static_cast<uint32_t>(green) << 16u)
+        | (static_cast<uint32_t>(blue) << 8u) | 255u;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileDebugRenderer.h
+++ b/apps/src/core/scenarios/nes/NesTileDebugRenderer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "core/RenderMessage.h"
+#include "core/Result.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+#include "core/scenarios/nes/NesTileDebugView.h"
+#include "core/scenarios/nes/NesTileFrame.h"
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <string>
+#include <vector>
+
+namespace DirtSim {
+
+struct NesTileDebugRenderImage {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    std::vector<uint8_t> rgba;
+};
+
+struct NesTileDebugRenderInput {
+    const ScenarioVideoFrame* videoFrame = nullptr;
+    const NesTileFrame* tileFrame = nullptr;
+    const NesTileTokenFrame* tokenFrame = nullptr;
+    const NesPlayerRelativeTileFrame* relativeFrame = nullptr;
+};
+
+Result<NesTileDebugRenderImage, std::string> makeNesTileDebugRenderImage(
+    NesTileDebugView view, const NesTileDebugRenderInput& input);
+ScenarioVideoFrame makeNesTileDebugScenarioVideoFrame(
+    const NesTileDebugRenderImage& image, uint64_t frameId);
+uint32_t nesTileDebugTokenColor(NesTileTokenizer::TileToken token);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileDebugView.h
+++ b/apps/src/core/scenarios/nes/NesTileDebugView.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdint>
+
+namespace DirtSim {
+
+enum class NesTileDebugView : uint8_t {
+    NormalVideo = 0,
+    PatternPixels = 1,
+    ScreenTokens = 2,
+    PlayerRelativeTokens = 3,
+    Comparison = 4,
+};
+
+constexpr bool isNesTileDebugViewValid(NesTileDebugView view)
+{
+    switch (view) {
+        case NesTileDebugView::NormalVideo:
+        case NesTileDebugView::PatternPixels:
+        case NesTileDebugView::ScreenTokens:
+        case NesTileDebugView::PlayerRelativeTokens:
+        case NesTileDebugView::Comparison:
+            return true;
+    }
+
+    return false;
+}
+
+constexpr uint16_t nesTileDebugViewIndex(NesTileDebugView view)
+{
+    switch (view) {
+        case NesTileDebugView::NormalVideo:
+            return 0u;
+        case NesTileDebugView::PatternPixels:
+            return 1u;
+        case NesTileDebugView::ScreenTokens:
+            return 2u;
+        case NesTileDebugView::PlayerRelativeTokens:
+            return 3u;
+        case NesTileDebugView::Comparison:
+            return 4u;
+    }
+
+    return 0u;
+}
+
+constexpr const char* nesTileDebugViewOptions()
+{
+    return "Normal\nPattern\nScreen Tokens\nPlayer Relative\nComparison";
+}
+
+constexpr NesTileDebugView nesTileDebugViewFromIndex(uint16_t index)
+{
+    switch (index) {
+        case 0u:
+            return NesTileDebugView::NormalVideo;
+        case 1u:
+            return NesTileDebugView::PatternPixels;
+        case 2u:
+            return NesTileDebugView::ScreenTokens;
+        case 3u:
+            return NesTileDebugView::PlayerRelativeTokens;
+        case 4u:
+            return NesTileDebugView::Comparison;
+    }
+
+    return NesTileDebugView::NormalVideo;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesTileFrame.cpp
@@ -1,0 +1,134 @@
+#include "core/scenarios/nes/NesTileFrame.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace DirtSim {
+
+namespace {
+
+constexpr uint16_t kFullFrameHeightPixels = 240u;
+constexpr uint16_t kFullFrameWidthPixels = 256u;
+constexpr uint16_t kPatternBytesPerTile = 16u;
+constexpr uint16_t kTileSizePixels = 8u;
+constexpr uint16_t kTopCropPixels = 8u;
+
+size_t mirroredNametableOffset(uint16_t logicalOffset, uint8_t mirror)
+{
+    switch (mirror) {
+        case 0u:
+            return logicalOffset % 1024u;
+        case 1u:
+            return (logicalOffset % 1024u) + 1024u;
+        case 2u:
+            return logicalOffset & 2047u;
+        case 3u:
+            return ((logicalOffset / 2u) & 1024u) | (logicalOffset % 1024u);
+        default:
+            return logicalOffset & 2047u;
+    }
+}
+
+uint8_t readNametableTileIdAtWorldPixel(
+    const NesPpuSnapshot& snapshot, uint16_t scrollX, uint16_t scrollY, uint16_t x, uint16_t y)
+{
+    const uint16_t worldX = static_cast<uint16_t>((scrollX + x) % 512u);
+    const uint16_t worldY = static_cast<uint16_t>((scrollY + y) % 480u);
+
+    const uint16_t tileX = static_cast<uint16_t>(worldX / kTileSizePixels);
+    const uint16_t tileY = static_cast<uint16_t>(worldY / kTileSizePixels);
+    const uint16_t nametableX = static_cast<uint16_t>((tileX / 32u) & 0x01u);
+    const uint16_t nametableY = static_cast<uint16_t>((tileY / 30u) & 0x01u);
+    const uint16_t localTileX = static_cast<uint16_t>(tileX % 32u);
+    const uint16_t localTileY = static_cast<uint16_t>(tileY % 30u);
+    const uint16_t logicalOffset = static_cast<uint16_t>(
+        nametableY * 0x800u + nametableX * 0x400u + localTileY * 32u + localTileX);
+    return snapshot.vram[mirroredNametableOffset(logicalOffset, snapshot.mirror)];
+}
+
+size_t tilePatternBaseOffset(const NesPpuSnapshot& snapshot, uint8_t tileId)
+{
+    const size_t patternBase = (snapshot.ppuCtrl & 0x10u) != 0u ? 0x1000u : 0u;
+    return patternBase + static_cast<size_t>(tileId) * kPatternBytesPerTile;
+}
+
+uint64_t tilePatternHash(const NesPpuSnapshot& snapshot, uint8_t tileId)
+{
+    constexpr uint64_t kFnvOffsetBasis = 14695981039346656037ull;
+    constexpr uint64_t kFnvPrime = 1099511628211ull;
+
+    const size_t base = tilePatternBaseOffset(snapshot, tileId);
+    uint64_t hash = kFnvOffsetBasis;
+    for (size_t i = 0; i < kPatternBytesPerTile; ++i) {
+        hash ^= snapshot.chr[base + i];
+        hash *= kFnvPrime;
+    }
+    return hash;
+}
+
+uint8_t tilePatternPixel(
+    const NesPpuSnapshot& snapshot, uint8_t tileId, uint8_t patternX, uint8_t patternY)
+{
+    const size_t base = tilePatternBaseOffset(snapshot, tileId);
+    const uint8_t lo = snapshot.chr[base + patternY];
+    const uint8_t hi = snapshot.chr[base + 8u + patternY];
+    const uint8_t bit = static_cast<uint8_t>(7u - patternX);
+    return static_cast<uint8_t>(((lo >> bit) & 0x01u) | (((hi >> bit) & 0x01u) << 1u));
+}
+
+uint16_t scrollXFromV(const NesPpuSnapshot& snapshot)
+{
+    return static_cast<uint16_t>(
+        (((snapshot.v >> 10u) & 0x01u) * kFullFrameWidthPixels)
+        + ((snapshot.v & 0x001Fu) * kTileSizePixels) + (snapshot.fineX & 0x07u));
+}
+
+uint16_t scrollYFromV(const NesPpuSnapshot& snapshot)
+{
+    return static_cast<uint16_t>(
+        (((snapshot.v >> 11u) & 0x01u) * kFullFrameHeightPixels)
+        + (((snapshot.v >> 5u) & 0x001Fu) * kTileSizePixels) + ((snapshot.v >> 12u) & 0x07u));
+}
+
+} // namespace
+
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot)
+{
+    NesTileFrame frame;
+    frame.frameId = snapshot.frameId;
+    frame.scrollX = scrollXFromV(snapshot);
+    frame.scrollY = scrollYFromV(snapshot);
+
+    for (uint16_t y = 0; y < NesTileFrame::VisibleHeightPixels; ++y) {
+        const uint16_t fullY = static_cast<uint16_t>(y + kTopCropPixels);
+        const size_t rowBase = static_cast<size_t>(y) * NesTileFrame::VisibleWidthPixels;
+        for (uint16_t x = 0; x < NesTileFrame::VisibleWidthPixels; ++x) {
+            const uint8_t tileId =
+                readNametableTileIdAtWorldPixel(snapshot, frame.scrollX, frame.scrollY, x, fullY);
+            const uint16_t worldX = static_cast<uint16_t>((frame.scrollX + x) % 512u);
+            const uint16_t worldY = static_cast<uint16_t>((frame.scrollY + fullY) % 480u);
+            const uint8_t patternX = static_cast<uint8_t>(worldX % kTileSizePixels);
+            const uint8_t patternY = static_cast<uint8_t>(worldY % kTileSizePixels);
+            frame.patternPixels[rowBase + x] =
+                tilePatternPixel(snapshot, tileId, patternX, patternY);
+        }
+    }
+
+    for (uint16_t gy = 0; gy < NesTileFrame::VisibleTileRows; ++gy) {
+        for (uint16_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
+            const uint16_t sampleX = static_cast<uint16_t>(gx * kTileSizePixels + 4u);
+            const uint16_t sampleY =
+                static_cast<uint16_t>(gy * kTileSizePixels + 4u + kTopCropPixels);
+            const uint8_t tileId = readNametableTileIdAtWorldPixel(
+                snapshot, frame.scrollX, frame.scrollY, sampleX, sampleY);
+            const size_t cellIndex =
+                static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
+            frame.tileIds[cellIndex] = tileId;
+            frame.tilePatternHashes[cellIndex] = tilePatternHash(snapshot, tileId);
+        }
+    }
+
+    return frame;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesTileFrame.cpp
@@ -92,6 +92,15 @@ uint16_t scrollYFromV(const NesPpuSnapshot& snapshot)
 
 } // namespace
 
+std::array<uint64_t, 256u> makeNesTileIdPatternHashes(const NesPpuSnapshot& snapshot)
+{
+    std::array<uint64_t, 256u> tilePatternHashes{};
+    for (size_t tileId = 0; tileId < tilePatternHashes.size(); ++tileId) {
+        tilePatternHashes[tileId] = tilePatternHash(snapshot, static_cast<uint8_t>(tileId));
+    }
+    return tilePatternHashes;
+}
+
 NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot)
 {
     NesTileFrame frame;

--- a/apps/src/core/scenarios/nes/NesTileFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesTileFrame.cpp
@@ -1,5 +1,7 @@
 #include "core/scenarios/nes/NesTileFrame.h"
 
+#include "core/Timers.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -12,6 +14,27 @@ constexpr uint16_t kFullFrameWidthPixels = 256u;
 constexpr uint16_t kPatternBytesPerTile = 16u;
 constexpr uint16_t kTileSizePixels = 8u;
 constexpr uint16_t kTopCropPixels = NesTileFrame::TopCropPixels;
+
+class OptionalScopeTimer final {
+public:
+    OptionalScopeTimer(Timers* timers, const char* name) : timers_(timers), name_(name)
+    {
+        if (timers_ != nullptr) {
+            timers_->startTimer(name_);
+        }
+    }
+
+    ~OptionalScopeTimer()
+    {
+        if (timers_ != nullptr) {
+            timers_->stopTimer(name_);
+        }
+    }
+
+private:
+    Timers* timers_ = nullptr;
+    const char* name_ = nullptr;
+};
 
 size_t mirroredNametableOffset(uint16_t logicalOffset, uint8_t mirror)
 {
@@ -103,37 +126,69 @@ std::array<uint64_t, 256u> makeNesTileIdPatternHashes(const NesPpuSnapshot& snap
 
 NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot)
 {
-    NesTileFrame frame;
-    frame.frameId = snapshot.frameId;
-    frame.scrollX = scrollXFromV(snapshot);
-    frame.scrollY = scrollYFromV(snapshot);
+    return makeNesTileFrame(snapshot, NesTileFrameBuildOptions{});
+}
 
-    for (uint16_t y = 0; y < NesTileFrame::VisibleHeightPixels; ++y) {
-        const uint16_t fullY = static_cast<uint16_t>(y + kTopCropPixels);
-        const size_t rowBase = static_cast<size_t>(y) * NesTileFrame::VisibleWidthPixels;
-        for (uint16_t x = 0; x < NesTileFrame::VisibleWidthPixels; ++x) {
-            const uint8_t tileId =
-                readNametableTileIdAtWorldPixel(snapshot, frame.scrollX, frame.scrollY, x, fullY);
-            const uint16_t worldX = static_cast<uint16_t>((frame.scrollX + x) % 512u);
-            const uint16_t worldY = static_cast<uint16_t>((frame.scrollY + fullY) % 480u);
-            const uint8_t patternX = static_cast<uint8_t>(worldX % kTileSizePixels);
-            const uint8_t patternY = static_cast<uint8_t>(worldY % kTileSizePixels);
-            frame.patternPixels[rowBase + x] =
-                tilePatternPixel(snapshot, tileId, patternX, patternY);
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot, Timers* timers)
+{
+    return makeNesTileFrame(snapshot, NesTileFrameBuildOptions{}, timers);
+}
+
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot, NesTileFrameBuildOptions options)
+{
+    return makeNesTileFrame(snapshot, options, nullptr);
+}
+
+NesTileFrame makeNesTileFrame(
+    const NesPpuSnapshot& snapshot, NesTileFrameBuildOptions options, Timers* timers)
+{
+    NesTileFrame frame;
+    {
+        OptionalScopeTimer timer(timers, "nes_tile_frame_scroll_decode");
+        frame.frameId = snapshot.frameId;
+        frame.scrollX = scrollXFromV(snapshot);
+        frame.scrollY = scrollYFromV(snapshot);
+    }
+
+    if (options.includePatternPixels) {
+        OptionalScopeTimer timer(timers, "nes_tile_frame_pattern_pixels");
+        for (uint16_t y = 0; y < NesTileFrame::VisibleHeightPixels; ++y) {
+            const uint16_t fullY = static_cast<uint16_t>(y + kTopCropPixels);
+            const size_t rowBase = static_cast<size_t>(y) * NesTileFrame::VisibleWidthPixels;
+            for (uint16_t x = 0; x < NesTileFrame::VisibleWidthPixels; ++x) {
+                const uint8_t tileId = readNametableTileIdAtWorldPixel(
+                    snapshot, frame.scrollX, frame.scrollY, x, fullY);
+                const uint16_t worldX = static_cast<uint16_t>((frame.scrollX + x) % 512u);
+                const uint16_t worldY = static_cast<uint16_t>((frame.scrollY + fullY) % 480u);
+                const uint8_t patternX = static_cast<uint8_t>(worldX % kTileSizePixels);
+                const uint8_t patternY = static_cast<uint8_t>(worldY % kTileSizePixels);
+                frame.patternPixels[rowBase + x] =
+                    tilePatternPixel(snapshot, tileId, patternX, patternY);
+            }
         }
     }
 
-    for (uint16_t gy = 0; gy < NesTileFrame::VisibleTileRows; ++gy) {
-        for (uint16_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
-            const uint16_t sampleX = static_cast<uint16_t>(gx * kTileSizePixels + 4u);
-            const uint16_t sampleY =
-                static_cast<uint16_t>(gy * kTileSizePixels + 4u + kTopCropPixels);
-            const uint8_t tileId = readNametableTileIdAtWorldPixel(
-                snapshot, frame.scrollX, frame.scrollY, sampleX, sampleY);
-            const size_t cellIndex =
-                static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
-            frame.tileIds[cellIndex] = tileId;
-            frame.tilePatternHashes[cellIndex] = tilePatternHash(snapshot, tileId);
+    {
+        OptionalScopeTimer timer(timers, "nes_tile_frame_tile_ids");
+        for (uint16_t gy = 0; gy < NesTileFrame::VisibleTileRows; ++gy) {
+            for (uint16_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
+                const uint16_t sampleX = static_cast<uint16_t>(gx * kTileSizePixels + 4u);
+                const uint16_t sampleY =
+                    static_cast<uint16_t>(gy * kTileSizePixels + 4u + kTopCropPixels);
+                const uint8_t tileId = readNametableTileIdAtWorldPixel(
+                    snapshot, frame.scrollX, frame.scrollY, sampleX, sampleY);
+                const size_t cellIndex =
+                    static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
+                frame.tileIds[cellIndex] = tileId;
+            }
+        }
+    }
+
+    {
+        OptionalScopeTimer timer(timers, "nes_tile_frame_tile_hashes");
+        for (size_t cellIndex = 0; cellIndex < frame.tileIds.size(); ++cellIndex) {
+            frame.tilePatternHashes[cellIndex] =
+                tilePatternHash(snapshot, frame.tileIds[cellIndex]);
         }
     }
 

--- a/apps/src/core/scenarios/nes/NesTileFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesTileFrame.cpp
@@ -11,7 +11,7 @@ constexpr uint16_t kFullFrameHeightPixels = 240u;
 constexpr uint16_t kFullFrameWidthPixels = 256u;
 constexpr uint16_t kPatternBytesPerTile = 16u;
 constexpr uint16_t kTileSizePixels = 8u;
-constexpr uint16_t kTopCropPixels = 8u;
+constexpr uint16_t kTopCropPixels = NesTileFrame::TopCropPixels;
 
 size_t mirroredNametableOffset(uint16_t logicalOffset, uint8_t mirror)
 {

--- a/apps/src/core/scenarios/nes/NesTileFrame.h
+++ b/apps/src/core/scenarios/nes/NesTileFrame.h
@@ -22,6 +22,7 @@ struct NesTileFrame {
     std::array<uint8_t, VisibleTileColumns * VisibleTileRows> tileIds{};
 };
 
+std::array<uint64_t, 256u> makeNesTileIdPatternHashes(const NesPpuSnapshot& snapshot);
 NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot);
 
 } // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileFrame.h
+++ b/apps/src/core/scenarios/nes/NesTileFrame.h
@@ -5,6 +5,8 @@
 #include <array>
 #include <cstdint>
 
+class Timers;
+
 namespace DirtSim {
 
 struct NesTileFrame {
@@ -22,7 +24,15 @@ struct NesTileFrame {
     std::array<uint8_t, VisibleTileColumns * VisibleTileRows> tileIds{};
 };
 
+struct NesTileFrameBuildOptions {
+    bool includePatternPixels = true;
+};
+
 std::array<uint64_t, 256u> makeNesTileIdPatternHashes(const NesPpuSnapshot& snapshot);
 NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot);
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot, NesTileFrameBuildOptions options);
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot, Timers* timers);
+NesTileFrame makeNesTileFrame(
+    const NesPpuSnapshot& snapshot, NesTileFrameBuildOptions options, Timers* timers);
 
 } // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileFrame.h
+++ b/apps/src/core/scenarios/nes/NesTileFrame.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/scenarios/nes/NesPpuSnapshot.h"
+
+#include <array>
+#include <cstdint>
+
+namespace DirtSim {
+
+struct NesTileFrame {
+    static constexpr uint16_t VisibleHeightPixels = 224u;
+    static constexpr uint16_t VisibleTileColumns = 32u;
+    static constexpr uint16_t VisibleTileRows = 28u;
+    static constexpr uint16_t VisibleWidthPixels = 256u;
+
+    uint64_t frameId = 0;
+    uint16_t scrollX = 0;
+    uint16_t scrollY = 0;
+    std::array<uint8_t, VisibleWidthPixels * VisibleHeightPixels> patternPixels{};
+    std::array<uint64_t, VisibleTileColumns * VisibleTileRows> tilePatternHashes{};
+    std::array<uint8_t, VisibleTileColumns * VisibleTileRows> tileIds{};
+};
+
+NesTileFrame makeNesTileFrame(const NesPpuSnapshot& snapshot);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileFrame.h
+++ b/apps/src/core/scenarios/nes/NesTileFrame.h
@@ -8,6 +8,7 @@
 namespace DirtSim {
 
 struct NesTileFrame {
+    static constexpr uint16_t TopCropPixels = 8u;
     static constexpr uint16_t VisibleHeightPixels = 224u;
     static constexpr uint16_t VisibleTileColumns = 32u;
     static constexpr uint16_t VisibleTileRows = 28u;

--- a/apps/src/core/scenarios/nes/NesTileRecurrentBrain.cpp
+++ b/apps/src/core/scenarios/nes/NesTileRecurrentBrain.cpp
@@ -235,6 +235,13 @@ struct NesTileRecurrentBrain::Impl {
         for (const auto token : sensory.tileFrame.tokens) {
             DIRTSIM_ASSERT(
                 token < TILE_VOCAB_SIZE, "NesTileRecurrentBrain: Tile token out of range");
+            if (token == NesTileTokenizer::VoidToken) {
+                for (int dim = 0; dim < TILE_EMBED_DIM; ++dim) {
+                    input_buffer[index++] = 0.0f;
+                }
+                continue;
+            }
+
             const WeightType* embedding =
                 &tile_embedding[static_cast<size_t>(token) * TILE_EMBED_DIM];
             for (int dim = 0; dim < TILE_EMBED_DIM; ++dim) {

--- a/apps/src/core/scenarios/nes/NesTileRecurrentBrain.cpp
+++ b/apps/src/core/scenarios/nes/NesTileRecurrentBrain.cpp
@@ -1,0 +1,475 @@
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
+
+#include "core/Assert.h"
+#include "core/organisms/brains/WeightType.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+#include "core/scenarios/nes/NesTileSensoryData.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace DirtSim {
+
+namespace {
+
+constexpr int TILE_VOCAB_SIZE = NesTileRecurrentBrain::TileVocabularySize;
+constexpr int TILE_EMBED_DIM = NesTileRecurrentBrain::TileEmbeddingDim;
+constexpr int RELATIVE_TILE_COLUMNS = NesTileRecurrentBrain::RelativeTileColumns;
+constexpr int RELATIVE_TILE_ROWS = NesTileRecurrentBrain::RelativeTileRows;
+constexpr int VISUAL_INPUT_SIZE = NesTileRecurrentBrain::VisualInputSize;
+constexpr int SCALAR_INPUT_SIZE = NesTileRecurrentBrain::ScalarInputSize;
+constexpr int INPUT_SIZE = NesTileRecurrentBrain::InputSize;
+constexpr int H1_SIZE = NesTileRecurrentBrain::H1Size;
+constexpr int H2_SIZE = NesTileRecurrentBrain::H2Size;
+constexpr int OUTPUT_SIZE = NesTileRecurrentBrain::OutputSize;
+
+static_assert(TILE_VOCAB_SIZE == NesTileTokenizer::DefaultVocabSize);
+static_assert(RELATIVE_TILE_COLUMNS == NesPlayerRelativeTileFrame::RelativeTileColumns);
+static_assert(RELATIVE_TILE_ROWS == NesPlayerRelativeTileFrame::RelativeTileRows);
+
+constexpr int TILE_EMBEDDING_SIZE = TILE_VOCAB_SIZE * TILE_EMBED_DIM;
+constexpr int W_XH1_SIZE = INPUT_SIZE * H1_SIZE;
+constexpr int W_H1H1_SIZE = H1_SIZE * H1_SIZE;
+constexpr int B_H1_SIZE = H1_SIZE;
+constexpr int ALPHA1_LOGIT_SIZE = H1_SIZE;
+constexpr int W_H1H2_SIZE = H1_SIZE * H2_SIZE;
+constexpr int W_H2H2_SIZE = H2_SIZE * H2_SIZE;
+constexpr int B_H2_SIZE = H2_SIZE;
+constexpr int ALPHA2_LOGIT_SIZE = H2_SIZE;
+constexpr int ACTIVATION_LEAK_LOGIT_SIZE = 2;
+constexpr int W_H2O_SIZE = H2_SIZE * OUTPUT_SIZE;
+constexpr int B_O_SIZE = OUTPUT_SIZE;
+constexpr int TOTAL_WEIGHTS = TILE_EMBEDDING_SIZE + W_XH1_SIZE + W_H1H1_SIZE + B_H1_SIZE
+    + ALPHA1_LOGIT_SIZE + W_H1H2_SIZE + W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE
+    + ACTIVATION_LEAK_LOGIT_SIZE + W_H2O_SIZE + B_O_SIZE;
+
+constexpr WeightType HIDDEN_STATE_CLAMP_ABS = 3.0f;
+constexpr WeightType HIDDEN_LEAK_ALPHA_MIN = 0.02f;
+constexpr WeightType HIDDEN_LEAK_ALPHA_MAX = 0.98f;
+constexpr WeightType HIDDEN_LEAK_ALPHA_LOGIT_INIT = -1.3862944f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_MIN = 0.02f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_MAX = 0.3f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_INIT = 0.1f;
+constexpr WeightType LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT = -0.91629076f;
+
+WeightType leakyRelu(WeightType x, WeightType negativeSlope)
+{
+    return x >= 0.0f ? x : (negativeSlope * x);
+}
+
+WeightType sigmoid(WeightType x)
+{
+    if (x >= 0.0f) {
+        const WeightType z = std::exp(-x);
+        return 1.0f / (1.0f + z);
+    }
+
+    const WeightType z = std::exp(x);
+    return z / (1.0f + z);
+}
+
+WeightType sigmoidToRange(WeightType x, WeightType minValue, WeightType maxValue)
+{
+    const WeightType unit = sigmoid(x);
+    const WeightType scaled = minValue + ((maxValue - minValue) * unit);
+    return std::clamp(scaled, minValue, maxValue);
+}
+
+} // namespace
+
+struct NesTileRecurrentBrain::Impl {
+    std::vector<WeightType> tile_embedding;
+    std::vector<WeightType> w_xh1;
+    std::vector<WeightType> w_h1h1;
+    std::vector<WeightType> b_h1;
+    std::vector<WeightType> alpha1_logit;
+    std::vector<WeightType> alpha1;
+
+    std::vector<WeightType> w_h1h2;
+    std::vector<WeightType> w_h2h2;
+    std::vector<WeightType> b_h2;
+    std::vector<WeightType> alpha2_logit;
+    std::vector<WeightType> alpha2;
+    WeightType h1NegativeSlopeLogit = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    WeightType h1NegativeSlope = LEAKY_RELU_NEGATIVE_SLOPE_INIT;
+    WeightType h2NegativeSlopeLogit = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    WeightType h2NegativeSlope = LEAKY_RELU_NEGATIVE_SLOPE_INIT;
+
+    std::vector<WeightType> w_h2o;
+    std::vector<WeightType> b_o;
+
+    std::vector<WeightType> input_buffer;
+    std::vector<WeightType> h1_buffer;
+    std::vector<WeightType> h1_state;
+    std::vector<WeightType> h2_buffer;
+    std::vector<WeightType> h2_state;
+    std::vector<WeightType> output_buffer;
+
+    Impl()
+        : tile_embedding(TILE_EMBEDDING_SIZE, 0.0f),
+          w_xh1(W_XH1_SIZE, 0.0f),
+          w_h1h1(W_H1H1_SIZE, 0.0f),
+          b_h1(B_H1_SIZE, 0.0f),
+          alpha1_logit(ALPHA1_LOGIT_SIZE, HIDDEN_LEAK_ALPHA_LOGIT_INIT),
+          alpha1(ALPHA1_LOGIT_SIZE, 0.0f),
+          w_h1h2(W_H1H2_SIZE, 0.0f),
+          w_h2h2(W_H2H2_SIZE, 0.0f),
+          b_h2(B_H2_SIZE, 0.0f),
+          alpha2_logit(ALPHA2_LOGIT_SIZE, HIDDEN_LEAK_ALPHA_LOGIT_INIT),
+          alpha2(ALPHA2_LOGIT_SIZE, 0.0f),
+          w_h2o(W_H2O_SIZE, 0.0f),
+          b_o(B_O_SIZE, 0.0f),
+          input_buffer(INPUT_SIZE, 0.0f),
+          h1_buffer(H1_SIZE, 0.0f),
+          h1_state(H1_SIZE, 0.0f),
+          h2_buffer(H2_SIZE, 0.0f),
+          h2_state(H2_SIZE, 0.0f),
+          output_buffer(OUTPUT_SIZE, 0.0f)
+    {}
+
+    void loadFromGenome(const Genome& genome)
+    {
+        DIRTSIM_ASSERT(
+            genome.weights.size() == static_cast<size_t>(TOTAL_WEIGHTS),
+            "NesTileRecurrentBrain: Genome weight count mismatch");
+
+        int idx = 0;
+        for (int i = 0; i < TILE_EMBEDDING_SIZE; ++i) {
+            tile_embedding[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < W_XH1_SIZE; ++i) {
+            w_xh1[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < W_H1H1_SIZE; ++i) {
+            w_h1h1[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < B_H1_SIZE; ++i) {
+            b_h1[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < ALPHA1_LOGIT_SIZE; ++i) {
+            alpha1_logit[i] = genome.weights[idx++];
+            alpha1[i] =
+                std::clamp(sigmoid(alpha1_logit[i]), HIDDEN_LEAK_ALPHA_MIN, HIDDEN_LEAK_ALPHA_MAX);
+        }
+        h1NegativeSlopeLogit = genome.weights[idx++];
+        h1NegativeSlope = sigmoidToRange(
+            h1NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
+        for (int i = 0; i < W_H1H2_SIZE; ++i) {
+            w_h1h2[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < W_H2H2_SIZE; ++i) {
+            w_h2h2[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < B_H2_SIZE; ++i) {
+            b_h2[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
+            alpha2_logit[i] = genome.weights[idx++];
+            alpha2[i] =
+                std::clamp(sigmoid(alpha2_logit[i]), HIDDEN_LEAK_ALPHA_MIN, HIDDEN_LEAK_ALPHA_MAX);
+        }
+        h2NegativeSlopeLogit = genome.weights[idx++];
+        h2NegativeSlope = sigmoidToRange(
+            h2NegativeSlopeLogit, LEAKY_RELU_NEGATIVE_SLOPE_MIN, LEAKY_RELU_NEGATIVE_SLOPE_MAX);
+        for (int i = 0; i < W_H2O_SIZE; ++i) {
+            w_h2o[i] = genome.weights[idx++];
+        }
+        for (int i = 0; i < B_O_SIZE; ++i) {
+            b_o[i] = genome.weights[idx++];
+        }
+
+        std::fill(h1_state.begin(), h1_state.end(), 0.0f);
+        std::fill(h2_state.begin(), h2_state.end(), 0.0f);
+    }
+
+    Genome toGenome() const
+    {
+        Genome genome(static_cast<size_t>(TOTAL_WEIGHTS));
+        int idx = 0;
+
+        for (int i = 0; i < TILE_EMBEDDING_SIZE; ++i) {
+            genome.weights[idx++] = tile_embedding[i];
+        }
+        for (int i = 0; i < W_XH1_SIZE; ++i) {
+            genome.weights[idx++] = w_xh1[i];
+        }
+        for (int i = 0; i < W_H1H1_SIZE; ++i) {
+            genome.weights[idx++] = w_h1h1[i];
+        }
+        for (int i = 0; i < B_H1_SIZE; ++i) {
+            genome.weights[idx++] = b_h1[i];
+        }
+        for (int i = 0; i < ALPHA1_LOGIT_SIZE; ++i) {
+            genome.weights[idx++] = alpha1_logit[i];
+        }
+        genome.weights[idx++] = h1NegativeSlopeLogit;
+        for (int i = 0; i < W_H1H2_SIZE; ++i) {
+            genome.weights[idx++] = w_h1h2[i];
+        }
+        for (int i = 0; i < W_H2H2_SIZE; ++i) {
+            genome.weights[idx++] = w_h2h2[i];
+        }
+        for (int i = 0; i < B_H2_SIZE; ++i) {
+            genome.weights[idx++] = b_h2[i];
+        }
+        for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
+            genome.weights[idx++] = alpha2_logit[i];
+        }
+        genome.weights[idx++] = h2NegativeSlopeLogit;
+        for (int i = 0; i < W_H2O_SIZE; ++i) {
+            genome.weights[idx++] = w_h2o[i];
+        }
+        for (int i = 0; i < B_O_SIZE; ++i) {
+            genome.weights[idx++] = b_o[i];
+        }
+
+        return genome;
+    }
+
+    const std::vector<WeightType>& flattenSensoryData(const NesTileSensoryData& sensory)
+    {
+        int index = 0;
+        for (const auto token : sensory.tileFrame.tokens) {
+            DIRTSIM_ASSERT(
+                token < TILE_VOCAB_SIZE, "NesTileRecurrentBrain: Tile token out of range");
+            const WeightType* embedding =
+                &tile_embedding[static_cast<size_t>(token) * TILE_EMBED_DIM];
+            for (int dim = 0; dim < TILE_EMBED_DIM; ++dim) {
+                input_buffer[index++] = embedding[dim];
+            }
+        }
+
+        input_buffer[index++] = 0.0f;
+        input_buffer[index++] = 0.0f;
+        input_buffer[index++] = 0.0f;
+        input_buffer[index++] = static_cast<WeightType>(sensory.facingX);
+        input_buffer[index++] = static_cast<WeightType>(sensory.selfViewX);
+        input_buffer[index++] = static_cast<WeightType>(sensory.selfViewY);
+        input_buffer[index++] = static_cast<WeightType>(sensory.previousControlX);
+        input_buffer[index++] = static_cast<WeightType>(sensory.previousControlY);
+        input_buffer[index++] =
+            sensory.previousA ? static_cast<WeightType>(1.0f) : static_cast<WeightType>(0.0f);
+        input_buffer[index++] =
+            sensory.previousB ? static_cast<WeightType>(1.0f) : static_cast<WeightType>(0.0f);
+        for (double sense : sensory.specialSenses) {
+            input_buffer[index++] = static_cast<WeightType>(sense);
+        }
+        input_buffer[index++] = static_cast<WeightType>(sensory.energy);
+        input_buffer[index++] = static_cast<WeightType>(sensory.health);
+
+        DIRTSIM_ASSERT(index == INPUT_SIZE, "NesTileRecurrentBrain: Input size mismatch");
+
+        return input_buffer;
+    }
+
+    const std::vector<WeightType>& forward(const std::vector<WeightType>& input)
+    {
+        std::copy(b_h1.begin(), b_h1.end(), h1_buffer.begin());
+        for (int i = 0; i < INPUT_SIZE; ++i) {
+            const WeightType inputValue = input[i];
+            if (inputValue == 0.0f) {
+                continue;
+            }
+            const WeightType* weights = &w_xh1[i * H1_SIZE];
+            for (int h = 0; h < H1_SIZE; ++h) {
+                h1_buffer[h] += inputValue * weights[h];
+            }
+        }
+
+        for (int i = 0; i < H1_SIZE; ++i) {
+            const WeightType recurrentValue = h1_state[i];
+            if (recurrentValue == 0.0f) {
+                continue;
+            }
+            const WeightType* weights = &w_h1h1[i * H1_SIZE];
+            for (int h = 0; h < H1_SIZE; ++h) {
+                h1_buffer[h] += recurrentValue * weights[h];
+            }
+        }
+
+        for (int h = 0; h < H1_SIZE; ++h) {
+            h1_buffer[h] = leakyRelu(h1_buffer[h], h1NegativeSlope);
+        }
+
+        for (int h = 0; h < H1_SIZE; ++h) {
+            const WeightType candidate =
+                std::clamp(h1_buffer[h], -HIDDEN_STATE_CLAMP_ABS, HIDDEN_STATE_CLAMP_ABS);
+            const WeightType learnedAlpha = alpha1[h];
+            const WeightType blended =
+                ((1.0f - learnedAlpha) * h1_state[h]) + (learnedAlpha * candidate);
+            h1_state[h] = std::clamp(blended, -HIDDEN_STATE_CLAMP_ABS, HIDDEN_STATE_CLAMP_ABS);
+        }
+
+        std::copy(b_h2.begin(), b_h2.end(), h2_buffer.begin());
+        for (int i = 0; i < H1_SIZE; ++i) {
+            const WeightType inputValue = h1_state[i];
+            if (inputValue == 0.0f) {
+                continue;
+            }
+            const WeightType* weights = &w_h1h2[i * H2_SIZE];
+            for (int h = 0; h < H2_SIZE; ++h) {
+                h2_buffer[h] += inputValue * weights[h];
+            }
+        }
+
+        for (int i = 0; i < H2_SIZE; ++i) {
+            const WeightType recurrentValue = h2_state[i];
+            if (recurrentValue == 0.0f) {
+                continue;
+            }
+            const WeightType* weights = &w_h2h2[i * H2_SIZE];
+            for (int h = 0; h < H2_SIZE; ++h) {
+                h2_buffer[h] += recurrentValue * weights[h];
+            }
+        }
+
+        for (int h = 0; h < H2_SIZE; ++h) {
+            h2_buffer[h] = leakyRelu(h2_buffer[h], h2NegativeSlope);
+        }
+
+        for (int h = 0; h < H2_SIZE; ++h) {
+            const WeightType candidate =
+                std::clamp(h2_buffer[h], -HIDDEN_STATE_CLAMP_ABS, HIDDEN_STATE_CLAMP_ABS);
+            const WeightType learnedAlpha = alpha2[h];
+            const WeightType blended =
+                ((1.0f - learnedAlpha) * h2_state[h]) + (learnedAlpha * candidate);
+            h2_state[h] = std::clamp(blended, -HIDDEN_STATE_CLAMP_ABS, HIDDEN_STATE_CLAMP_ABS);
+        }
+
+        std::copy(b_o.begin(), b_o.end(), output_buffer.begin());
+        for (int h = 0; h < H2_SIZE; ++h) {
+            const WeightType hiddenValue = h2_state[h];
+            const WeightType* weights = &w_h2o[h * OUTPUT_SIZE];
+            for (int o = 0; o < OUTPUT_SIZE; ++o) {
+                output_buffer[o] += hiddenValue * weights[o];
+            }
+        }
+
+        return output_buffer;
+    }
+};
+
+NesTileRecurrentBrain::NesTileRecurrentBrain(const Genome& genome) : impl_(std::make_unique<Impl>())
+{
+    impl_->loadFromGenome(genome);
+}
+
+NesTileRecurrentBrain::~NesTileRecurrentBrain() = default;
+
+NesTileRecurrentBrain::NesTileRecurrentBrain(NesTileRecurrentBrain&&) noexcept = default;
+NesTileRecurrentBrain& NesTileRecurrentBrain::operator=(NesTileRecurrentBrain&&) noexcept = default;
+
+ControllerOutput NesTileRecurrentBrain::inferControllerOutput(const NesTileSensoryData& sensory)
+{
+    const auto& input = impl_->flattenSensoryData(sensory);
+    const auto& output = impl_->forward(input);
+
+    const float xRaw = static_cast<float>(output[0]);
+    const float yRaw = static_cast<float>(output[1]);
+    const float aRaw = static_cast<float>(output[2]);
+    const float bRaw = static_cast<float>(output[3]);
+
+    return ControllerOutput{
+        .x = static_cast<float>(std::tanh(output[0])),
+        .y = static_cast<float>(std::tanh(output[1])),
+        .a = output[2] > 0.0f,
+        .b = output[3] > 0.0f,
+        .xRaw = xRaw,
+        .yRaw = yRaw,
+        .aRaw = aRaw,
+        .bRaw = bRaw,
+    };
+}
+
+Genome NesTileRecurrentBrain::getGenome() const
+{
+    return impl_->toGenome();
+}
+
+void NesTileRecurrentBrain::setGenome(const Genome& genome)
+{
+    impl_->loadFromGenome(genome);
+}
+
+Genome NesTileRecurrentBrain::randomGenome(std::mt19937& rng)
+{
+    Genome genome(static_cast<size_t>(TOTAL_WEIGHTS));
+
+    const WeightType xh1Stddev = std::sqrt(2.0f / (INPUT_SIZE + H1_SIZE));
+    const WeightType h1h1Stddev = std::sqrt(2.0f / (H1_SIZE + H1_SIZE));
+    const WeightType h1h2Stddev = std::sqrt(2.0f / (H1_SIZE + H2_SIZE));
+    const WeightType h2h2Stddev = std::sqrt(2.0f / (H2_SIZE + H2_SIZE));
+    const WeightType h2oStddev = std::sqrt(2.0f / (H2_SIZE + OUTPUT_SIZE));
+
+    std::normal_distribution<WeightType> embeddingDist(0.0f, 0.1f);
+    std::normal_distribution<WeightType> xh1Dist(0.0f, xh1Stddev);
+    std::normal_distribution<WeightType> h1h1Dist(0.0f, h1h1Stddev);
+    std::normal_distribution<WeightType> h1h2Dist(0.0f, h1h2Stddev);
+    std::normal_distribution<WeightType> h2h2Dist(0.0f, h2h2Stddev);
+    std::normal_distribution<WeightType> h2oDist(0.0f, h2oStddev);
+    std::uniform_real_distribution<WeightType> alphaLogitDist(-4.0f, 4.0f);
+
+    int idx = 0;
+    for (int i = 0; i < TILE_EMBEDDING_SIZE; ++i) {
+        genome.weights[idx++] = embeddingDist(rng);
+    }
+    for (int i = 0; i < W_XH1_SIZE; ++i) {
+        genome.weights[idx++] = xh1Dist(rng);
+    }
+    for (int i = 0; i < W_H1H1_SIZE; ++i) {
+        genome.weights[idx++] = h1h1Dist(rng);
+    }
+    for (int i = 0; i < B_H1_SIZE; ++i) {
+        genome.weights[idx++] = 0.0f;
+    }
+    for (int i = 0; i < ALPHA1_LOGIT_SIZE; ++i) {
+        genome.weights[idx++] = alphaLogitDist(rng);
+    }
+    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    for (int i = 0; i < W_H1H2_SIZE; ++i) {
+        genome.weights[idx++] = h1h2Dist(rng);
+    }
+    for (int i = 0; i < W_H2H2_SIZE; ++i) {
+        genome.weights[idx++] = h2h2Dist(rng);
+    }
+    for (int i = 0; i < B_H2_SIZE; ++i) {
+        genome.weights[idx++] = 0.0f;
+    }
+    for (int i = 0; i < ALPHA2_LOGIT_SIZE; ++i) {
+        genome.weights[idx++] = alphaLogitDist(rng);
+    }
+    genome.weights[idx++] = LEAKY_RELU_NEGATIVE_SLOPE_LOGIT_INIT;
+    for (int i = 0; i < W_H2O_SIZE; ++i) {
+        genome.weights[idx++] = h2oDist(rng);
+    }
+    for (int i = 0; i < B_O_SIZE; ++i) {
+        genome.weights[idx++] = 0.0f;
+    }
+
+    DIRTSIM_ASSERT(idx == TOTAL_WEIGHTS, "NesTileRecurrentBrain: Generated genome size mismatch");
+    return genome;
+}
+
+bool NesTileRecurrentBrain::isGenomeCompatible(const Genome& genome)
+{
+    return genome.weights.size() == static_cast<size_t>(TOTAL_WEIGHTS);
+}
+
+GenomeLayout NesTileRecurrentBrain::getGenomeLayout()
+{
+    return GenomeLayout{
+        .segments = {
+            { "tile_embedding", TILE_EMBEDDING_SIZE },
+            { "input_h1", W_XH1_SIZE },
+            { "h1_recurrent", W_H1H1_SIZE + B_H1_SIZE + ALPHA1_LOGIT_SIZE + 1 },
+            { "h1_to_h2", W_H1H2_SIZE },
+            { "h2_recurrent", W_H2H2_SIZE + B_H2_SIZE + ALPHA2_LOGIT_SIZE + 1 },
+            { "output", W_H2O_SIZE + B_O_SIZE },
+        },
+    };
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileRecurrentBrain.h
+++ b/apps/src/core/scenarios/nes/NesTileRecurrentBrain.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "core/organisms/brains/ControllerOutput.h"
+#include "core/organisms/brains/Genome.h"
+#include "core/organisms/evolution/GenomeLayout.h"
+
+#include <memory>
+#include <random>
+
+namespace DirtSim {
+
+struct NesTileSensoryData;
+
+class NesTileRecurrentBrain final {
+public:
+    static constexpr int TileVocabularySize = 512;
+    static constexpr int TileEmbeddingDim = 4;
+    static constexpr int RelativeTileColumns = 63;
+    static constexpr int RelativeTileRows = 55;
+    static constexpr int VisualInputSize =
+        RelativeTileColumns * RelativeTileRows * TileEmbeddingDim;
+    static constexpr int ScalarInputSize = 44;
+    static constexpr int InputSize = VisualInputSize + ScalarInputSize;
+    static constexpr int H1Size = 64;
+    static constexpr int H2Size = 32;
+    static constexpr int OutputSize = 4;
+
+    explicit NesTileRecurrentBrain(const Genome& genome);
+    ~NesTileRecurrentBrain();
+
+    NesTileRecurrentBrain(const NesTileRecurrentBrain&) = delete;
+    NesTileRecurrentBrain& operator=(const NesTileRecurrentBrain&) = delete;
+    NesTileRecurrentBrain(NesTileRecurrentBrain&&) noexcept;
+    NesTileRecurrentBrain& operator=(NesTileRecurrentBrain&&) noexcept;
+
+    ControllerOutput inferControllerOutput(const NesTileSensoryData& sensory);
+
+    Genome getGenome() const;
+    void setGenome(const Genome& genome);
+
+    static Genome randomGenome(std::mt19937& rng);
+    static bool isGenomeCompatible(const Genome& genome);
+    static GenomeLayout getGenomeLayout();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileSensoryBuilder.cpp
+++ b/apps/src/core/scenarios/nes/NesTileSensoryBuilder.cpp
@@ -1,0 +1,53 @@
+#include "core/scenarios/nes/NesTileSensoryBuilder.h"
+
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+
+#include <string>
+
+namespace DirtSim {
+
+namespace {
+
+void applyBuilderInput(NesTileSensoryData& sensory, const NesTileSensoryBuilderInput& input)
+{
+    sensory.facingX = input.facingX;
+    sensory.selfViewX = input.selfViewX;
+    sensory.selfViewY = input.selfViewY;
+    setNesTilePreviousControlFromControllerMask(sensory, input.controllerMask);
+    sensory.specialSenses = input.specialSenses;
+    sensory.energy = input.energy;
+    sensory.health = input.health;
+    sensory.deltaTimeSeconds = input.deltaTimeSeconds;
+}
+
+} // namespace
+
+Result<NesTileSensoryData, std::string> makeNesTileSensoryDataFromPpuSnapshot(
+    const NesPpuSnapshot& ppuSnapshot,
+    NesTileTokenizer& tokenizer,
+    const NesTileSensoryBuilderInput& input)
+{
+    return makeNesTileSensoryDataFromTileFrame(makeNesTileFrame(ppuSnapshot), tokenizer, input);
+}
+
+Result<NesTileSensoryData, std::string> makeNesTileSensoryDataFromTileFrame(
+    const NesTileFrame& tileFrame,
+    NesTileTokenizer& tokenizer,
+    const NesTileSensoryBuilderInput& input)
+{
+    const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+    if (tokenFrameResult.isError()) {
+        return Result<NesTileSensoryData, std::string>::error(
+            "NesTileSensoryBuilder: Failed to tokenize tile frame: "
+            + tokenFrameResult.errorValue());
+    }
+
+    NesTileSensoryData sensory;
+    sensory.tileFrame = makeNesPlayerRelativeTileFrame(
+        tokenFrameResult.value(), input.playerScreenX, input.playerScreenY);
+    applyBuilderInput(sensory, input);
+    return Result<NesTileSensoryData, std::string>::okay(sensory);
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileSensoryBuilder.h
+++ b/apps/src/core/scenarios/nes/NesTileSensoryBuilder.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "core/Result.h"
+#include "core/scenarios/nes/NesTileFrame.h"
+#include "core/scenarios/nes/NesTileSensoryData.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace DirtSim {
+
+struct NesTileSensoryBuilderInput {
+    int16_t playerScreenX = 0;
+    int16_t playerScreenY = 0;
+    float facingX = 0.0f;
+    float selfViewX = 0.5f;
+    float selfViewY = 0.5f;
+    uint8_t controllerMask = 0u;
+    std::array<double, NesTileSensoryData::SpecialSenseCount> specialSenses{};
+    float energy = 1.0f;
+    float health = 1.0f;
+    double deltaTimeSeconds = 0.0;
+};
+
+Result<NesTileSensoryData, std::string> makeNesTileSensoryDataFromPpuSnapshot(
+    const NesPpuSnapshot& ppuSnapshot,
+    NesTileTokenizer& tokenizer,
+    const NesTileSensoryBuilderInput& input);
+
+Result<NesTileSensoryData, std::string> makeNesTileSensoryDataFromTileFrame(
+    const NesTileFrame& tileFrame,
+    NesTileTokenizer& tokenizer,
+    const NesTileSensoryBuilderInput& input);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileSensoryData.cpp
+++ b/apps/src/core/scenarios/nes/NesTileSensoryData.cpp
@@ -1,0 +1,30 @@
+#include "core/scenarios/nes/NesTileSensoryData.h"
+
+#include "core/organisms/evolution/NesPolicyLayout.h"
+
+#include <cstdint>
+
+namespace DirtSim {
+
+void setNesTilePreviousControlFromControllerMask(
+    NesTileSensoryData& sensory, uint8_t controllerMask)
+{
+    const bool leftHeld = (controllerMask & NesPolicyLayout::ButtonLeft) != 0u;
+    const bool rightHeld = (controllerMask & NesPolicyLayout::ButtonRight) != 0u;
+    sensory.previousControlX = 0.0f;
+    if (leftHeld != rightHeld) {
+        sensory.previousControlX = leftHeld ? -1.0f : 1.0f;
+    }
+
+    const bool upHeld = (controllerMask & NesPolicyLayout::ButtonUp) != 0u;
+    const bool downHeld = (controllerMask & NesPolicyLayout::ButtonDown) != 0u;
+    sensory.previousControlY = 0.0f;
+    if (upHeld != downHeld) {
+        sensory.previousControlY = upHeld ? -1.0f : 1.0f;
+    }
+
+    sensory.previousA = (controllerMask & NesPolicyLayout::ButtonA) != 0u;
+    sensory.previousB = (controllerMask & NesPolicyLayout::ButtonB) != 0u;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileSensoryData.h
+++ b/apps/src/core/scenarios/nes/NesTileSensoryData.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace DirtSim {
+
+struct NesTileSensoryData {
+    static constexpr size_t SpecialSenseCount = 32u;
+
+    NesPlayerRelativeTileFrame tileFrame;
+    float facingX = 0.0f;
+    float selfViewX = 0.5f;
+    float selfViewY = 0.5f;
+    float previousControlX = 0.0f;
+    float previousControlY = 0.0f;
+    bool previousA = false;
+    bool previousB = false;
+    std::array<double, SpecialSenseCount> specialSenses{};
+    float energy = 1.0f;
+    float health = 1.0f;
+    double deltaTimeSeconds = 0.0;
+};
+
+void setNesTilePreviousControlFromControllerMask(
+    NesTileSensoryData& sensory, uint8_t controllerMask);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenFrame.cpp
+++ b/apps/src/core/scenarios/nes/NesTileTokenFrame.cpp
@@ -1,0 +1,31 @@
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+
+#include <cstddef>
+#include <string>
+
+namespace DirtSim {
+
+Result<NesTileTokenFrame, std::string> makeNesTileTokenFrame(
+    const NesTileFrame& tileFrame, NesTileTokenizer& tokenizer)
+{
+    NesTileTokenFrame tokenFrame{
+        .frameId = tileFrame.frameId,
+        .scrollX = tileFrame.scrollX,
+        .scrollY = tileFrame.scrollY,
+    };
+
+    for (size_t cellIndex = 0; cellIndex < tileFrame.tilePatternHashes.size(); ++cellIndex) {
+        const auto tokenResult = tokenizer.tokenForHash(tileFrame.tilePatternHashes[cellIndex]);
+        if (tokenResult.isError()) {
+            return Result<NesTileTokenFrame, std::string>::error(
+                "NesTileTokenFrame: Failed to tokenize cell " + std::to_string(cellIndex) + ": "
+                + tokenResult.errorValue());
+        }
+
+        tokenFrame.tokens[cellIndex] = tokenResult.value();
+    }
+
+    return Result<NesTileTokenFrame, std::string>::okay(tokenFrame);
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenFrame.h
+++ b/apps/src/core/scenarios/nes/NesTileTokenFrame.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/Result.h"
+#include "core/scenarios/nes/NesTileFrame.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace DirtSim {
+
+struct NesTileTokenFrame {
+    static constexpr uint16_t VisibleTileColumns = NesTileFrame::VisibleTileColumns;
+    static constexpr uint16_t VisibleTileRows = NesTileFrame::VisibleTileRows;
+
+    uint64_t frameId = 0;
+    uint16_t scrollX = 0;
+    uint16_t scrollY = 0;
+    std::array<NesTileTokenizer::TileToken, VisibleTileColumns * VisibleTileRows> tokens{};
+};
+
+Result<NesTileTokenFrame, std::string> makeNesTileTokenFrame(
+    const NesTileFrame& tileFrame, NesTileTokenizer& tokenizer);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
@@ -1,0 +1,64 @@
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include "core/Assert.h"
+
+#include <string>
+
+namespace DirtSim {
+
+NesTileTokenizer::NesTileTokenizer(TileToken vocabSize) : vocabSize_(vocabSize)
+{
+    DIRTSIM_ASSERT(vocabSize_ > VoidToken + 1u, "NesTileTokenizer: vocabSize must be at least 2");
+}
+
+Result<NesTileTokenizer::TileIdTokenRemap, std::string> NesTileTokenizer::tileIdTokenRemapBuild(
+    const TileIdPatternHashTable& tilePatternHashes)
+{
+    TileIdTokenRemap remap{};
+
+    for (size_t tileId = 0; tileId < tilePatternHashes.size(); ++tileId) {
+        const auto tokenResult = tokenForHash(tilePatternHashes[tileId]);
+        if (tokenResult.isError()) {
+            return Result<TileIdTokenRemap, std::string>::error(
+                "NesTileTokenizer: Failed to map tile id " + std::to_string(tileId) + ": "
+                + tokenResult.errorValue());
+        }
+
+        remap[tileId] = tokenResult.value();
+    }
+
+    return Result<TileIdTokenRemap, std::string>::okay(remap);
+}
+
+Result<NesTileTokenizer::TileToken, std::string> NesTileTokenizer::tokenForHash(
+    std::optional<TilePatternHash> patternHash)
+{
+    if (!patternHash.has_value()) {
+        return Result<TileToken, std::string>::okay(VoidToken);
+    }
+
+    const auto it = hashToToken_.find(patternHash.value());
+    if (it != hashToToken_.end()) {
+        return Result<TileToken, std::string>::okay(it->second);
+    }
+
+    if (nextToken_ >= vocabSize_) {
+        return Result<TileToken, std::string>::error(
+            "NesTileTokenizer: Tile token vocabulary exhausted after "
+            + std::to_string(hashToToken_.size()) + " unique patterns with vocab size "
+            + std::to_string(vocabSize_));
+    }
+
+    const TileToken assignedToken = nextToken_;
+    hashToToken_.emplace(patternHash.value(), assignedToken);
+    ++nextToken_;
+    return Result<TileToken, std::string>::okay(assignedToken);
+}
+
+void NesTileTokenizer::reset()
+{
+    hashToToken_.clear();
+    nextToken_ = VoidToken + 1u;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
@@ -3,11 +3,42 @@
 #include "core/Assert.h"
 
 #include <algorithm>
+#include <iomanip>
+#include <sstream>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace DirtSim {
+
+namespace {
+
+void hashBytes(uint64_t& hash, const void* data, size_t size)
+{
+    constexpr uint64_t FNV_PRIME = 1099511628211ull;
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < size; ++i) {
+        hash ^= bytes[i];
+        hash *= FNV_PRIME;
+    }
+}
+
+template <typename T>
+void hashValue(uint64_t& hash, const T& value)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    hashBytes(hash, &value, sizeof(T));
+}
+
+std::string toHexString(uint64_t value)
+{
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(16) << value;
+    return stream.str();
+}
+
+} // namespace
 
 NesTileTokenizer::NesTileTokenizer(TileToken vocabSize) : vocabSize_(vocabSize)
 {
@@ -103,6 +134,32 @@ Result<NesTileTokenizer::TileToken, std::string> NesTileTokenizer::tokenForHash(
     hashToToken_.emplace(patternHash.value(), assignedToken);
     ++nextToken_;
     return Result<TileToken, std::string>::okay(assignedToken);
+}
+
+std::string NesTileTokenizer::getVocabularyHash() const
+{
+    constexpr uint64_t FNV_OFFSET_BASIS = 1469598103934665603ull;
+    uint64_t hash = FNV_OFFSET_BASIS;
+
+    hashValue(hash, vocabSize_);
+    hashValue(hash, VoidToken);
+    hashValue(hash, mode_);
+
+    std::vector<std::pair<TileToken, TilePatternHash>> tokenToHash;
+    tokenToHash.reserve(hashToToken_.size());
+    for (const auto& [patternHash, token] : hashToToken_) {
+        tokenToHash.emplace_back(token, patternHash);
+    }
+    std::sort(tokenToHash.begin(), tokenToHash.end());
+
+    const uint64_t mappedHashCount = tokenToHash.size();
+    hashValue(hash, mappedHashCount);
+    for (const auto& [token, patternHash] : tokenToHash) {
+        hashValue(hash, token);
+        hashValue(hash, patternHash);
+    }
+
+    return toHexString(hash);
 }
 
 void NesTileTokenizer::reset()

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.cpp
@@ -2,13 +2,57 @@
 
 #include "core/Assert.h"
 
+#include <algorithm>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace DirtSim {
 
 NesTileTokenizer::NesTileTokenizer(TileToken vocabSize) : vocabSize_(vocabSize)
 {
     DIRTSIM_ASSERT(vocabSize_ > VoidToken + 1u, "NesTileTokenizer: vocabSize must be at least 2");
+}
+
+Result<size_t, std::string> NesTileTokenizer::buildVocabulary(
+    const TileIdPatternHashTable& tilePatternHashes)
+{
+    return buildVocabulary(
+        std::vector<TilePatternHash>(tilePatternHashes.begin(), tilePatternHashes.end()));
+}
+
+Result<size_t, std::string> NesTileTokenizer::buildVocabulary(
+    std::vector<TilePatternHash> tilePatternHashes)
+{
+    std::sort(tilePatternHashes.begin(), tilePatternHashes.end());
+    tilePatternHashes.erase(
+        std::unique(tilePatternHashes.begin(), tilePatternHashes.end()), tilePatternHashes.end());
+
+    if (tilePatternHashes.size() >= static_cast<size_t>(vocabSize_)) {
+        return Result<size_t, std::string>::error(
+            "NesTileTokenizer: Tile token vocabulary exhausted while building "
+            + std::to_string(tilePatternHashes.size()) + " unique patterns with vocab size "
+            + std::to_string(vocabSize_));
+    }
+
+    std::unordered_map<TilePatternHash, TileToken> hashToToken;
+    hashToToken.reserve(tilePatternHashes.size());
+
+    TileToken nextToken = VoidToken + 1u;
+    for (const TilePatternHash hash : tilePatternHashes) {
+        hashToToken.emplace(hash, nextToken);
+        ++nextToken;
+    }
+
+    hashToToken_ = std::move(hashToToken);
+    nextToken_ = nextToken;
+    mode_ = Mode::Learning;
+    return Result<size_t, std::string>::okay(hashToToken_.size());
+}
+
+void NesTileTokenizer::freeze()
+{
+    mode_ = Mode::Frozen;
 }
 
 Result<NesTileTokenizer::TileIdTokenRemap, std::string> NesTileTokenizer::tileIdTokenRemapBuild(
@@ -42,6 +86,12 @@ Result<NesTileTokenizer::TileToken, std::string> NesTileTokenizer::tokenForHash(
         return Result<TileToken, std::string>::okay(it->second);
     }
 
+    if (mode_ == Mode::Frozen) {
+        return Result<TileToken, std::string>::error(
+            "NesTileTokenizer: Frozen vocabulary missing tile pattern hash "
+            + std::to_string(patternHash.value()));
+    }
+
     if (nextToken_ >= vocabSize_) {
         return Result<TileToken, std::string>::error(
             "NesTileTokenizer: Tile token vocabulary exhausted after "
@@ -58,6 +108,7 @@ Result<NesTileTokenizer::TileToken, std::string> NesTileTokenizer::tokenForHash(
 void NesTileTokenizer::reset()
 {
     hashToToken_.clear();
+    mode_ = Mode::Learning;
     nextToken_ = VoidToken + 1u;
 }
 

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.h
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace DirtSim {
 
@@ -18,21 +19,31 @@ public:
     using TileIdPatternHashTable = std::array<TilePatternHash, 256u>;
     using TileIdTokenRemap = std::array<TileToken, 256u>;
 
+    enum class Mode : uint8_t {
+        Learning = 0,
+        Frozen = 1,
+    };
+
     static constexpr TileToken DefaultVocabSize = 512u;
     static constexpr TileToken VoidToken = 0u;
 
     explicit NesTileTokenizer(TileToken vocabSize = DefaultVocabSize);
 
+    Result<size_t, std::string> buildVocabulary(const TileIdPatternHashTable& tilePatternHashes);
+    Result<size_t, std::string> buildVocabulary(std::vector<TilePatternHash> tilePatternHashes);
+    void freeze();
     Result<TileIdTokenRemap, std::string> tileIdTokenRemapBuild(
         const TileIdPatternHashTable& tilePatternHashes);
     Result<TileToken, std::string> tokenForHash(std::optional<TilePatternHash> patternHash);
 
+    Mode getMode() const { return mode_; }
     TileToken getVocabSize() const { return vocabSize_; }
     size_t getMappedHashCount() const { return hashToToken_.size(); }
     void reset();
 
 private:
     std::unordered_map<TilePatternHash, TileToken> hashToToken_;
+    Mode mode_ = Mode::Learning;
     TileToken nextToken_ = VoidToken + 1u;
     TileToken vocabSize_ = DefaultVocabSize;
 };

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.h
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "core/Result.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace DirtSim {
+
+class NesTileTokenizer final {
+public:
+    using TilePatternHash = uint64_t;
+    using TileToken = uint16_t;
+    using TileIdPatternHashTable = std::array<TilePatternHash, 256u>;
+    using TileIdTokenRemap = std::array<TileToken, 256u>;
+
+    static constexpr TileToken DefaultVocabSize = 512u;
+    static constexpr TileToken VoidToken = 0u;
+
+    explicit NesTileTokenizer(TileToken vocabSize = DefaultVocabSize);
+
+    Result<TileIdTokenRemap, std::string> tileIdTokenRemapBuild(
+        const TileIdPatternHashTable& tilePatternHashes);
+    Result<TileToken, std::string> tokenForHash(std::optional<TilePatternHash> patternHash);
+
+    TileToken getVocabSize() const { return vocabSize_; }
+    size_t getMappedHashCount() const { return hashToToken_.size(); }
+    void reset();
+
+private:
+    std::unordered_map<TilePatternHash, TileToken> hashToToken_;
+    TileToken nextToken_ = VoidToken + 1u;
+    TileToken vocabSize_ = DefaultVocabSize;
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenizer.h
+++ b/apps/src/core/scenarios/nes/NesTileTokenizer.h
@@ -39,6 +39,7 @@ public:
     Mode getMode() const { return mode_; }
     TileToken getVocabSize() const { return vocabSize_; }
     size_t getMappedHashCount() const { return hashToToken_.size(); }
+    std::string getVocabularyHash() const;
     void reset();
 
 private:

--- a/apps/src/core/scenarios/nes/NesTileTokenizerBootstrapper.cpp
+++ b/apps/src/core/scenarios/nes/NesTileTokenizerBootstrapper.cpp
@@ -1,0 +1,128 @@
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
+
+#include "core/Timers.h"
+#include "core/scenarios/nes/NesGameAdapter.h"
+#include "core/scenarios/nes/NesGameAdapterRegistry.h"
+#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
+
+namespace DirtSim {
+
+Result<std::shared_ptr<NesTileTokenizer>, std::string> NesTileTokenizerBootstrapper::build(
+    Scenario::EnumType scenarioId, const std::optional<ScenarioConfig>& scenarioConfigOverride)
+{
+    return build(scenarioId, scenarioConfigOverride, Config{});
+}
+
+Result<std::shared_ptr<NesTileTokenizer>, std::string> NesTileTokenizerBootstrapper::build(
+    Scenario::EnumType scenarioId,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    Config config)
+{
+    const NesGameAdapterRegistry adapterRegistry = NesGameAdapterRegistry::createDefault();
+    return build(scenarioId, scenarioConfigOverride, adapterRegistry, config);
+}
+
+Result<std::shared_ptr<NesTileTokenizer>, std::string> NesTileTokenizerBootstrapper::build(
+    Scenario::EnumType scenarioId,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    const NesGameAdapterRegistry& adapterRegistry)
+{
+    return build(scenarioId, scenarioConfigOverride, adapterRegistry, Config{});
+}
+
+Result<std::shared_ptr<NesTileTokenizer>, std::string> NesTileTokenizerBootstrapper::build(
+    Scenario::EnumType scenarioId,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    const NesGameAdapterRegistry& adapterRegistry,
+    Config config)
+{
+    if (config.bootstrapFrames <= 0) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "NesTileTokenizerBootstrapper: bootstrapFrames must be positive");
+    }
+
+    NesSmolnesScenarioDriver driver(scenarioId);
+    if (scenarioConfigOverride.has_value()) {
+        const auto configResult = driver.setConfig(scenarioConfigOverride.value());
+        if (configResult.isError()) {
+            return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+                "NesTileTokenizerBootstrapper: NES tile tokenizer config rejected: "
+                + configResult.errorValue());
+        }
+    }
+
+    const auto setupResult = driver.setup();
+    if (setupResult.isError()) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "NesTileTokenizerBootstrapper: NES tile tokenizer runtime setup failed: "
+            + setupResult.errorValue());
+    }
+
+    auto adapter = adapterRegistry.createAdapter(scenarioId);
+    if (!adapter) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "NesTileTokenizerBootstrapper: Missing NES game adapter for tile tokenizer bootstrap");
+    }
+    adapter->reset(driver.getRuntimeResolvedRomId());
+
+    NesTileVocabularyBuilder builder;
+    Timers timers;
+    std::optional<uint8_t> lastGameState = std::nullopt;
+
+    for (int frameIndex = 0; frameIndex < config.bootstrapFrames; ++frameIndex) {
+        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
+            builder.addSnapshot(snapshot.value());
+        }
+
+        const NesGameAdapterControllerOutput controllerOutput = adapter->resolveControllerMask(
+            NesGameAdapterControllerInput{ .inferredControllerMask = 0,
+                                           .lastGameState = lastGameState });
+        auto stepResult = driver.step(timers, controllerOutput.resolvedControllerMask);
+        if (!stepResult.runtimeHealthy || !stepResult.runtimeRunning) {
+            if (builder.getSampledTileCount() == 0) {
+                return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+                    "NesTileTokenizerBootstrapper: NES tile tokenizer runtime stopped before "
+                    "samples: "
+                    + stepResult.lastError);
+            }
+            break;
+        }
+
+        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
+            builder.addSnapshot(snapshot.value());
+        }
+
+        if (stepResult.advancedFrames == 0) {
+            continue;
+        }
+
+        const NesGameAdapterFrameInput frameInput{
+            .advancedFrames = stepResult.advancedFrames,
+            .controllerMask = controllerOutput.resolvedControllerMask,
+            .paletteFrame =
+                stepResult.paletteFrame.has_value() ? &stepResult.paletteFrame.value() : nullptr,
+            .memorySnapshot = std::move(stepResult.memorySnapshot),
+        };
+        const NesGameAdapterFrameOutput frameOutput = adapter->evaluateFrame(frameInput);
+        if (frameOutput.gameState.has_value()) {
+            lastGameState = frameOutput.gameState;
+        }
+        if (frameOutput.done) {
+            break;
+        }
+    }
+
+    auto tokenizer = std::make_shared<NesTileTokenizer>();
+    const auto buildResult = builder.buildFrozenTokenizer(*tokenizer);
+    if (buildResult.isError()) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "NesTileTokenizerBootstrapper: NES tile tokenizer bootstrap failed: "
+            + buildResult.errorValue());
+    }
+
+    return Result<std::shared_ptr<NesTileTokenizer>, std::string>::okay(std::move(tokenizer));
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileTokenizerBootstrapper.h
+++ b/apps/src/core/scenarios/nes/NesTileTokenizerBootstrapper.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "core/Result.h"
+#include "core/ScenarioConfig.h"
+#include "core/ScenarioId.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace DirtSim {
+
+class NesGameAdapterRegistry;
+class NesTileTokenizer;
+
+class NesTileTokenizerBootstrapper final {
+public:
+    static constexpr int DefaultBootstrapFrames = 16;
+
+    struct Config {
+        int bootstrapFrames = DefaultBootstrapFrames;
+    };
+
+    static Result<std::shared_ptr<NesTileTokenizer>, std::string> build(
+        Scenario::EnumType scenarioId, const std::optional<ScenarioConfig>& scenarioConfigOverride);
+    static Result<std::shared_ptr<NesTileTokenizer>, std::string> build(
+        Scenario::EnumType scenarioId,
+        const std::optional<ScenarioConfig>& scenarioConfigOverride,
+        Config config);
+    static Result<std::shared_ptr<NesTileTokenizer>, std::string> build(
+        Scenario::EnumType scenarioId,
+        const std::optional<ScenarioConfig>& scenarioConfigOverride,
+        const NesGameAdapterRegistry& adapterRegistry);
+    static Result<std::shared_ptr<NesTileTokenizer>, std::string> build(
+        Scenario::EnumType scenarioId,
+        const std::optional<ScenarioConfig>& scenarioConfigOverride,
+        const NesGameAdapterRegistry& adapterRegistry,
+        Config config);
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
+++ b/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
@@ -1,0 +1,57 @@
+#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
+
+#include "core/scenarios/nes/NesTileFrame.h"
+
+namespace DirtSim {
+
+void NesTileVocabularyBuilder::addFrame(const NesTileFrame& frame)
+{
+    tilePatternHashes_.insert(
+        tilePatternHashes_.end(), frame.tilePatternHashes.begin(), frame.tilePatternHashes.end());
+}
+
+void NesTileVocabularyBuilder::addSnapshot(const NesPpuSnapshot& snapshot)
+{
+    addFrame(makeNesTileFrame(snapshot));
+}
+
+Result<NesTileVocabularyBuildResult, std::string> NesTileVocabularyBuilder::buildFrozenTokenizer(
+    NesTileTokenizer& tokenizer) const
+{
+    if (tilePatternHashes_.empty()) {
+        return Result<NesTileVocabularyBuildResult, std::string>::error(
+            "NesTileVocabularyBuilder: Cannot build vocabulary without tile samples");
+    }
+
+    auto buildResult = tokenizer.buildVocabulary(tilePatternHashes_);
+    if (buildResult.isError()) {
+        return Result<NesTileVocabularyBuildResult, std::string>::error(
+            "NesTileVocabularyBuilder: Failed to build vocabulary: " + buildResult.errorValue());
+    }
+
+    tokenizer.freeze();
+    return Result<NesTileVocabularyBuildResult, std::string>::okay(
+        NesTileVocabularyBuildResult{
+            .sampledTileCount = tilePatternHashes_.size(),
+            .uniquePatternCount = buildResult.value(),
+        });
+}
+
+Result<NesTileTokenizer, std::string> NesTileVocabularyBuilder::buildFrozenTokenizer(
+    NesTileTokenizer::TileToken vocabSize) const
+{
+    NesTileTokenizer tokenizer(vocabSize);
+    auto buildResult = buildFrozenTokenizer(tokenizer);
+    if (buildResult.isError()) {
+        return Result<NesTileTokenizer, std::string>::error(buildResult.errorValue());
+    }
+
+    return Result<NesTileTokenizer, std::string>::okay(std::move(tokenizer));
+}
+
+void NesTileVocabularyBuilder::reset()
+{
+    tilePatternHashes_.clear();
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
+++ b/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.cpp
@@ -12,6 +12,9 @@ void NesTileVocabularyBuilder::addFrame(const NesTileFrame& frame)
 
 void NesTileVocabularyBuilder::addSnapshot(const NesPpuSnapshot& snapshot)
 {
+    const auto tileIdPatternHashes = makeNesTileIdPatternHashes(snapshot);
+    tilePatternHashes_.insert(
+        tilePatternHashes_.end(), tileIdPatternHashes.begin(), tileIdPatternHashes.end());
     addFrame(makeNesTileFrame(snapshot));
 }
 

--- a/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.h
+++ b/apps/src/core/scenarios/nes/NesTileVocabularyBuilder.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "core/Result.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace DirtSim {
+
+struct NesPpuSnapshot;
+struct NesTileFrame;
+
+struct NesTileVocabularyBuildResult {
+    size_t sampledTileCount = 0;
+    size_t uniquePatternCount = 0;
+};
+
+class NesTileVocabularyBuilder final {
+public:
+    void addFrame(const NesTileFrame& frame);
+    void addSnapshot(const NesPpuSnapshot& snapshot);
+    Result<NesTileVocabularyBuildResult, std::string> buildFrozenTokenizer(
+        NesTileTokenizer& tokenizer) const;
+    Result<NesTileTokenizer, std::string> buildFrozenTokenizer(
+        NesTileTokenizer::TileToken vocabSize = NesTileTokenizer::DefaultVocabSize) const;
+
+    size_t getSampledTileCount() const { return tilePatternHashes_.size(); }
+    void reset();
+
+private:
+    std::vector<NesTileTokenizer::TilePatternHash> tilePatternHashes_;
+};
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.cpp
@@ -2,6 +2,8 @@
 
 #include "SmolnesRuntimeBackend.h"
 
+#include <algorithm>
+
 namespace DirtSim {
 
 namespace {
@@ -210,6 +212,30 @@ std::optional<SmolnesRuntime::ControllerSnapshot> SmolnesRuntime::copyController
         .controller1SequenceId = raw.controller1_sequence_id,
         .controller1State = raw.controller1_state,
     };
+}
+
+std::optional<NesPpuSnapshot> SmolnesRuntime::copyPpuSnapshot() const
+{
+    if (runtimeHandle_ == nullptr) {
+        return std::nullopt;
+    }
+
+    SmolnesRuntimePpuSnapshot raw{};
+    if (!smolnesRuntimeCopyPpuSnapshot(runtimeHandle_, &raw)) {
+        return std::nullopt;
+    }
+
+    NesPpuSnapshot snapshot;
+    snapshot.frameId = raw.frame_id;
+    snapshot.v = raw.v;
+    snapshot.fineX = raw.fine_x;
+    snapshot.mirror = raw.mirror;
+    snapshot.ppuCtrl = raw.ppuctrl;
+    snapshot.ppuMask = raw.ppumask;
+    std::copy(std::begin(raw.chr), std::end(raw.chr), snapshot.chr.begin());
+    std::copy(std::begin(raw.oam), std::end(raw.oam), snapshot.oam.begin());
+    std::copy(std::begin(raw.vram), std::end(raw.vram), snapshot.vram.begin());
+    return snapshot;
 }
 
 std::optional<SmolnesRuntime::MemorySnapshot> SmolnesRuntime::copyMemorySnapshot() const

--- a/apps/src/core/scenarios/nes/SmolnesRuntime.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntime.h
@@ -2,6 +2,7 @@
 
 #include "core/RenderMessage.h"
 #include "core/scenarios/nes/NesPaletteFrame.h"
+#include "core/scenarios/nes/NesPpuSnapshot.h"
 #include "core/scenarios/nes/SmolnesRuntimeBackend.h"
 
 #include <array>
@@ -113,6 +114,7 @@ public:
     virtual std::optional<NesPaletteFrame> copyLatestPaletteFrame() const;
     virtual std::optional<LiveSnapshot> copyLiveSnapshot() const;
     virtual std::optional<ControllerSnapshot> copyControllerSnapshot() const;
+    virtual std::optional<NesPpuSnapshot> copyPpuSnapshot() const;
     struct ApuSnapshot {
         bool pulse1Enabled = false;
         bool pulse2Enabled = false;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.c
@@ -32,6 +32,7 @@ struct SmolnesRuntimeHandle {
     bool hasLatestFrame;
     bool hasLatestPaletteFrame;
     bool hasMemorySnapshot;
+    bool hasPpuSnapshot;
     bool healthy;
     bool stopRequested;
     bool threadJoinable;
@@ -110,12 +111,20 @@ struct SmolnesRuntimeHandle {
     uint8_t latestFrameController1State;
     uint64_t nextController1SequenceId;
     uint8_t cpuRamSnapshot[SMOLNES_RUNTIME_CPU_RAM_BYTES];
+    uint8_t chrSnapshot[SMOLNES_RUNTIME_PPU_CHR_BYTES];
     uint8_t latestFrame[SMOLNES_RUNTIME_FRAME_BYTES];
     uint8_t latestPaletteFrame[SMOLNES_RUNTIME_PALETTE_FRAME_BYTES];
+    uint8_t oamSnapshot[SMOLNES_RUNTIME_PPU_OAM_BYTES];
     uint8_t prgRamSnapshot[SMOLNES_RUNTIME_PRG_RAM_BYTES];
+    uint8_t vramSnapshot[SMOLNES_RUNTIME_PPU_VRAM_BYTES];
     uint8_t rendererStub;
     uint8_t textureStub;
     uint8_t windowStub;
+    uint16_t ppuVSnapshot;
+    uint8_t ppuFineXSnapshot;
+    uint8_t ppuMirrorSnapshot;
+    uint8_t ppuCtrlSnapshot;
+    uint8_t ppuMaskSnapshot;
 
     SmolnesApuSnapshot apuSnapshot;
     bool hasApuSnapshot;
@@ -385,8 +394,7 @@ static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
     runtime->runtimeThreadPpuVisibleBgOnlyScalarPixels += gPpuVisibleBgOnlyScalarPixels;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedPixels += gPpuVisibleBgOnlyBatchedPixels;
     runtime->runtimeThreadPpuVisibleBgOnlyBatchedCalls += gPpuVisibleBgOnlyBatchedCalls;
-    runtime->runtimeThreadDeferredPpuFlushPpuRegisterCalls +=
-        gDeferredPpuFlushPpuRegisterCalls;
+    runtime->runtimeThreadDeferredPpuFlushPpuRegisterCalls += gDeferredPpuFlushPpuRegisterCalls;
     runtime->runtimeThreadDeferredPpuFlushPpuRegisterDots += gDeferredPpuFlushPpuRegisterDots;
     for (size_t registerIndex = 0; registerIndex < 8; ++registerIndex) {
         runtime->runtimeThreadDeferredPpuFlushPpuRegisterReadCalls[registerIndex] +=
@@ -404,8 +412,7 @@ static void flushPerInstructionAccumulatorsLocked(SmolnesRuntimeHandle* runtime)
     runtime->runtimeThreadDeferredPpuFlushMapperWriteDots += gDeferredPpuFlushMapperWriteDots;
     runtime->runtimeThreadDeferredPpuFlushDot256BoundaryCalls +=
         gDeferredPpuFlushDot256BoundaryCalls;
-    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryDots +=
-        gDeferredPpuFlushDot256BoundaryDots;
+    runtime->runtimeThreadDeferredPpuFlushDot256BoundaryDots += gDeferredPpuFlushDot256BoundaryDots;
     runtime->runtimeThreadPpuSpriteEvalMs += gPpuSpriteEvalAccumMs;
     runtime->runtimeThreadPpuSpriteEvalCalls += gPpuSpriteEvalAccumCalls;
     runtime->runtimeThreadPpuPostVisibleMs += gPpuPostVisibleAccumMs;
@@ -740,7 +747,8 @@ void smolnesRuntimeWrappedFrameExecutionBegin(void)
         runtime->latchedController1State = runtime->pendingController1State;
         runtime->latchedController1ObservedTimestampNs =
             runtime->pendingController1ObservedTimestampNs;
-        runtime->latchedController1RequestTimestampNs = runtime->pendingController1RequestTimestampNs;
+        runtime->latchedController1RequestTimestampNs =
+            runtime->pendingController1RequestTimestampNs;
         runtime->latchedController1SequenceId = runtime->pendingController1SequenceId;
         runtime->latchedController1AppliedFrameId =
             (runtime->latchedController1SequenceId == 0) ? 0 : (runtime->renderedFrames + 1);
@@ -923,10 +931,7 @@ void smolnesRuntimeWrappedPpuPhaseClear(void)
 }
 
 void smolnesRuntimeWrappedPpuVisibleBgOnlyStats(
-    uint16_t spanPixels,
-    uint16_t scalarPixels,
-    uint16_t batchedPixels,
-    uint16_t batchedCalls)
+    uint16_t spanPixels, uint16_t scalarPixels, uint16_t batchedPixels, uint16_t batchedCalls)
 {
     if (!gDetailedTimingEnabled) {
         return;
@@ -1170,9 +1175,9 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
 #define SMOLNES_DEFERRED_PPU_SAMPLE smolnesRuntimeWrappedDeferredPpuSample
 #define SMOLNES_DEFERRED_PPU_STEP_BEGIN smolnesRuntimeWrappedDeferredPpuStepBegin
 #define SMOLNES_DEFERRED_PPU_STEP_END smolnesRuntimeWrappedDeferredPpuStepEnd
-#define SMOLNES_DEFERRED_PPU_FLUSH_REASON(reason, dots)                                       \
+#define SMOLNES_DEFERRED_PPU_FLUSH_REASON(reason, dots) \
     smolnesRuntimeWrappedDeferredPpuFlushReason((reason), (dots))
-#define SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS(reg, is_write, dots)                   \
+#define SMOLNES_DEFERRED_PPU_FLUSH_PPU_REGISTER_ACCESS(reg, is_write, dots) \
     smolnesRuntimeWrappedDeferredPpuFlushPpuRegisterAccess((reg), (is_write), (dots))
 #define SMOLNES_DEFERRED_PPU_FLUSH_REASON_PPU_REGISTER_ACCESS 1u
 #define SMOLNES_DEFERRED_PPU_FLUSH_REASON_OAM_DMA 2u
@@ -1180,14 +1185,14 @@ int smolnesRuntimeWrappedPollEvent(SDL_Event* event)
 #define SMOLNES_DEFERRED_PPU_FLUSH_REASON_DOT_256_BOUNDARY 4u
 #define SMOLNES_PPU_PHASE_SET smolnesRuntimeWrappedPpuPhaseSet
 #define SMOLNES_PPU_PHASE_CLEAR smolnesRuntimeWrappedPpuPhaseClear
-#define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)                                              \
-    do {                                                                                     \
-        if (gPpuStepActive) {                                                                \
-            smolnesRuntimeWrappedPpuPhaseSet(phase);                                         \
-        }                                                                                    \
+#define SMOLNES_PPU_PHASE_SET_IF_ACTIVE(phase)       \
+    do {                                             \
+        if (gPpuStepActive) {                        \
+            smolnesRuntimeWrappedPpuPhaseSet(phase); \
+        }                                            \
     } while (0)
 #define SMOLNES_PPU_VISIBLE_BG_ONLY_STATS(span_pixels, scalar_pixels, batched_pixels, batch_count) \
-    smolnesRuntimeWrappedPpuVisibleBgOnlyStats(                                                  \
+    smolnesRuntimeWrappedPpuVisibleBgOnlyStats(                                                    \
         (span_pixels), (scalar_pixels), (batched_pixels), (batch_count))
 #define SMOLNES_FRAME_SUBMIT_BEGIN smolnesRuntimeWrappedFrameSubmitBegin
 #define SMOLNES_FRAME_SUBMIT_END smolnesRuntimeWrappedFrameSubmitEnd
@@ -1211,15 +1216,15 @@ static void smolnesRuntimeWrappedApuClock(uint32_t cycles)
     smolnesApuClock(&gApuState, cycles);
 }
 
-#define SMOLNES_PIXEL_OUTPUT(offset, color, palette) \
-    do { \
-        if (gPixelOutputEnabled) { \
+#define SMOLNES_PIXEL_OUTPUT(offset, color, palette)                      \
+    do {                                                                  \
+        if (gPixelOutputEnabled) {                                        \
             uint8_t pi_ = palette_ram[(color) ? (palette) | (color) : 0]; \
-            frame_buffer_palette[offset] = pi_; \
-            if (gRgbaOutputEnabled) { \
-                frame_buffer[offset] = nes_palette_rgb565[pi_]; \
-            } \
-        } \
+            frame_buffer_palette[offset] = pi_;                           \
+            if (gRgbaOutputEnabled) {                                     \
+                frame_buffer[offset] = nes_palette_rgb565[pi_];           \
+            }                                                             \
+        }                                                                 \
     } while (0)
 #define SMOLNES_APU_CLOCK_BEGIN smolnesRuntimeWrappedApuClockBegin
 #define SMOLNES_APU_CLOCK_END smolnesRuntimeWrappedApuClockEnd
@@ -1274,6 +1279,17 @@ static void refreshMemorySnapshotLocked(SmolnesRuntimeHandle* runtime)
     const double snapshotStartMs = monotonicNowMs();
     memcpy(runtime->cpuRamSnapshot, ram, SMOLNES_RUNTIME_CPU_RAM_BYTES);
     memcpy(runtime->prgRamSnapshot, prgram, SMOLNES_RUNTIME_PRG_RAM_BYTES);
+    memcpy(runtime->oamSnapshot, oam, SMOLNES_RUNTIME_PPU_OAM_BYTES);
+    memcpy(runtime->vramSnapshot, vram, SMOLNES_RUNTIME_PPU_VRAM_BYTES);
+    runtime->ppuVSnapshot = V;
+    runtime->ppuFineXSnapshot = fine_x;
+    runtime->ppuMirrorSnapshot = mirror;
+    runtime->ppuCtrlSnapshot = ppuctrl;
+    runtime->ppuMaskSnapshot = ppumask;
+    for (uint16_t addr = 0; addr < SMOLNES_RUNTIME_PPU_CHR_BYTES; ++addr) {
+        runtime->chrSnapshot[addr] = *get_chr_byte(addr);
+    }
+    runtime->hasPpuSnapshot = true;
 
     // Copy APU snapshot and samples.
     smolnesApuGetSnapshot(&gApuState, &runtime->apuSnapshot);
@@ -1367,6 +1383,7 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     runtime->hasLatestFrame = false;
     runtime->hasLatestPaletteFrame = false;
     runtime->hasMemorySnapshot = false;
+    runtime->hasPpuSnapshot = false;
     runtime->runFramesWaitMs = 0.0;
     runtime->runFramesWaitCalls = 0;
     runtime->runtimeThreadIdleWaitMs = 0.0;
@@ -1431,8 +1448,16 @@ bool smolnesRuntimeStart(SmolnesRuntimeHandle* runtime, const char* romPath)
     memset(runtime->latestFrame, 0, sizeof(runtime->latestFrame));
     memset(runtime->latestPaletteFrame, 0, sizeof(runtime->latestPaletteFrame));
     memset(runtime->cpuRamSnapshot, 0, sizeof(runtime->cpuRamSnapshot));
+    memset(runtime->chrSnapshot, 0, sizeof(runtime->chrSnapshot));
+    memset(runtime->oamSnapshot, 0, sizeof(runtime->oamSnapshot));
     memset(runtime->prgRamSnapshot, 0, sizeof(runtime->prgRamSnapshot));
+    memset(runtime->vramSnapshot, 0, sizeof(runtime->vramSnapshot));
     memset(&runtime->apuSnapshot, 0, sizeof(runtime->apuSnapshot));
+    runtime->ppuVSnapshot = 0;
+    runtime->ppuFineXSnapshot = 0;
+    runtime->ppuMirrorSnapshot = 0;
+    runtime->ppuCtrlSnapshot = 0;
+    runtime->ppuMaskSnapshot = 0;
     runtime->hasApuSnapshot = false;
     memset(runtime->apuSampleBuffer, 0, sizeof(runtime->apuSampleBuffer));
     runtime->apuSampleBufferCount = 0;
@@ -1716,6 +1741,34 @@ bool smolnesRuntimeCopyMemorySnapshot(
     return true;
 }
 
+bool smolnesRuntimeCopyPpuSnapshot(
+    const SmolnesRuntimeHandle* runtime, SmolnesRuntimePpuSnapshot* snapshotOut)
+{
+    if (runtime == NULL || snapshotOut == NULL) {
+        return false;
+    }
+
+    SmolnesRuntimeHandle* mutableRuntime = (SmolnesRuntimeHandle*)runtime;
+    pthread_mutex_lock(&mutableRuntime->runtimeMutex);
+    if (!mutableRuntime->threadRunning || !mutableRuntime->healthy
+        || !mutableRuntime->hasPpuSnapshot) {
+        pthread_mutex_unlock(&mutableRuntime->runtimeMutex);
+        return false;
+    }
+
+    snapshotOut->frame_id = mutableRuntime->latestFrameId;
+    snapshotOut->v = mutableRuntime->ppuVSnapshot;
+    snapshotOut->fine_x = mutableRuntime->ppuFineXSnapshot;
+    snapshotOut->mirror = mutableRuntime->ppuMirrorSnapshot;
+    snapshotOut->ppuctrl = mutableRuntime->ppuCtrlSnapshot;
+    snapshotOut->ppumask = mutableRuntime->ppuMaskSnapshot;
+    memcpy(snapshotOut->chr, mutableRuntime->chrSnapshot, SMOLNES_RUNTIME_PPU_CHR_BYTES);
+    memcpy(snapshotOut->oam, mutableRuntime->oamSnapshot, SMOLNES_RUNTIME_PPU_OAM_BYTES);
+    memcpy(snapshotOut->vram, mutableRuntime->vramSnapshot, SMOLNES_RUNTIME_PPU_VRAM_BYTES);
+    pthread_mutex_unlock(&mutableRuntime->runtimeMutex);
+    return true;
+}
+
 bool smolnesRuntimeCopyPrgRam(
     const SmolnesRuntimeHandle* runtime, uint8_t* buffer, uint32_t bufferSize)
 {
@@ -1883,8 +1936,9 @@ bool smolnesRuntimeCopyLiveSnapshot(
 
     SmolnesRuntimeHandle* mutableRuntime = (SmolnesRuntimeHandle*)runtime;
     pthread_mutex_lock(&mutableRuntime->runtimeMutex);
-    if (!mutableRuntime->threadRunning || !mutableRuntime->healthy || !mutableRuntime->hasLatestFrame
-        || !mutableRuntime->hasLatestPaletteFrame || !mutableRuntime->hasMemorySnapshot) {
+    if (!mutableRuntime->threadRunning || !mutableRuntime->healthy
+        || !mutableRuntime->hasLatestFrame || !mutableRuntime->hasLatestPaletteFrame
+        || !mutableRuntime->hasMemorySnapshot) {
         pthread_mutex_unlock(&mutableRuntime->runtimeMutex);
         return false;
     }
@@ -1905,7 +1959,8 @@ bool smolnesRuntimeCopyLiveSnapshot(
         mutableRuntime->latestFrameController1LatchTimestampNs;
     controllerSnapshotOut->controller1_request_timestamp_ns =
         mutableRuntime->latestFrameController1RequestTimestampNs;
-    controllerSnapshotOut->controller1_sequence_id = mutableRuntime->latestFrameController1SequenceId;
+    controllerSnapshotOut->controller1_sequence_id =
+        mutableRuntime->latestFrameController1SequenceId;
     controllerSnapshotOut->controller1_state = mutableRuntime->latestFrameController1State;
     pthread_mutex_unlock(&mutableRuntime->runtimeMutex);
     return true;

--- a/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
+++ b/apps/src/core/scenarios/nes/SmolnesRuntimeBackend.h
@@ -85,7 +85,22 @@ typedef enum SmolnesRuntimePacingModeValue {
 #define SMOLNES_RUNTIME_PALETTE_FRAME_BYTES \
     (SMOLNES_RUNTIME_FRAME_WIDTH * SMOLNES_RUNTIME_FRAME_HEIGHT)
 #define SMOLNES_RUNTIME_CPU_RAM_BYTES 8192u
+#define SMOLNES_RUNTIME_PPU_CHR_BYTES 8192u
+#define SMOLNES_RUNTIME_PPU_OAM_BYTES 256u
+#define SMOLNES_RUNTIME_PPU_VRAM_BYTES 2048u
 #define SMOLNES_RUNTIME_PRG_RAM_BYTES 8192u
+
+typedef struct SmolnesRuntimePpuSnapshot {
+    uint64_t frame_id;
+    uint16_t v;
+    uint8_t fine_x;
+    uint8_t mirror;
+    uint8_t ppuctrl;
+    uint8_t ppumask;
+    uint8_t chr[SMOLNES_RUNTIME_PPU_CHR_BYTES];
+    uint8_t oam[SMOLNES_RUNTIME_PPU_OAM_BYTES];
+    uint8_t vram[SMOLNES_RUNTIME_PPU_VRAM_BYTES];
+} SmolnesRuntimePpuSnapshot;
 
 #define SMOLNES_RUNTIME_BUTTON_A (1u << 0)
 #define SMOLNES_RUNTIME_BUTTON_B (1u << 1)
@@ -123,6 +138,8 @@ bool smolnesRuntimeCopyMemorySnapshot(
     uint64_t* frameId);
 bool smolnesRuntimeCopyCpuRam(
     const SmolnesRuntimeHandle* runtime, uint8_t* buffer, uint32_t bufferSize);
+bool smolnesRuntimeCopyPpuSnapshot(
+    const SmolnesRuntimeHandle* runtime, SmolnesRuntimePpuSnapshot* snapshotOut);
 bool smolnesRuntimeCopyPrgRam(
     const SmolnesRuntimeHandle* runtime, uint8_t* buffer, uint32_t bufferSize);
 bool smolnesRuntimeCopyProfilingSnapshot(

--- a/apps/src/core/scenarios/tests/NesGameAdapterRegistry_test.cpp
+++ b/apps/src/core/scenarios/tests/NesGameAdapterRegistry_test.cpp
@@ -36,6 +36,15 @@ public:
         return sensory;
     }
 
+    NesTileSensoryBuilderInput makeNesTileSensoryBuilderInput(
+        const NesGameAdapterSensoryInput& input) const override
+    {
+        return NesTileSensoryBuilderInput{
+            .controllerMask = input.controllerMask,
+            .deltaTimeSeconds = input.deltaTimeSeconds,
+        };
+    }
+
 private:
     int* resolveCalls_ = nullptr;
 };

--- a/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
+++ b/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
@@ -3,6 +3,7 @@
 #include "core/organisms/evolution/NesPolicyLayout.h"
 #include "core/scenarios/nes/NesFlappyBirdEvaluator.h"
 #include "core/scenarios/nes/NesFlappyParatroopaRamExtractor.h"
+#include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
 #include "core/scenarios/nes/NesTileSensoryBuilder.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
 #include "core/scenarios/nes/SmolnesRuntime.h"
@@ -357,6 +358,67 @@ TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterBuildsTileSensoryInpu
     EXPECT_FLOAT_EQ(sensory.previousControlX, 1.0f);
     EXPECT_TRUE(sensory.previousA);
     EXPECT_FALSE(sensory.previousB);
+}
+
+TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosTilePositionWrapsAbsoluteXAgainstTileScroll)
+{
+    NesSuperMarioBrosState state;
+    state.playerYScreen = 120u;
+
+    state.absoluteX = 0x0180u;
+    EXPECT_EQ(makeNesSuperMarioBrosPlayerTileScreenX(state, 0x0100u), 128);
+
+    state.absoluteX = 0x0208u;
+    EXPECT_EQ(makeNesSuperMarioBrosPlayerTileScreenX(state, 0x0188u), 128);
+
+    state.absoluteX = 0x0108u;
+    EXPECT_EQ(makeNesSuperMarioBrosPlayerTileScreenX(state, 0x0188u), -128);
+
+    EXPECT_EQ(
+        makeNesSuperMarioBrosPlayerTileScreenY(state),
+        120 - static_cast<int16_t>(NesTileFrame::TopCropPixels));
+}
+
+TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterBuildsTilePositionFromTileScroll)
+{
+    std::unique_ptr<NesGameAdapter> adapter = createNesSuperMarioBrosGameAdapter();
+    ASSERT_NE(adapter, nullptr);
+    adapter->reset("smb");
+
+    SmolnesRuntime::MemorySnapshot snapshot = makeSmbSnapshot(
+        1,
+        2,
+        0x02,
+        0x20,
+        25,
+        static_cast<uint8_t>(static_cast<int8_t>(-40)),
+        120,
+        2,
+        0x08,
+        0x01,
+        3,
+        1);
+
+    const NesGameAdapterFrameInput frameInput{
+        .advancedFrames = 400,
+        .controllerMask = 0,
+        .paletteFrame = nullptr,
+        .memorySnapshot = snapshot,
+    };
+    (void)adapter->evaluateFrame(frameInput);
+
+    const NesGameAdapterSensoryInput sensoryInput{
+        .controllerMask = 0,
+        .paletteFrame = nullptr,
+        .lastGameState = std::nullopt,
+        .deltaTimeSeconds = 0.016,
+        .tileFrameScrollX = 0x01A0u,
+    };
+    const NesTileSensoryBuilderInput tileInput =
+        adapter->makeNesTileSensoryBuilderInput(sensoryInput);
+
+    EXPECT_EQ(tileInput.playerScreenX, 128);
+    EXPECT_EQ(tileInput.playerScreenY, 120 - static_cast<int16_t>(NesTileFrame::TopCropPixels));
 }
 
 TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesLeftFacingFromRam)

--- a/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
+++ b/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
@@ -3,11 +3,14 @@
 #include "core/organisms/evolution/NesPolicyLayout.h"
 #include "core/scenarios/nes/NesFlappyBirdEvaluator.h"
 #include "core/scenarios/nes/NesFlappyParatroopaRamExtractor.h"
+#include "core/scenarios/nes/NesTileSensoryBuilder.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
 #include "core/scenarios/nes/SmolnesRuntime.h"
 
 #include <algorithm>
 #include <array>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace DirtSim;
 
@@ -116,6 +119,16 @@ void setEnemySlot(
     snapshot.cpuRam[kEnemyXPageAddrs[slot]] = xPage;
     snapshot.cpuRam[kEnemyXScreenAddrs[slot]] = xScreen;
     snapshot.cpuRam[kEnemyYScreenAddrs[slot]] = yScreen;
+}
+
+size_t relativeTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::RelativeTileColumns + column;
+}
+
+size_t screenTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesTileFrame::VisibleTileColumns + column;
 }
 } // namespace
 
@@ -268,6 +281,82 @@ TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesCuratedSpecial
     for (int i = 18; i < DuckSensoryData::SPECIAL_SENSE_COUNT; ++i) {
         EXPECT_EQ(sensory.special_senses[i], 0.0) << "slot " << i << " should be zero";
     }
+}
+
+TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterBuildsTileSensoryInput)
+{
+    std::unique_ptr<NesGameAdapter> adapter = createNesSuperMarioBrosGameAdapter();
+    ASSERT_NE(adapter, nullptr);
+    adapter->reset("smb");
+
+    SmolnesRuntime::MemorySnapshot snapshot = makeSmbSnapshot(
+        1,
+        2,
+        0x03,
+        0x80,
+        25,
+        static_cast<uint8_t>(static_cast<int8_t>(-40)),
+        120,
+        2,
+        0x08,
+        0x01,
+        3,
+        1);
+    snapshot.cpuRam[kSmbFacingDirectionAddr] = 1u;
+    snapshot.cpuRam[kSmbMovementDirectionAddr] = 1u;
+
+    const NesGameAdapterFrameInput frameInput{
+        .advancedFrames = 400,
+        .controllerMask = 0,
+        .paletteFrame = nullptr,
+        .memorySnapshot = snapshot,
+    };
+    (void)adapter->evaluateFrame(frameInput);
+
+    const uint8_t controllerMask = NesPolicyLayout::ButtonRight | NesPolicyLayout::ButtonA;
+    const NesGameAdapterSensoryInput sensoryInput{
+        .controllerMask = controllerMask,
+        .paletteFrame = nullptr,
+        .lastGameState = std::nullopt,
+        .deltaTimeSeconds = 0.016,
+    };
+    const NesTileSensoryBuilderInput tileInput =
+        adapter->makeNesTileSensoryBuilderInput(sensoryInput);
+
+    EXPECT_EQ(tileInput.playerScreenX, 128);
+    EXPECT_EQ(tileInput.playerScreenY, 120 - static_cast<int16_t>(NesTileFrame::TopCropPixels));
+    EXPECT_FLOAT_EQ(tileInput.facingX, 1.0f);
+    EXPECT_NEAR(tileInput.selfViewX, 128.0 / 256.0, 1e-6);
+    EXPECT_NEAR(tileInput.selfViewY, 120.0 / 240.0, 1e-6);
+    EXPECT_EQ(tileInput.controllerMask, controllerMask);
+    EXPECT_NEAR(tileInput.specialSenses[0], (1.0 * 4.0 + 2.0) / 32.0, 1e-6);
+    EXPECT_NEAR(tileInput.specialSenses[17], 1.0, 1e-6);
+    EXPECT_DOUBLE_EQ(tileInput.deltaTimeSeconds, 0.016);
+
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u, 20u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    NesTileFrame tileFrame;
+    tileFrame.tilePatternHashes.fill(20u);
+    tileFrame.tilePatternHashes[screenTileIndex(16u, 14u)] = 10u;
+
+    const auto sensoryResult = makeNesTileSensoryDataFromTileFrame(tileFrame, tokenizer, tileInput);
+
+    ASSERT_TRUE(sensoryResult.isValue()) << sensoryResult.errorValue();
+    const NesTileSensoryData& sensory = sensoryResult.value();
+    EXPECT_EQ(sensory.tileFrame.playerTileColumn, 16);
+    EXPECT_EQ(sensory.tileFrame.playerTileRow, 14);
+    EXPECT_EQ(
+        sensory.tileFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        1u);
+    EXPECT_FLOAT_EQ(sensory.previousControlX, 1.0f);
+    EXPECT_TRUE(sensory.previousA);
+    EXPECT_FALSE(sensory.previousB);
 }
 
 TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesLeftFacingFromRam)

--- a/apps/src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
+++ b/apps/src/core/scenarios/tests/NesPlayerRelativeTileFrame_test.cpp
@@ -1,0 +1,165 @@
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+using namespace DirtSim;
+
+namespace {
+
+size_t relativeTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::RelativeTileColumns + column;
+}
+
+size_t screenTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::ScreenTileColumns + column;
+}
+
+NesTileTokenizer::TileToken tokenAt(uint16_t column, uint16_t row)
+{
+    return static_cast<NesTileTokenizer::TileToken>(
+        row * NesPlayerRelativeTileFrame::ScreenTileColumns + column + 1u);
+}
+
+NesTileTokenFrame makeScreenTokenFrame()
+{
+    NesTileTokenFrame frame{
+        .frameId = 77u,
+        .scrollX = 9u,
+        .scrollY = 18u,
+    };
+
+    for (uint16_t row = 0; row < NesPlayerRelativeTileFrame::ScreenTileRows; ++row) {
+        for (uint16_t column = 0; column < NesPlayerRelativeTileFrame::ScreenTileColumns;
+             ++column) {
+            frame.tokens[screenTileIndex(column, row)] = tokenAt(column, row);
+        }
+    }
+
+    return frame;
+}
+
+size_t nonVoidTokenCount(const NesPlayerRelativeTileFrame& frame)
+{
+    return static_cast<size_t>(
+        std::count_if(frame.tokens.begin(), frame.tokens.end(), [](auto token) {
+            return token != NesTileTokenizer::VoidToken;
+        }));
+}
+
+int16_t pixelForTile(uint16_t tile)
+{
+    return static_cast<int16_t>(tile * NesPlayerRelativeTileFrame::TileSizePixels + 4u);
+}
+
+} // namespace
+
+TEST(NesPlayerRelativeTileFrameTest, DimensionsCoverEveryVisibleTileOffset)
+{
+    EXPECT_EQ(NesPlayerRelativeTileFrame::RelativeTileColumns, 63u);
+    EXPECT_EQ(NesPlayerRelativeTileFrame::RelativeTileRows, 55u);
+    EXPECT_EQ(NesPlayerRelativeTileFrame::AnchorTileColumn, 31u);
+    EXPECT_EQ(NesPlayerRelativeTileFrame::AnchorTileRow, 27u);
+}
+
+TEST(NesPlayerRelativeTileFrameTest, InteriorPlayerMapsScreenAroundAnchorWithoutLoss)
+{
+    const NesTileTokenFrame tokenFrame = makeScreenTokenFrame();
+
+    const NesPlayerRelativeTileFrame relativeFrame =
+        makeNesPlayerRelativeTileFrame(tokenFrame, pixelForTile(16u), pixelForTile(20u));
+
+    EXPECT_EQ(relativeFrame.frameId, 77u);
+    EXPECT_EQ(relativeFrame.scrollX, 9u);
+    EXPECT_EQ(relativeFrame.scrollY, 18u);
+    EXPECT_EQ(relativeFrame.playerTileColumn, 16);
+    EXPECT_EQ(relativeFrame.playerTileRow, 20);
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        tokenAt(16u, 20u));
+    EXPECT_EQ(relativeFrame.tokens[relativeTileIndex(15u, 7u)], tokenAt(0u, 0u));
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(46u, 34u)],
+        tokenAt(
+            NesPlayerRelativeTileFrame::ScreenTileColumns - 1u,
+            NesPlayerRelativeTileFrame::ScreenTileRows - 1u));
+    EXPECT_EQ(
+        nonVoidTokenCount(relativeFrame),
+        static_cast<size_t>(NesPlayerRelativeTileFrame::ScreenTileColumns)
+            * NesPlayerRelativeTileFrame::ScreenTileRows);
+}
+
+TEST(NesPlayerRelativeTileFrameTest, TopLeftPlayerKeepsWholeScreen)
+{
+    const NesTileTokenFrame tokenFrame = makeScreenTokenFrame();
+
+    const NesPlayerRelativeTileFrame relativeFrame =
+        makeNesPlayerRelativeTileFrame(tokenFrame, pixelForTile(0u), pixelForTile(0u));
+
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        tokenAt(0u, 0u));
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::RelativeTileColumns - 1u,
+            NesPlayerRelativeTileFrame::RelativeTileRows - 1u)],
+        tokenAt(
+            NesPlayerRelativeTileFrame::ScreenTileColumns - 1u,
+            NesPlayerRelativeTileFrame::ScreenTileRows - 1u));
+    EXPECT_EQ(
+        nonVoidTokenCount(relativeFrame),
+        static_cast<size_t>(NesPlayerRelativeTileFrame::ScreenTileColumns)
+            * NesPlayerRelativeTileFrame::ScreenTileRows);
+}
+
+TEST(NesPlayerRelativeTileFrameTest, BottomRightPlayerKeepsWholeScreen)
+{
+    const NesTileTokenFrame tokenFrame = makeScreenTokenFrame();
+
+    const NesPlayerRelativeTileFrame relativeFrame = makeNesPlayerRelativeTileFrame(
+        tokenFrame,
+        pixelForTile(NesPlayerRelativeTileFrame::ScreenTileColumns - 1u),
+        pixelForTile(NesPlayerRelativeTileFrame::ScreenTileRows - 1u));
+
+    EXPECT_EQ(relativeFrame.tokens[relativeTileIndex(0u, 0u)], tokenAt(0u, 0u));
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        tokenAt(
+            NesPlayerRelativeTileFrame::ScreenTileColumns - 1u,
+            NesPlayerRelativeTileFrame::ScreenTileRows - 1u));
+    EXPECT_EQ(
+        nonVoidTokenCount(relativeFrame),
+        static_cast<size_t>(NesPlayerRelativeTileFrame::ScreenTileColumns)
+            * NesPlayerRelativeTileFrame::ScreenTileRows);
+}
+
+TEST(NesPlayerRelativeTileFrameTest, NegativePlayerPixelsUseFloorTileCoordinates)
+{
+    const NesTileTokenFrame tokenFrame = makeScreenTokenFrame();
+
+    const NesPlayerRelativeTileFrame relativeFrame =
+        makeNesPlayerRelativeTileFrame(tokenFrame, -1, -1);
+
+    EXPECT_EQ(relativeFrame.playerTileColumn, -1);
+    EXPECT_EQ(relativeFrame.playerTileRow, -1);
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn + 1u,
+            NesPlayerRelativeTileFrame::AnchorTileRow + 1u)],
+        tokenAt(0u, 0u));
+    EXPECT_EQ(
+        relativeFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        NesTileTokenizer::VoidToken);
+}

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
@@ -4,6 +4,8 @@
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include "core/scenarios/nes/NesSuperMarioBrosRamExtractor.h"
 #include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
+#include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
+#include "core/scenarios/nes/NesTileDebugRenderer.h"
 #include "core/scenarios/nes/NesTileFrame.h"
 #include "core/scenarios/nes/NesTileTokenFrame.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
@@ -27,9 +29,14 @@ using namespace DirtSim;
 namespace {
 
 constexpr uint64_t kSetupScriptEndFrame = 300u;
-constexpr uint32_t kPanelGapPixels = 12u;
-constexpr uint16_t kSmbTopCropPixels = 8u;
 constexpr std::array<uint64_t, 5> kProbeFrames = { 300u, 400u, 500u, 700u, 899u };
+
+struct PlayerRelativeProbeSample {
+    uint16_t absoluteX = 0;
+    uint16_t scrollX = 0;
+    uint8_t rawPlayerXScreen = 0;
+    int16_t playerVisibleX = 0;
+};
 
 std::optional<std::filesystem::path> resolveNesSmbFixtureRomPath()
 {
@@ -70,148 +77,6 @@ uint8_t scriptedControllerMaskForFrame(uint64_t frameIndex)
     }
 
     return baselineControllerMaskForGameFrame(frameIndex - kSetupScriptEndFrame);
-}
-
-std::array<uint8_t, 4> rgb565ToRgba8888(uint16_t value)
-{
-    const uint8_t red5 = static_cast<uint8_t>((value >> 11) & 0x1Fu);
-    const uint8_t green6 = static_cast<uint8_t>((value >> 5) & 0x3Fu);
-    const uint8_t blue5 = static_cast<uint8_t>(value & 0x1Fu);
-
-    return {
-        static_cast<uint8_t>((red5 << 3) | (red5 >> 2)),
-        static_cast<uint8_t>((green6 << 2) | (green6 >> 4)),
-        static_cast<uint8_t>((blue5 << 3) | (blue5 >> 2)),
-        255u,
-    };
-}
-
-uint16_t readRgb565Pixel(const ScenarioVideoFrame& frame, size_t pixelIndex)
-{
-    const size_t offset = pixelIndex * 2u;
-    const uint8_t lo = std::to_integer<uint8_t>(frame.pixels[offset]);
-    const uint8_t hi = std::to_integer<uint8_t>(frame.pixels[offset + 1u]);
-    return static_cast<uint16_t>(lo | (static_cast<uint16_t>(hi) << 8u));
-}
-
-void setRgbaPixel(
-    std::vector<uint8_t>& rgba, uint32_t width, uint32_t x, uint32_t y, uint32_t color)
-{
-    const size_t offset = (static_cast<size_t>(y) * width + x) * 4u;
-    rgba[offset + 0u] = static_cast<uint8_t>((color >> 24u) & 0xFFu);
-    rgba[offset + 1u] = static_cast<uint8_t>((color >> 16u) & 0xFFu);
-    rgba[offset + 2u] = static_cast<uint8_t>((color >> 8u) & 0xFFu);
-    rgba[offset + 3u] = static_cast<uint8_t>(color & 0xFFu);
-}
-
-uint32_t tileTokenColor(NesTileTokenizer::TileToken token)
-{
-    if (token == NesTileTokenizer::VoidToken) {
-        return 0x000000FFu;
-    }
-
-    const uint32_t mixed = static_cast<uint32_t>(token) * 2654435761u;
-    const uint8_t red = static_cast<uint8_t>(64u + ((mixed >> 0u) & 0x7Fu));
-    const uint8_t green = static_cast<uint8_t>(64u + ((mixed >> 8u) & 0x7Fu));
-    const uint8_t blue = static_cast<uint8_t>(64u + ((mixed >> 16u) & 0x7Fu));
-    return (static_cast<uint32_t>(red) << 24u) | (static_cast<uint32_t>(green) << 16u)
-        | (static_cast<uint32_t>(blue) << 8u) | 255u;
-}
-
-template <size_t TokenCount>
-void drawTokenPanel(
-    std::vector<uint8_t>& rgba,
-    uint32_t imageWidth,
-    uint32_t panelX,
-    uint16_t tileColumns,
-    uint16_t tileRows,
-    const std::array<NesTileTokenizer::TileToken, TokenCount>& tokens)
-{
-    for (uint32_t gy = 0; gy < tileRows; ++gy) {
-        for (uint32_t gx = 0; gx < tileColumns; ++gx) {
-            const size_t cellIndex = static_cast<size_t>(gy) * tileColumns + gx;
-            const uint32_t color = tileTokenColor(tokens[cellIndex]);
-            for (uint32_t py = 0; py < NesPlayerRelativeTileFrame::TileSizePixels; ++py) {
-                for (uint32_t px = 0; px < NesPlayerRelativeTileFrame::TileSizePixels; ++px) {
-                    setRgbaPixel(
-                        rgba,
-                        imageWidth,
-                        panelX + gx * NesPlayerRelativeTileFrame::TileSizePixels + px,
-                        gy * NesPlayerRelativeTileFrame::TileSizePixels + py,
-                        color);
-                }
-            }
-        }
-    }
-}
-
-std::vector<uint8_t> makeComparisonImage(
-    const ScenarioVideoFrame& videoFrame,
-    const NesTileFrame& tileFrame,
-    const NesTileTokenFrame& tokenFrame,
-    const NesPlayerRelativeTileFrame& relativeFrame)
-{
-    const uint32_t panelWidth = NesTileFrame::VisibleWidthPixels;
-    const uint32_t panelHeight = NesTileFrame::VisibleHeightPixels;
-    const uint32_t relativePanelWidth = NesPlayerRelativeTileFrame::RelativeTileColumns
-        * NesPlayerRelativeTileFrame::TileSizePixels;
-    const uint32_t relativePanelHeight =
-        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels;
-    const uint32_t width = panelWidth * 3u + relativePanelWidth + kPanelGapPixels * 3u;
-    const uint32_t height = std::max(panelHeight, relativePanelHeight);
-    std::vector<uint8_t> rgba(static_cast<size_t>(width) * height * 4u, 18u);
-
-    for (uint32_t y = 0; y < height; ++y) {
-        for (uint32_t x = 0; x < width; ++x) {
-            setRgbaPixel(rgba, width, x, y, 0x121212FFu);
-        }
-    }
-
-    const uint32_t patternPanelX = panelWidth + kPanelGapPixels;
-    const uint32_t tokenPanelX = patternPanelX + panelWidth + kPanelGapPixels;
-    const uint32_t relativePanelX = tokenPanelX + panelWidth + kPanelGapPixels;
-
-    for (uint32_t y = 0; y < panelHeight; ++y) {
-        const size_t rowBase = static_cast<size_t>(y) * panelWidth;
-        for (uint32_t x = 0; x < panelWidth; ++x) {
-            const size_t pixelIndex = rowBase + x;
-            const auto actual = rgb565ToRgba8888(readRgb565Pixel(videoFrame, pixelIndex));
-            setRgbaPixel(
-                rgba,
-                width,
-                x,
-                y,
-                (static_cast<uint32_t>(actual[0]) << 24u)
-                    | (static_cast<uint32_t>(actual[1]) << 16u)
-                    | (static_cast<uint32_t>(actual[2]) << 8u) | 255u);
-
-            const uint8_t shade = static_cast<uint8_t>(tileFrame.patternPixels[pixelIndex] * 85u);
-            setRgbaPixel(
-                rgba,
-                width,
-                patternPanelX + x,
-                y,
-                (static_cast<uint32_t>(shade) << 24u) | (static_cast<uint32_t>(shade) << 16u)
-                    | (static_cast<uint32_t>(shade) << 8u) | 255u);
-        }
-    }
-
-    drawTokenPanel(
-        rgba,
-        width,
-        tokenPanelX,
-        NesTileTokenFrame::VisibleTileColumns,
-        NesTileTokenFrame::VisibleTileRows,
-        tokenFrame.tokens);
-    drawTokenPanel(
-        rgba,
-        width,
-        relativePanelX,
-        NesPlayerRelativeTileFrame::RelativeTileColumns,
-        NesPlayerRelativeTileFrame::RelativeTileRows,
-        relativeFrame.tokens);
-
-    return rgba;
 }
 
 void pngWriteCallback(void* context, void* data, int size)
@@ -258,6 +123,70 @@ std::filesystem::path comparisonPathForFrame(uint64_t frameIndex)
 
 } // namespace
 
+TEST(NesSuperMarioBrosTileProbeTest, PlayerRelativeXStaysStableAcrossCenteredProbeFrames)
+{
+    const auto romPath = resolveNesSmbFixtureRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "Missing SMB ROM. Set DIRTSIM_NES_SMB_TEST_ROM_PATH or place "
+                        "testdata/roms/smb.nes.";
+    }
+
+    NesSmolnesScenarioDriver driver(Scenario::EnumType::NesSuperMarioBros);
+    Config::NesSuperMarioBros config = std::get<Config::NesSuperMarioBros>(
+        makeDefaultConfig(Scenario::EnumType::NesSuperMarioBros));
+    config.romId = "";
+    config.romPath = romPath->string();
+    config.requireSmolnesMapper = true;
+
+    ASSERT_FALSE(driver.setConfig(ScenarioConfig{ config }).isError());
+    ASSERT_FALSE(driver.setup().isError()) << driver.getRuntimeLastError();
+
+    NesSuperMarioBrosRamExtractor extractor;
+    Timers timers;
+    std::optional<PlayerRelativeProbeSample> frame400Sample;
+    std::optional<PlayerRelativeProbeSample> frame500Sample;
+    for (uint64_t frameIndex = 0; frameIndex <= 500u; ++frameIndex) {
+        const auto stepResult = driver.step(timers, scriptedControllerMaskForFrame(frameIndex));
+        if (frameIndex != 400u && frameIndex != 500u) {
+            continue;
+        }
+
+        const auto ppuSnapshot = driver.copyRuntimePpuSnapshot();
+        ASSERT_TRUE(ppuSnapshot.has_value()) << "Missing PPU snapshot at " << frameIndex;
+        ASSERT_TRUE(stepResult.memorySnapshot.has_value())
+            << "Missing memory snapshot at " << frameIndex;
+        const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
+        const NesSuperMarioBrosState smbState = extractor.extract(
+            stepResult.memorySnapshot.value(), frameIndex >= kSetupScriptEndFrame);
+        const PlayerRelativeProbeSample sample{
+            .absoluteX = smbState.absoluteX,
+            .scrollX = tileFrame.scrollX,
+            .rawPlayerXScreen = smbState.playerXScreen,
+            .playerVisibleX = makeNesSuperMarioBrosPlayerTileScreenX(smbState, tileFrame.scrollX),
+        };
+        if (frameIndex == 400u) {
+            frame400Sample = sample;
+        }
+        else {
+            frame500Sample = sample;
+        }
+    }
+
+    ASSERT_TRUE(frame400Sample.has_value());
+    ASSERT_TRUE(frame500Sample.has_value());
+    EXPECT_LE(
+        std::abs(
+            static_cast<int>(frame400Sample->playerVisibleX)
+            - static_cast<int>(frame500Sample->playerVisibleX)),
+        16)
+        << "frame 400 visibleX=" << frame400Sample->playerVisibleX
+        << " rawX=" << static_cast<int>(frame400Sample->rawPlayerXScreen)
+        << " absoluteX=" << frame400Sample->absoluteX << " scrollX=" << frame400Sample->scrollX
+        << "; frame 500 visibleX=" << frame500Sample->playerVisibleX
+        << " rawX=" << static_cast<int>(frame500Sample->rawPlayerXScreen)
+        << " absoluteX=" << frame500Sample->absoluteX << " scrollX=" << frame500Sample->scrollX;
+}
+
 TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
 {
     const auto romPath = resolveNesSmbFixtureRomPath();
@@ -296,25 +225,25 @@ TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
         ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
         const NesSuperMarioBrosState smbState = extractor.extract(
             stepResult.memorySnapshot.value(), frameIndex >= kSetupScriptEndFrame);
-        const int16_t playerVisibleX = static_cast<int16_t>(smbState.playerXScreen);
-        const int16_t playerVisibleY =
-            static_cast<int16_t>(smbState.playerYScreen) - static_cast<int16_t>(kSmbTopCropPixels);
+        const int16_t playerVisibleX =
+            makeNesSuperMarioBrosPlayerTileScreenX(smbState, tileFrame.scrollX);
+        const int16_t playerVisibleY = makeNesSuperMarioBrosPlayerTileScreenY(smbState);
         const NesPlayerRelativeTileFrame relativeFrame = makeNesPlayerRelativeTileFrame(
             tokenFrameResult.value(), playerVisibleX, playerVisibleY);
-        const std::vector<uint8_t> rgba = makeComparisonImage(
-            stepResult.scenarioVideoFrame.value(),
-            tileFrame,
-            tokenFrameResult.value(),
-            relativeFrame);
+        const auto imageResult = makeNesTileDebugRenderImage(
+            NesTileDebugView::Comparison,
+            NesTileDebugRenderInput{
+                .videoFrame = &stepResult.scenarioVideoFrame.value(),
+                .tileFrame = &tileFrame,
+                .tokenFrame = &tokenFrameResult.value(),
+                .relativeFrame = &relativeFrame,
+            });
+        ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
         const std::filesystem::path outputPath = comparisonPathForFrame(frameIndex);
         ASSERT_TRUE(writePng(
-            rgba,
-            NesTileFrame::VisibleWidthPixels * 3u
-                + NesPlayerRelativeTileFrame::RelativeTileColumns
-                    * NesPlayerRelativeTileFrame::TileSizePixels
-                + kPanelGapPixels * 3u,
-            NesPlayerRelativeTileFrame::RelativeTileRows
-                * NesPlayerRelativeTileFrame::TileSizePixels,
+            imageResult.value().rgba,
+            imageResult.value().width,
+            imageResult.value().height,
             outputPath))
             << "Failed to write " << outputPath;
         std::cout << "Wrote SMB tile probe: " << outputPath.string() << "\n";

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
@@ -1,6 +1,8 @@
 #include "core/ScenarioConfig.h"
 #include "core/Timers.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesSuperMarioBrosRamExtractor.h"
 #include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
 #include "core/scenarios/nes/NesTileFrame.h"
 #include "core/scenarios/nes/NesTileTokenFrame.h"
@@ -26,6 +28,7 @@ namespace {
 
 constexpr uint64_t kSetupScriptEndFrame = 300u;
 constexpr uint32_t kPanelGapPixels = 12u;
+constexpr uint16_t kSmbTopCropPixels = 8u;
 constexpr std::array<uint64_t, 5> kProbeFrames = { 300u, 400u, 500u, 700u, 899u };
 
 std::optional<std::filesystem::path> resolveNesSmbFixtureRomPath()
@@ -115,15 +118,47 @@ uint32_t tileTokenColor(NesTileTokenizer::TileToken token)
         | (static_cast<uint32_t>(blue) << 8u) | 255u;
 }
 
+template <size_t TokenCount>
+void drawTokenPanel(
+    std::vector<uint8_t>& rgba,
+    uint32_t imageWidth,
+    uint32_t panelX,
+    uint16_t tileColumns,
+    uint16_t tileRows,
+    const std::array<NesTileTokenizer::TileToken, TokenCount>& tokens)
+{
+    for (uint32_t gy = 0; gy < tileRows; ++gy) {
+        for (uint32_t gx = 0; gx < tileColumns; ++gx) {
+            const size_t cellIndex = static_cast<size_t>(gy) * tileColumns + gx;
+            const uint32_t color = tileTokenColor(tokens[cellIndex]);
+            for (uint32_t py = 0; py < NesPlayerRelativeTileFrame::TileSizePixels; ++py) {
+                for (uint32_t px = 0; px < NesPlayerRelativeTileFrame::TileSizePixels; ++px) {
+                    setRgbaPixel(
+                        rgba,
+                        imageWidth,
+                        panelX + gx * NesPlayerRelativeTileFrame::TileSizePixels + px,
+                        gy * NesPlayerRelativeTileFrame::TileSizePixels + py,
+                        color);
+                }
+            }
+        }
+    }
+}
+
 std::vector<uint8_t> makeComparisonImage(
     const ScenarioVideoFrame& videoFrame,
     const NesTileFrame& tileFrame,
-    const NesTileTokenFrame& tokenFrame)
+    const NesTileTokenFrame& tokenFrame,
+    const NesPlayerRelativeTileFrame& relativeFrame)
 {
     const uint32_t panelWidth = NesTileFrame::VisibleWidthPixels;
     const uint32_t panelHeight = NesTileFrame::VisibleHeightPixels;
-    const uint32_t width = panelWidth * 3u + kPanelGapPixels * 2u;
-    const uint32_t height = panelHeight;
+    const uint32_t relativePanelWidth = NesPlayerRelativeTileFrame::RelativeTileColumns
+        * NesPlayerRelativeTileFrame::TileSizePixels;
+    const uint32_t relativePanelHeight =
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels;
+    const uint32_t width = panelWidth * 3u + relativePanelWidth + kPanelGapPixels * 3u;
+    const uint32_t height = std::max(panelHeight, relativePanelHeight);
     std::vector<uint8_t> rgba(static_cast<size_t>(width) * height * 4u, 18u);
 
     for (uint32_t y = 0; y < height; ++y) {
@@ -134,6 +169,7 @@ std::vector<uint8_t> makeComparisonImage(
 
     const uint32_t patternPanelX = panelWidth + kPanelGapPixels;
     const uint32_t tokenPanelX = patternPanelX + panelWidth + kPanelGapPixels;
+    const uint32_t relativePanelX = tokenPanelX + panelWidth + kPanelGapPixels;
 
     for (uint32_t y = 0; y < panelHeight; ++y) {
         const size_t rowBase = static_cast<size_t>(y) * panelWidth;
@@ -160,18 +196,20 @@ std::vector<uint8_t> makeComparisonImage(
         }
     }
 
-    for (uint32_t gy = 0; gy < NesTileFrame::VisibleTileRows; ++gy) {
-        for (uint32_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
-            const size_t cellIndex =
-                static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
-            const uint32_t color = tileTokenColor(tokenFrame.tokens[cellIndex]);
-            for (uint32_t py = 0; py < 8u; ++py) {
-                for (uint32_t px = 0; px < 8u; ++px) {
-                    setRgbaPixel(rgba, width, tokenPanelX + gx * 8u + px, gy * 8u + py, color);
-                }
-            }
-        }
-    }
+    drawTokenPanel(
+        rgba,
+        width,
+        tokenPanelX,
+        NesTileTokenFrame::VisibleTileColumns,
+        NesTileTokenFrame::VisibleTileRows,
+        tokenFrame.tokens);
+    drawTokenPanel(
+        rgba,
+        width,
+        relativePanelX,
+        NesPlayerRelativeTileFrame::RelativeTileColumns,
+        NesPlayerRelativeTileFrame::RelativeTileRows,
+        relativeFrame.tokens);
 
     return rgba;
 }
@@ -236,6 +274,7 @@ TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
     ASSERT_FALSE(driver.setConfig(ScenarioConfig{ config }).isError());
     ASSERT_FALSE(driver.setup().isError()) << driver.getRuntimeLastError();
 
+    NesSuperMarioBrosRamExtractor extractor;
     NesTileTokenizer tokenizer;
     Timers timers;
     const uint64_t finalFrame = kProbeFrames.back();
@@ -250,16 +289,32 @@ TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
 
         const auto ppuSnapshot = driver.copyRuntimePpuSnapshot();
         ASSERT_TRUE(ppuSnapshot.has_value()) << "Missing PPU snapshot at " << frameIndex;
+        ASSERT_TRUE(stepResult.memorySnapshot.has_value())
+            << "Missing memory snapshot at " << frameIndex;
         const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
         const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
         ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
+        const NesSuperMarioBrosState smbState = extractor.extract(
+            stepResult.memorySnapshot.value(), frameIndex >= kSetupScriptEndFrame);
+        const int16_t playerVisibleX = static_cast<int16_t>(smbState.playerXScreen);
+        const int16_t playerVisibleY =
+            static_cast<int16_t>(smbState.playerYScreen) - static_cast<int16_t>(kSmbTopCropPixels);
+        const NesPlayerRelativeTileFrame relativeFrame = makeNesPlayerRelativeTileFrame(
+            tokenFrameResult.value(), playerVisibleX, playerVisibleY);
         const std::vector<uint8_t> rgba = makeComparisonImage(
-            stepResult.scenarioVideoFrame.value(), tileFrame, tokenFrameResult.value());
+            stepResult.scenarioVideoFrame.value(),
+            tileFrame,
+            tokenFrameResult.value(),
+            relativeFrame);
         const std::filesystem::path outputPath = comparisonPathForFrame(frameIndex);
         ASSERT_TRUE(writePng(
             rgba,
-            NesTileFrame::VisibleWidthPixels * 3u + kPanelGapPixels * 2u,
-            NesTileFrame::VisibleHeightPixels,
+            NesTileFrame::VisibleWidthPixels * 3u
+                + NesPlayerRelativeTileFrame::RelativeTileColumns
+                    * NesPlayerRelativeTileFrame::TileSizePixels
+                + kPanelGapPixels * 3u,
+            NesPlayerRelativeTileFrame::RelativeTileRows
+                * NesPlayerRelativeTileFrame::TileSizePixels,
             outputPath))
             << "Failed to write " << outputPath;
         std::cout << "Wrote SMB tile probe: " << outputPath.string() << "\n";

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
@@ -3,6 +3,8 @@
 #include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
 #include "core/scenarios/nes/NesTileFrame.h"
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
 
 #include "external/stb/stb_image_write.h"
 
@@ -99,17 +101,24 @@ void setRgbaPixel(
     rgba[offset + 3u] = static_cast<uint8_t>(color & 0xFFu);
 }
 
-uint32_t tileHashColor(uint64_t hash)
+uint32_t tileTokenColor(NesTileTokenizer::TileToken token)
 {
-    const uint8_t red = static_cast<uint8_t>(64u + ((hash >> 0u) & 0x7Fu));
-    const uint8_t green = static_cast<uint8_t>(64u + ((hash >> 8u) & 0x7Fu));
-    const uint8_t blue = static_cast<uint8_t>(64u + ((hash >> 16u) & 0x7Fu));
+    if (token == NesTileTokenizer::VoidToken) {
+        return 0x000000FFu;
+    }
+
+    const uint32_t mixed = static_cast<uint32_t>(token) * 2654435761u;
+    const uint8_t red = static_cast<uint8_t>(64u + ((mixed >> 0u) & 0x7Fu));
+    const uint8_t green = static_cast<uint8_t>(64u + ((mixed >> 8u) & 0x7Fu));
+    const uint8_t blue = static_cast<uint8_t>(64u + ((mixed >> 16u) & 0x7Fu));
     return (static_cast<uint32_t>(red) << 24u) | (static_cast<uint32_t>(green) << 16u)
         | (static_cast<uint32_t>(blue) << 8u) | 255u;
 }
 
 std::vector<uint8_t> makeComparisonImage(
-    const ScenarioVideoFrame& videoFrame, const NesTileFrame& tileFrame)
+    const ScenarioVideoFrame& videoFrame,
+    const NesTileFrame& tileFrame,
+    const NesTileTokenFrame& tokenFrame)
 {
     const uint32_t panelWidth = NesTileFrame::VisibleWidthPixels;
     const uint32_t panelHeight = NesTileFrame::VisibleHeightPixels;
@@ -155,7 +164,7 @@ std::vector<uint8_t> makeComparisonImage(
         for (uint32_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
             const size_t cellIndex =
                 static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
-            const uint32_t color = tileHashColor(tileFrame.tilePatternHashes[cellIndex]);
+            const uint32_t color = tileTokenColor(tokenFrame.tokens[cellIndex]);
             for (uint32_t py = 0; py < 8u; ++py) {
                 for (uint32_t px = 0; px < 8u; ++px) {
                     setRgbaPixel(rgba, width, tokenPanelX + gx * 8u + px, gy * 8u + py, color);
@@ -227,6 +236,7 @@ TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
     ASSERT_FALSE(driver.setConfig(ScenarioConfig{ config }).isError());
     ASSERT_FALSE(driver.setup().isError()) << driver.getRuntimeLastError();
 
+    NesTileTokenizer tokenizer;
     Timers timers;
     const uint64_t finalFrame = kProbeFrames.back();
     for (uint64_t frameIndex = 0; frameIndex <= finalFrame; ++frameIndex) {
@@ -241,8 +251,10 @@ TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
         const auto ppuSnapshot = driver.copyRuntimePpuSnapshot();
         ASSERT_TRUE(ppuSnapshot.has_value()) << "Missing PPU snapshot at " << frameIndex;
         const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
-        const std::vector<uint8_t> rgba =
-            makeComparisonImage(stepResult.scenarioVideoFrame.value(), tileFrame);
+        const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+        ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
+        const std::vector<uint8_t> rgba = makeComparisonImage(
+            stepResult.scenarioVideoFrame.value(), tileFrame, tokenFrameResult.value());
         const std::filesystem::path outputPath = comparisonPathForFrame(frameIndex);
         ASSERT_TRUE(writePng(
             rgba,

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosTileProbe_test.cpp
@@ -1,0 +1,255 @@
+#include "core/ScenarioConfig.h"
+#include "core/Timers.h"
+#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
+#include "core/scenarios/nes/NesTileFrame.h"
+
+#include "external/stb/stb_image_write.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace DirtSim;
+
+namespace {
+
+constexpr uint64_t kSetupScriptEndFrame = 300u;
+constexpr uint32_t kPanelGapPixels = 12u;
+constexpr std::array<uint64_t, 5> kProbeFrames = { 300u, 400u, 500u, 700u, 899u };
+
+std::optional<std::filesystem::path> resolveNesSmbFixtureRomPath()
+{
+    if (const char* romPathEnv = std::getenv("DIRTSIM_NES_SMB_TEST_ROM_PATH");
+        romPathEnv != nullptr) {
+        const std::filesystem::path romPath{ romPathEnv };
+        if (std::filesystem::exists(romPath)) {
+            return romPath;
+        }
+    }
+
+    const std::filesystem::path repoRelativeRomPath =
+        std::filesystem::path("testdata") / "roms" / "smb.nes";
+    if (std::filesystem::exists(repoRelativeRomPath)) {
+        return repoRelativeRomPath;
+    }
+
+    return std::nullopt;
+}
+
+uint8_t baselineControllerMaskForGameFrame(uint64_t gameFrame)
+{
+    const bool gradualWalkWindow = gameFrame >= 140u && gameFrame < 220u;
+    const bool pressRight = !gradualWalkWindow || ((gameFrame % 2u) == 0u);
+
+    uint8_t mask = pressRight ? SMOLNES_RUNTIME_BUTTON_RIGHT : 0u;
+    if (gameFrame % 60u < 15u) {
+        mask |= SMOLNES_RUNTIME_BUTTON_A;
+    }
+
+    return mask;
+}
+
+uint8_t scriptedControllerMaskForFrame(uint64_t frameIndex)
+{
+    if (frameIndex < kSetupScriptEndFrame) {
+        return getNesSuperMarioBrosScriptedSetupMaskForFrame(frameIndex);
+    }
+
+    return baselineControllerMaskForGameFrame(frameIndex - kSetupScriptEndFrame);
+}
+
+std::array<uint8_t, 4> rgb565ToRgba8888(uint16_t value)
+{
+    const uint8_t red5 = static_cast<uint8_t>((value >> 11) & 0x1Fu);
+    const uint8_t green6 = static_cast<uint8_t>((value >> 5) & 0x3Fu);
+    const uint8_t blue5 = static_cast<uint8_t>(value & 0x1Fu);
+
+    return {
+        static_cast<uint8_t>((red5 << 3) | (red5 >> 2)),
+        static_cast<uint8_t>((green6 << 2) | (green6 >> 4)),
+        static_cast<uint8_t>((blue5 << 3) | (blue5 >> 2)),
+        255u,
+    };
+}
+
+uint16_t readRgb565Pixel(const ScenarioVideoFrame& frame, size_t pixelIndex)
+{
+    const size_t offset = pixelIndex * 2u;
+    const uint8_t lo = std::to_integer<uint8_t>(frame.pixels[offset]);
+    const uint8_t hi = std::to_integer<uint8_t>(frame.pixels[offset + 1u]);
+    return static_cast<uint16_t>(lo | (static_cast<uint16_t>(hi) << 8u));
+}
+
+void setRgbaPixel(
+    std::vector<uint8_t>& rgba, uint32_t width, uint32_t x, uint32_t y, uint32_t color)
+{
+    const size_t offset = (static_cast<size_t>(y) * width + x) * 4u;
+    rgba[offset + 0u] = static_cast<uint8_t>((color >> 24u) & 0xFFu);
+    rgba[offset + 1u] = static_cast<uint8_t>((color >> 16u) & 0xFFu);
+    rgba[offset + 2u] = static_cast<uint8_t>((color >> 8u) & 0xFFu);
+    rgba[offset + 3u] = static_cast<uint8_t>(color & 0xFFu);
+}
+
+uint32_t tileHashColor(uint64_t hash)
+{
+    const uint8_t red = static_cast<uint8_t>(64u + ((hash >> 0u) & 0x7Fu));
+    const uint8_t green = static_cast<uint8_t>(64u + ((hash >> 8u) & 0x7Fu));
+    const uint8_t blue = static_cast<uint8_t>(64u + ((hash >> 16u) & 0x7Fu));
+    return (static_cast<uint32_t>(red) << 24u) | (static_cast<uint32_t>(green) << 16u)
+        | (static_cast<uint32_t>(blue) << 8u) | 255u;
+}
+
+std::vector<uint8_t> makeComparisonImage(
+    const ScenarioVideoFrame& videoFrame, const NesTileFrame& tileFrame)
+{
+    const uint32_t panelWidth = NesTileFrame::VisibleWidthPixels;
+    const uint32_t panelHeight = NesTileFrame::VisibleHeightPixels;
+    const uint32_t width = panelWidth * 3u + kPanelGapPixels * 2u;
+    const uint32_t height = panelHeight;
+    std::vector<uint8_t> rgba(static_cast<size_t>(width) * height * 4u, 18u);
+
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            setRgbaPixel(rgba, width, x, y, 0x121212FFu);
+        }
+    }
+
+    const uint32_t patternPanelX = panelWidth + kPanelGapPixels;
+    const uint32_t tokenPanelX = patternPanelX + panelWidth + kPanelGapPixels;
+
+    for (uint32_t y = 0; y < panelHeight; ++y) {
+        const size_t rowBase = static_cast<size_t>(y) * panelWidth;
+        for (uint32_t x = 0; x < panelWidth; ++x) {
+            const size_t pixelIndex = rowBase + x;
+            const auto actual = rgb565ToRgba8888(readRgb565Pixel(videoFrame, pixelIndex));
+            setRgbaPixel(
+                rgba,
+                width,
+                x,
+                y,
+                (static_cast<uint32_t>(actual[0]) << 24u)
+                    | (static_cast<uint32_t>(actual[1]) << 16u)
+                    | (static_cast<uint32_t>(actual[2]) << 8u) | 255u);
+
+            const uint8_t shade = static_cast<uint8_t>(tileFrame.patternPixels[pixelIndex] * 85u);
+            setRgbaPixel(
+                rgba,
+                width,
+                patternPanelX + x,
+                y,
+                (static_cast<uint32_t>(shade) << 24u) | (static_cast<uint32_t>(shade) << 16u)
+                    | (static_cast<uint32_t>(shade) << 8u) | 255u);
+        }
+    }
+
+    for (uint32_t gy = 0; gy < NesTileFrame::VisibleTileRows; ++gy) {
+        for (uint32_t gx = 0; gx < NesTileFrame::VisibleTileColumns; ++gx) {
+            const size_t cellIndex =
+                static_cast<size_t>(gy) * NesTileFrame::VisibleTileColumns + gx;
+            const uint32_t color = tileHashColor(tileFrame.tilePatternHashes[cellIndex]);
+            for (uint32_t py = 0; py < 8u; ++py) {
+                for (uint32_t px = 0; px < 8u; ++px) {
+                    setRgbaPixel(rgba, width, tokenPanelX + gx * 8u + px, gy * 8u + py, color);
+                }
+            }
+        }
+    }
+
+    return rgba;
+}
+
+void pngWriteCallback(void* context, void* data, int size)
+{
+    auto* buffer = static_cast<std::vector<uint8_t>*>(context);
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    buffer->insert(buffer->end(), bytes, bytes + size);
+}
+
+bool writePng(
+    const std::vector<uint8_t>& rgba,
+    uint32_t width,
+    uint32_t height,
+    const std::filesystem::path& path)
+{
+    std::vector<uint8_t> png;
+    if (stbi_write_png_to_func(
+            pngWriteCallback,
+            &png,
+            static_cast<int>(width),
+            static_cast<int>(height),
+            4,
+            rgba.data(),
+            static_cast<int>(width * 4u))
+        == 0) {
+        return false;
+    }
+
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    if (!stream.is_open()) {
+        return false;
+    }
+
+    stream.write(
+        reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+    return stream.good();
+}
+
+std::filesystem::path comparisonPathForFrame(uint64_t frameIndex)
+{
+    return std::filesystem::path(::testing::TempDir())
+        / ("nes_smb_tile_probe_" + std::to_string(frameIndex) + ".png");
+}
+
+} // namespace
+
+TEST(NesSuperMarioBrosTileProbeTest, DISABLED_SavesTileComparisonPngs)
+{
+    const auto romPath = resolveNesSmbFixtureRomPath();
+    ASSERT_TRUE(romPath.has_value())
+        << "Missing SMB ROM. Set DIRTSIM_NES_SMB_TEST_ROM_PATH or place testdata/roms/smb.nes.";
+
+    NesSmolnesScenarioDriver driver(Scenario::EnumType::NesSuperMarioBros);
+    Config::NesSuperMarioBros config = std::get<Config::NesSuperMarioBros>(
+        makeDefaultConfig(Scenario::EnumType::NesSuperMarioBros));
+    config.romId = "";
+    config.romPath = romPath->string();
+    config.requireSmolnesMapper = true;
+
+    ASSERT_FALSE(driver.setConfig(ScenarioConfig{ config }).isError());
+    ASSERT_FALSE(driver.setup().isError()) << driver.getRuntimeLastError();
+
+    Timers timers;
+    const uint64_t finalFrame = kProbeFrames.back();
+    for (uint64_t frameIndex = 0; frameIndex <= finalFrame; ++frameIndex) {
+        const auto stepResult = driver.step(timers, scriptedControllerMaskForFrame(frameIndex));
+        ASSERT_TRUE(stepResult.scenarioVideoFrame.has_value())
+            << "Missing video frame at " << frameIndex;
+
+        if (std::find(kProbeFrames.begin(), kProbeFrames.end(), frameIndex) == kProbeFrames.end()) {
+            continue;
+        }
+
+        const auto ppuSnapshot = driver.copyRuntimePpuSnapshot();
+        ASSERT_TRUE(ppuSnapshot.has_value()) << "Missing PPU snapshot at " << frameIndex;
+        const NesTileFrame tileFrame = makeNesTileFrame(ppuSnapshot.value());
+        const std::vector<uint8_t> rgba =
+            makeComparisonImage(stepResult.scenarioVideoFrame.value(), tileFrame);
+        const std::filesystem::path outputPath = comparisonPathForFrame(frameIndex);
+        ASSERT_TRUE(writePng(
+            rgba,
+            NesTileFrame::VisibleWidthPixels * 3u + kPanelGapPixels * 2u,
+            NesTileFrame::VisibleHeightPixels,
+            outputPath))
+            << "Failed to write " << outputPath;
+        std::cout << "Wrote SMB tile probe: " << outputPath.string() << "\n";
+    }
+}

--- a/apps/src/core/scenarios/tests/NesTileDebugRenderer_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileDebugRenderer_test.cpp
@@ -1,0 +1,202 @@
+#include "core/scenarios/nes/NesTileDebugRenderer.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace DirtSim;
+
+namespace {
+
+ScenarioVideoFrame makeVideoFrame(uint16_t width, uint16_t height, uint16_t fillRgb565 = 0u)
+{
+    ScenarioVideoFrame frame{
+        .width = width,
+        .height = height,
+        .frame_id = 42u,
+        .pixels = std::vector<std::byte>(static_cast<size_t>(width) * height * 2u),
+    };
+
+    for (size_t pixelIndex = 0; pixelIndex < static_cast<size_t>(width) * height; ++pixelIndex) {
+        const size_t offset = pixelIndex * 2u;
+        frame.pixels[offset + 0u] = static_cast<std::byte>(fillRgb565 & 0xFFu);
+        frame.pixels[offset + 1u] = static_cast<std::byte>((fillRgb565 >> 8u) & 0xFFu);
+    }
+
+    return frame;
+}
+
+std::array<uint8_t, 4> rgbaAt(const NesTileDebugRenderImage& image, uint32_t x, uint32_t y)
+{
+    const size_t offset = (static_cast<size_t>(y) * image.width + x) * 4u;
+    return {
+        image.rgba[offset + 0u],
+        image.rgba[offset + 1u],
+        image.rgba[offset + 2u],
+        image.rgba[offset + 3u],
+    };
+}
+
+std::array<uint8_t, 4> rgbaFromColor(uint32_t color)
+{
+    return {
+        static_cast<uint8_t>((color >> 24u) & 0xFFu),
+        static_cast<uint8_t>((color >> 16u) & 0xFFu),
+        static_cast<uint8_t>((color >> 8u) & 0xFFu),
+        static_cast<uint8_t>(color & 0xFFu),
+    };
+}
+
+void setRgb565Pixel(ScenarioVideoFrame& frame, size_t pixelIndex, uint16_t rgb565)
+{
+    const size_t offset = pixelIndex * 2u;
+    frame.pixels[offset + 0u] = static_cast<std::byte>(rgb565 & 0xFFu);
+    frame.pixels[offset + 1u] = static_cast<std::byte>((rgb565 >> 8u) & 0xFFu);
+}
+
+} // namespace
+
+TEST(NesTileDebugRendererTest, NormalVideoConvertsRgb565PixelsToRgba)
+{
+    ScenarioVideoFrame videoFrame = makeVideoFrame(3u, 1u);
+    setRgb565Pixel(videoFrame, 0u, 0xF800u);
+    setRgb565Pixel(videoFrame, 1u, 0x07E0u);
+    setRgb565Pixel(videoFrame, 2u, 0x001Fu);
+
+    const auto imageResult = makeNesTileDebugRenderImage(
+        NesTileDebugView::NormalVideo, NesTileDebugRenderInput{ .videoFrame = &videoFrame });
+
+    ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
+    const NesTileDebugRenderImage& image = imageResult.value();
+    EXPECT_EQ(image.width, 3u);
+    EXPECT_EQ(image.height, 1u);
+    EXPECT_EQ(rgbaAt(image, 0u, 0u), (std::array<uint8_t, 4>{ 255u, 0u, 0u, 255u }));
+    EXPECT_EQ(rgbaAt(image, 1u, 0u), (std::array<uint8_t, 4>{ 0u, 255u, 0u, 255u }));
+    EXPECT_EQ(rgbaAt(image, 2u, 0u), (std::array<uint8_t, 4>{ 0u, 0u, 255u, 255u }));
+}
+
+TEST(NesTileDebugRendererTest, PatternPixelsRenderAsFourGrayscaleLevels)
+{
+    NesTileFrame tileFrame;
+    tileFrame.patternPixels[0u] = 0u;
+    tileFrame.patternPixels[1u] = 1u;
+    tileFrame.patternPixels[2u] = 2u;
+    tileFrame.patternPixels[3u] = 3u;
+
+    const auto imageResult = makeNesTileDebugRenderImage(
+        NesTileDebugView::PatternPixels, NesTileDebugRenderInput{ .tileFrame = &tileFrame });
+
+    ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
+    const NesTileDebugRenderImage& image = imageResult.value();
+    EXPECT_EQ(image.width, NesTileFrame::VisibleWidthPixels);
+    EXPECT_EQ(image.height, NesTileFrame::VisibleHeightPixels);
+    EXPECT_EQ(rgbaAt(image, 0u, 0u), (std::array<uint8_t, 4>{ 0u, 0u, 0u, 255u }));
+    EXPECT_EQ(rgbaAt(image, 1u, 0u), (std::array<uint8_t, 4>{ 85u, 85u, 85u, 255u }));
+    EXPECT_EQ(rgbaAt(image, 2u, 0u), (std::array<uint8_t, 4>{ 170u, 170u, 170u, 255u }));
+    EXPECT_EQ(rgbaAt(image, 3u, 0u), (std::array<uint8_t, 4>{ 255u, 255u, 255u, 255u }));
+}
+
+TEST(NesTileDebugRendererTest, ScreenTokensRenderDeterministicColorsAndVoidBlack)
+{
+    NesTileTokenFrame tokenFrame;
+    tokenFrame.tokens.fill(NesTileTokenizer::VoidToken);
+    tokenFrame.tokens[0u] = 7u;
+
+    const auto imageResult = makeNesTileDebugRenderImage(
+        NesTileDebugView::ScreenTokens, NesTileDebugRenderInput{ .tokenFrame = &tokenFrame });
+
+    ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
+    const NesTileDebugRenderImage& image = imageResult.value();
+    EXPECT_EQ(image.width, NesTileFrame::VisibleWidthPixels);
+    EXPECT_EQ(image.height, NesTileFrame::VisibleHeightPixels);
+    EXPECT_EQ(rgbaAt(image, 0u, 0u), rgbaFromColor(nesTileDebugTokenColor(7u)));
+    EXPECT_EQ(rgbaAt(image, 7u, 7u), rgbaFromColor(nesTileDebugTokenColor(7u)));
+    EXPECT_EQ(rgbaAt(image, 8u, 0u), (std::array<uint8_t, 4>{ 0u, 0u, 0u, 255u }));
+    EXPECT_EQ(nesTileDebugTokenColor(7u), nesTileDebugTokenColor(7u));
+    EXPECT_NE(nesTileDebugTokenColor(7u), nesTileDebugTokenColor(8u));
+}
+
+TEST(NesTileDebugRendererTest, PlayerRelativeTokensUseExpandedDimensions)
+{
+    NesPlayerRelativeTileFrame relativeFrame;
+    relativeFrame.tokens.fill(NesTileTokenizer::VoidToken);
+    relativeFrame.tokens.back() = 9u;
+
+    const auto imageResult = makeNesTileDebugRenderImage(
+        NesTileDebugView::PlayerRelativeTokens,
+        NesTileDebugRenderInput{ .relativeFrame = &relativeFrame });
+
+    ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
+    const NesTileDebugRenderImage& image = imageResult.value();
+    EXPECT_EQ(
+        image.width,
+        NesPlayerRelativeTileFrame::RelativeTileColumns
+            * NesPlayerRelativeTileFrame::TileSizePixels);
+    EXPECT_EQ(
+        image.height,
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels);
+    EXPECT_EQ(
+        rgbaAt(image, image.width - 1u, image.height - 1u),
+        rgbaFromColor(nesTileDebugTokenColor(9u)));
+}
+
+TEST(NesTileDebugRendererTest, ComparisonDimensionsIncludeExpandedRelativePanel)
+{
+    ScenarioVideoFrame videoFrame =
+        makeVideoFrame(NesTileFrame::VisibleWidthPixels, NesTileFrame::VisibleHeightPixels);
+    NesTileFrame tileFrame;
+    NesTileTokenFrame tokenFrame;
+    NesPlayerRelativeTileFrame relativeFrame;
+
+    const auto imageResult = makeNesTileDebugRenderImage(
+        NesTileDebugView::Comparison,
+        NesTileDebugRenderInput{
+            .videoFrame = &videoFrame,
+            .tileFrame = &tileFrame,
+            .tokenFrame = &tokenFrame,
+            .relativeFrame = &relativeFrame,
+        });
+
+    ASSERT_TRUE(imageResult.isValue()) << imageResult.errorValue();
+    const NesTileDebugRenderImage& image = imageResult.value();
+    EXPECT_EQ(
+        image.width,
+        NesTileFrame::VisibleWidthPixels * 3u
+            + NesPlayerRelativeTileFrame::RelativeTileColumns
+                * NesPlayerRelativeTileFrame::TileSizePixels
+            + 36u);
+    EXPECT_EQ(
+        image.height,
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels);
+}
+
+TEST(NesTileDebugRendererTest, ScenarioVideoFrameConversionWritesLittleEndianRgb565)
+{
+    const NesTileDebugRenderImage image{
+        .width = 2u,
+        .height = 1u,
+        .rgba = std::vector<uint8_t>{ 255u, 0u, 0u, 255u, 0u, 255u, 0u, 255u },
+    };
+
+    const ScenarioVideoFrame frame = makeNesTileDebugScenarioVideoFrame(image, 77u);
+
+    EXPECT_EQ(frame.width, 2u);
+    EXPECT_EQ(frame.height, 1u);
+    EXPECT_EQ(frame.frame_id, 77u);
+    ASSERT_EQ(frame.pixels.size(), 4u);
+    EXPECT_EQ(std::to_integer<uint8_t>(frame.pixels[0u]), 0x00u);
+    EXPECT_EQ(std::to_integer<uint8_t>(frame.pixels[1u]), 0xF8u);
+    EXPECT_EQ(std::to_integer<uint8_t>(frame.pixels[2u]), 0xE0u);
+    EXPECT_EQ(std::to_integer<uint8_t>(frame.pixels[3u]), 0x07u);
+}
+
+TEST(NesTileDebugRendererTest, RejectsMissingInputs)
+{
+    const auto imageResult =
+        makeNesTileDebugRenderImage(NesTileDebugView::Comparison, NesTileDebugRenderInput{});
+
+    ASSERT_TRUE(imageResult.isError());
+    EXPECT_NE(imageResult.errorValue().find("Missing video frame"), std::string::npos);
+}

--- a/apps/src/core/scenarios/tests/NesTileFrame_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileFrame_test.cpp
@@ -1,0 +1,85 @@
+#include "core/scenarios/nes/NesTileFrame.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+using namespace DirtSim;
+
+namespace {
+
+size_t tileCellIndex(uint16_t x, uint16_t y)
+{
+    return static_cast<size_t>(y) * NesTileFrame::VisibleTileColumns + x;
+}
+
+void setSolidTilePattern(NesPpuSnapshot& snapshot, uint8_t tileId, uint8_t color)
+{
+    const size_t base = static_cast<size_t>(tileId) * 16u;
+    const uint8_t lo = (color & 0x01u) != 0u ? 0xFFu : 0x00u;
+    const uint8_t hi = (color & 0x02u) != 0u ? 0xFFu : 0x00u;
+    for (size_t row = 0; row < 8u; ++row) {
+        snapshot.chr[base + row] = lo;
+        snapshot.chr[base + 8u + row] = hi;
+    }
+}
+
+} // namespace
+
+TEST(NesTileFrameTest, ExtractsVisiblePixelsFromSyntheticSnapshot)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.frameId = 7u;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    snapshot.vram[32u] = 1u;
+
+    const NesTileFrame frame = makeNesTileFrame(snapshot);
+
+    EXPECT_EQ(frame.frameId, 7u);
+    EXPECT_EQ(frame.scrollX, 0u);
+    EXPECT_EQ(frame.scrollY, 0u);
+    EXPECT_EQ(frame.tileIds[tileCellIndex(0u, 0u)], 1u);
+    EXPECT_EQ(frame.patternPixels[0u], 1u);
+    EXPECT_EQ(frame.patternPixels[7u], 1u);
+    EXPECT_EQ(frame.patternPixels[8u], 0u);
+    EXPECT_NE(
+        frame.tilePatternHashes[tileCellIndex(0u, 0u)],
+        frame.tilePatternHashes[tileCellIndex(1u, 0u)]);
+}
+
+TEST(NesTileFrameTest, FineXScrollMovesVisibleTileBoundary)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.fineX = 7u;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    setSolidTilePattern(snapshot, 2u, 2u);
+    snapshot.vram[32u] = 1u;
+    snapshot.vram[33u] = 2u;
+
+    const NesTileFrame frame = makeNesTileFrame(snapshot);
+
+    EXPECT_EQ(frame.patternPixels[0u], 1u);
+    EXPECT_EQ(frame.patternPixels[1u], 2u);
+    EXPECT_EQ(frame.tileIds[tileCellIndex(0u, 0u)], 2u);
+}
+
+TEST(NesTileFrameTest, HashesMatchForDifferentTileIdsWithSamePattern)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 3u);
+    setSolidTilePattern(snapshot, 2u, 3u);
+    snapshot.vram[32u] = 1u;
+    snapshot.vram[33u] = 2u;
+
+    const NesTileFrame frame = makeNesTileFrame(snapshot);
+
+    EXPECT_EQ(frame.tileIds[tileCellIndex(0u, 0u)], 1u);
+    EXPECT_EQ(frame.tileIds[tileCellIndex(1u, 0u)], 2u);
+    EXPECT_EQ(
+        frame.tilePatternHashes[tileCellIndex(0u, 0u)],
+        frame.tilePatternHashes[tileCellIndex(1u, 0u)]);
+}

--- a/apps/src/core/scenarios/tests/NesTileFrame_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileFrame_test.cpp
@@ -1,5 +1,7 @@
 #include "core/scenarios/nes/NesTileFrame.h"
 
+#include "core/Timers.h"
+
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -82,4 +84,62 @@ TEST(NesTileFrameTest, HashesMatchForDifferentTileIdsWithSamePattern)
     EXPECT_EQ(
         frame.tilePatternHashes[tileCellIndex(0u, 0u)],
         frame.tilePatternHashes[tileCellIndex(1u, 0u)]);
+}
+
+TEST(NesTileFrameTest, InstrumentedExtractionMatchesUninstrumentedFrame)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.frameId = 12u;
+    snapshot.fineX = 3u;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    setSolidTilePattern(snapshot, 2u, 2u);
+    snapshot.vram[32u] = 1u;
+    snapshot.vram[33u] = 2u;
+
+    Timers timers;
+    const NesTileFrame baseline = makeNesTileFrame(snapshot);
+    const NesTileFrame instrumented = makeNesTileFrame(snapshot, &timers);
+
+    EXPECT_EQ(instrumented.frameId, baseline.frameId);
+    EXPECT_EQ(instrumented.scrollX, baseline.scrollX);
+    EXPECT_EQ(instrumented.scrollY, baseline.scrollY);
+    EXPECT_EQ(instrumented.patternPixels, baseline.patternPixels);
+    EXPECT_EQ(instrumented.tileIds, baseline.tileIds);
+    EXPECT_EQ(instrumented.tilePatternHashes, baseline.tilePatternHashes);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_scroll_decode"), 1u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_pattern_pixels"), 1u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_tile_ids"), 1u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_tile_hashes"), 1u);
+}
+
+TEST(NesTileFrameTest, OptionalPatternPixelsSkipsOnlyPatternPanelData)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.frameId = 18u;
+    snapshot.fineX = 3u;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    setSolidTilePattern(snapshot, 2u, 2u);
+    snapshot.vram[32u] = 1u;
+    snapshot.vram[33u] = 2u;
+
+    Timers timers;
+    const NesTileFrame fullFrame = makeNesTileFrame(snapshot);
+    const NesTileFrame tileOnlyFrame = makeNesTileFrame(
+        snapshot, NesTileFrameBuildOptions{ .includePatternPixels = false }, &timers);
+    const std::array<uint8_t, NesTileFrame::VisibleWidthPixels * NesTileFrame::VisibleHeightPixels>
+        emptyPatternPixels{};
+
+    EXPECT_EQ(tileOnlyFrame.frameId, fullFrame.frameId);
+    EXPECT_EQ(tileOnlyFrame.scrollX, fullFrame.scrollX);
+    EXPECT_EQ(tileOnlyFrame.scrollY, fullFrame.scrollY);
+    EXPECT_EQ(tileOnlyFrame.tileIds, fullFrame.tileIds);
+    EXPECT_EQ(tileOnlyFrame.tilePatternHashes, fullFrame.tilePatternHashes);
+    EXPECT_EQ(tileOnlyFrame.patternPixels, emptyPatternPixels);
+    EXPECT_NE(fullFrame.patternPixels, emptyPatternPixels);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_scroll_decode"), 1u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_pattern_pixels"), 0u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_tile_ids"), 1u);
+    EXPECT_EQ(timers.getCallCount("nes_tile_frame_tile_hashes"), 1u);
 }

--- a/apps/src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
@@ -152,7 +152,7 @@ TEST(NesTileRecurrentBrainTest, IncompatibleGenomeSizesFailCompatibility)
             Genome(static_cast<size_t>(kTotalGenomeSize + 1), 0.0f)));
 }
 
-TEST(NesTileRecurrentBrainTest, TokenEmbeddingLookupUsesVoidAndTokenRows)
+TEST(NesTileRecurrentBrainTest, TokenEmbeddingLookupIgnoresVoidAndUsesTokenRows)
 {
     const Genome genome = makeEmbeddingProbeGenome();
     const float expectedScale = kMaxHiddenAlpha * kMaxHiddenAlpha;
@@ -165,7 +165,7 @@ TEST(NesTileRecurrentBrainTest, TokenEmbeddingLookupUsesVoidAndTokenRows)
     NesTileRecurrentBrain tokenBrain(genome);
     const ControllerOutput tokenOutput = tokenBrain.inferControllerOutput(tokenSensory);
 
-    EXPECT_NEAR(voidOutput.xRaw, 0.75f * expectedScale, 1e-5f);
+    EXPECT_NEAR(voidOutput.xRaw, 0.0f, 1e-5f);
     EXPECT_NEAR(tokenOutput.xRaw, 2.25f * expectedScale, 1e-5f);
 }
 

--- a/apps/src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileRecurrentBrain_test.cpp
@@ -1,0 +1,191 @@
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
+
+#include "core/organisms/brains/WeightType.h"
+#include "core/scenarios/nes/NesTileSensoryData.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <random>
+#include <string>
+
+using namespace DirtSim;
+
+namespace {
+
+constexpr float kMaxHiddenAlpha = 0.98f;
+constexpr float kStrongPositiveLogit = 100.0f;
+constexpr int kTileEmbeddingSize =
+    NesTileRecurrentBrain::TileVocabularySize * NesTileRecurrentBrain::TileEmbeddingDim;
+constexpr int kWXH1Size = NesTileRecurrentBrain::InputSize * NesTileRecurrentBrain::H1Size;
+constexpr int kWH1H1Size = NesTileRecurrentBrain::H1Size * NesTileRecurrentBrain::H1Size;
+constexpr int kBH1Size = NesTileRecurrentBrain::H1Size;
+constexpr int kAlpha1LogitSize = NesTileRecurrentBrain::H1Size;
+constexpr int kWH1H2Size = NesTileRecurrentBrain::H1Size * NesTileRecurrentBrain::H2Size;
+constexpr int kWH2H2Size = NesTileRecurrentBrain::H2Size * NesTileRecurrentBrain::H2Size;
+constexpr int kBH2Size = NesTileRecurrentBrain::H2Size;
+constexpr int kAlpha2LogitSize = NesTileRecurrentBrain::H2Size;
+constexpr int kWH2OSize = NesTileRecurrentBrain::H2Size * NesTileRecurrentBrain::OutputSize;
+constexpr int kBOSize = NesTileRecurrentBrain::OutputSize;
+constexpr int kTotalGenomeSize = kTileEmbeddingSize + kWXH1Size + kWH1H1Size + kBH1Size
+    + kAlpha1LogitSize + 1 + kWH1H2Size + kWH2H2Size + kBH2Size + kAlpha2LogitSize + 1 + kWH2OSize
+    + kBOSize;
+
+size_t segmentOffset(const GenomeLayout& layout, const std::string& segmentName)
+{
+    size_t offset = 0u;
+    for (const auto& segment : layout.segments) {
+        if (segment.name == segmentName) {
+            return offset;
+        }
+        offset += static_cast<size_t>(segment.size);
+    }
+
+    ADD_FAILURE() << "Missing genome segment: " << segmentName;
+    return 0u;
+}
+
+size_t tileEmbeddingIndex(uint16_t token, int dim)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "tile_embedding")
+        + static_cast<size_t>(token) * NesTileRecurrentBrain::TileEmbeddingDim
+        + static_cast<size_t>(dim);
+}
+
+size_t wXh1Index(size_t inputIndex, size_t hiddenIndex)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "input_h1")
+        + (inputIndex * NesTileRecurrentBrain::H1Size) + hiddenIndex;
+}
+
+size_t alpha1LogitIndex(size_t hiddenIndex)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "h1_recurrent")
+        + static_cast<size_t>(kWH1H1Size + kBH1Size) + hiddenIndex;
+}
+
+size_t wH1H2Index(size_t h1Index, size_t h2Index)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "h1_to_h2")
+        + (h1Index * NesTileRecurrentBrain::H2Size) + h2Index;
+}
+
+size_t alpha2LogitIndex(size_t hiddenIndex)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "h2_recurrent")
+        + static_cast<size_t>(kWH2H2Size + kBH2Size) + hiddenIndex;
+}
+
+size_t wH2OIndex(size_t h2Index, size_t outputIndex)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "output")
+        + (h2Index * NesTileRecurrentBrain::OutputSize) + outputIndex;
+}
+
+size_t outputBiasIndex(size_t outputIndex)
+{
+    return segmentOffset(NesTileRecurrentBrain::getGenomeLayout(), "output")
+        + static_cast<size_t>(kWH2OSize) + outputIndex;
+}
+
+Genome makeZeroGenome()
+{
+    return Genome(static_cast<size_t>(kTotalGenomeSize), 0.0f);
+}
+
+Genome makeEmbeddingProbeGenome()
+{
+    Genome genome = makeZeroGenome();
+    genome.weights[tileEmbeddingIndex(0u, 0)] = 0.75f;
+    genome.weights[tileEmbeddingIndex(7u, 0)] = 2.25f;
+    genome.weights[wXh1Index(0u, 0u)] = 1.0f;
+    genome.weights[alpha1LogitIndex(0u)] = kStrongPositiveLogit;
+    genome.weights[wH1H2Index(0u, 0u)] = 1.0f;
+    genome.weights[alpha2LogitIndex(0u)] = kStrongPositiveLogit;
+    genome.weights[wH2OIndex(0u, 0u)] = 1.0f;
+    return genome;
+}
+
+} // namespace
+
+TEST(NesTileRecurrentBrainTest, GenomeLayoutMatchesExpectedSegments)
+{
+    const GenomeLayout layout = NesTileRecurrentBrain::getGenomeLayout();
+
+    ASSERT_EQ(layout.segments.size(), 6u);
+    EXPECT_EQ(layout.segments[0].name, "tile_embedding");
+    EXPECT_EQ(layout.segments[0].size, kTileEmbeddingSize);
+    EXPECT_EQ(layout.segments[1].name, "input_h1");
+    EXPECT_EQ(layout.segments[1].size, kWXH1Size);
+    EXPECT_EQ(layout.segments[2].name, "h1_recurrent");
+    EXPECT_EQ(layout.segments[2].size, kWH1H1Size + kBH1Size + kAlpha1LogitSize + 1);
+    EXPECT_EQ(layout.segments[3].name, "h1_to_h2");
+    EXPECT_EQ(layout.segments[3].size, kWH1H2Size);
+    EXPECT_EQ(layout.segments[4].name, "h2_recurrent");
+    EXPECT_EQ(layout.segments[4].size, kWH2H2Size + kBH2Size + kAlpha2LogitSize + 1);
+    EXPECT_EQ(layout.segments[5].name, "output");
+    EXPECT_EQ(layout.segments[5].size, kWH2OSize + kBOSize);
+    EXPECT_EQ(layout.totalSize(), kTotalGenomeSize);
+    EXPECT_EQ(layout.totalSize(), 899398);
+}
+
+TEST(NesTileRecurrentBrainTest, RandomGenomeMatchesLayoutSize)
+{
+    std::mt19937 rng(123u);
+
+    const Genome genome = NesTileRecurrentBrain::randomGenome(rng);
+    const GenomeLayout layout = NesTileRecurrentBrain::getGenomeLayout();
+
+    EXPECT_EQ(genome.weights.size(), static_cast<size_t>(layout.totalSize()));
+    EXPECT_TRUE(NesTileRecurrentBrain::isGenomeCompatible(genome));
+}
+
+TEST(NesTileRecurrentBrainTest, IncompatibleGenomeSizesFailCompatibility)
+{
+    EXPECT_FALSE(NesTileRecurrentBrain::isGenomeCompatible(Genome{}));
+    EXPECT_FALSE(
+        NesTileRecurrentBrain::isGenomeCompatible(
+            Genome(static_cast<size_t>(kTotalGenomeSize - 1), 0.0f)));
+    EXPECT_FALSE(
+        NesTileRecurrentBrain::isGenomeCompatible(
+            Genome(static_cast<size_t>(kTotalGenomeSize + 1), 0.0f)));
+}
+
+TEST(NesTileRecurrentBrainTest, TokenEmbeddingLookupUsesVoidAndTokenRows)
+{
+    const Genome genome = makeEmbeddingProbeGenome();
+    const float expectedScale = kMaxHiddenAlpha * kMaxHiddenAlpha;
+
+    NesTileRecurrentBrain voidBrain(genome);
+    const ControllerOutput voidOutput = voidBrain.inferControllerOutput(NesTileSensoryData{});
+
+    NesTileSensoryData tokenSensory;
+    tokenSensory.tileFrame.tokens[0u] = 7u;
+    NesTileRecurrentBrain tokenBrain(genome);
+    const ControllerOutput tokenOutput = tokenBrain.inferControllerOutput(tokenSensory);
+
+    EXPECT_NEAR(voidOutput.xRaw, 0.75f * expectedScale, 1e-5f);
+    EXPECT_NEAR(tokenOutput.xRaw, 2.25f * expectedScale, 1e-5f);
+}
+
+TEST(NesTileRecurrentBrainTest, HandAuthoredGenomeProducesDeterministicControllerOutput)
+{
+    Genome genome = makeZeroGenome();
+    genome.weights[outputBiasIndex(0u)] = 0.5f;
+    genome.weights[outputBiasIndex(1u)] = -0.25f;
+    genome.weights[outputBiasIndex(2u)] = 0.75f;
+    genome.weights[outputBiasIndex(3u)] = -0.75f;
+
+    NesTileRecurrentBrain brain(genome);
+    const ControllerOutput output = brain.inferControllerOutput(NesTileSensoryData{});
+
+    EXPECT_NEAR(output.xRaw, 0.5f, 1e-6f);
+    EXPECT_NEAR(output.yRaw, -0.25f, 1e-6f);
+    EXPECT_NEAR(output.x, std::tanh(0.5f), 1e-6f);
+    EXPECT_NEAR(output.y, std::tanh(-0.25f), 1e-6f);
+    EXPECT_TRUE(output.a);
+    EXPECT_FALSE(output.b);
+    EXPECT_NEAR(output.aRaw, 0.75f, 1e-6f);
+    EXPECT_NEAR(output.bRaw, -0.75f, 1e-6f);
+}

--- a/apps/src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileSensoryBuilder_test.cpp
@@ -1,0 +1,166 @@
+#include "core/scenarios/nes/NesTileSensoryBuilder.h"
+
+#include "core/organisms/evolution/NesPolicyLayout.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace DirtSim;
+
+namespace {
+
+size_t relativeTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::RelativeTileColumns + column;
+}
+
+size_t screenTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesTileFrame::VisibleTileColumns + column;
+}
+
+int16_t pixelForTile(uint16_t tile)
+{
+    return static_cast<int16_t>(tile * NesPlayerRelativeTileFrame::TileSizePixels + 4u);
+}
+
+NesTileFrame makeTileFrame(uint64_t frameId, uint16_t scrollX, uint16_t scrollY, uint64_t fillHash)
+{
+    NesTileFrame frame{
+        .frameId = frameId,
+        .scrollX = scrollX,
+        .scrollY = scrollY,
+    };
+    frame.tilePatternHashes.fill(fillHash);
+    return frame;
+}
+
+void setSolidTilePattern(NesPpuSnapshot& snapshot, uint8_t tileId, uint8_t color)
+{
+    const size_t base = static_cast<size_t>(tileId) * 16u;
+    const uint8_t lo = (color & 0x01u) != 0u ? 0xFFu : 0x00u;
+    const uint8_t hi = (color & 0x02u) != 0u ? 0xFFu : 0x00u;
+    for (size_t row = 0; row < 8u; ++row) {
+        snapshot.chr[base + row] = lo;
+        snapshot.chr[base + 8u + row] = hi;
+    }
+}
+
+} // namespace
+
+TEST(NesTileSensoryBuilderTest, BuildsPlayerRelativeSensoryFromTileFrame)
+{
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 30u, 10u, 20u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    NesTileFrame tileFrame = makeTileFrame(123u, 12u, 96u, 20u);
+    tileFrame.tilePatternHashes[screenTileIndex(0u, 0u)] = 10u;
+    tileFrame.tilePatternHashes[screenTileIndex(16u, 20u)] = 30u;
+
+    NesTileSensoryBuilderInput input{
+        .playerScreenX = pixelForTile(16u),
+        .playerScreenY = pixelForTile(20u),
+        .facingX = -1.0f,
+        .selfViewX = 0.25f,
+        .selfViewY = 0.75f,
+        .controllerMask =
+            NesPolicyLayout::ButtonRight | NesPolicyLayout::ButtonDown | NesPolicyLayout::ButtonA,
+        .energy = 0.5f,
+        .health = 0.25f,
+        .deltaTimeSeconds = 1.0 / 60.0,
+    };
+    input.specialSenses[0u] = 0.125;
+    input.specialSenses[17u] = -1.0;
+
+    const auto sensoryResult = makeNesTileSensoryDataFromTileFrame(tileFrame, tokenizer, input);
+
+    ASSERT_TRUE(sensoryResult.isValue()) << sensoryResult.errorValue();
+    const NesTileSensoryData& sensory = sensoryResult.value();
+    EXPECT_EQ(sensory.tileFrame.frameId, 123u);
+    EXPECT_EQ(sensory.tileFrame.scrollX, 12u);
+    EXPECT_EQ(sensory.tileFrame.scrollY, 96u);
+    EXPECT_EQ(sensory.tileFrame.playerTileColumn, 16);
+    EXPECT_EQ(sensory.tileFrame.playerTileRow, 20);
+    EXPECT_EQ(
+        sensory.tileFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        3u);
+    EXPECT_EQ(sensory.tileFrame.tokens[relativeTileIndex(15u, 7u)], 1u);
+    EXPECT_EQ(sensory.tileFrame.tokens[relativeTileIndex(46u, 34u)], 2u);
+    EXPECT_EQ(sensory.facingX, -1.0f);
+    EXPECT_EQ(sensory.selfViewX, 0.25f);
+    EXPECT_EQ(sensory.selfViewY, 0.75f);
+    EXPECT_EQ(sensory.previousControlX, 1.0f);
+    EXPECT_EQ(sensory.previousControlY, 1.0f);
+    EXPECT_TRUE(sensory.previousA);
+    EXPECT_FALSE(sensory.previousB);
+    EXPECT_EQ(sensory.specialSenses[0u], 0.125);
+    EXPECT_EQ(sensory.specialSenses[17u], -1.0);
+    EXPECT_EQ(sensory.energy, 0.5f);
+    EXPECT_EQ(sensory.health, 0.25f);
+    EXPECT_DOUBLE_EQ(sensory.deltaTimeSeconds, 1.0 / 60.0);
+}
+
+TEST(NesTileSensoryBuilderTest, FrozenUnknownHashFailsFromTileFrame)
+{
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    NesTileFrame tileFrame = makeTileFrame(123u, 0u, 0u, 10u);
+    tileFrame.tilePatternHashes[5u] = 20u;
+
+    const auto sensoryResult =
+        makeNesTileSensoryDataFromTileFrame(tileFrame, tokenizer, NesTileSensoryBuilderInput{});
+
+    ASSERT_TRUE(sensoryResult.isError());
+    EXPECT_NE(sensoryResult.errorValue().find("Failed to tokenize tile frame"), std::string::npos);
+    EXPECT_NE(sensoryResult.errorValue().find("cell 5"), std::string::npos);
+    EXPECT_NE(sensoryResult.errorValue().find("Frozen vocabulary missing"), std::string::npos);
+}
+
+TEST(NesTileSensoryBuilderTest, BuildsFromPpuSnapshot)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.frameId = 7u;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    snapshot.vram[32u] = 1u;
+
+    const NesTileFrame expectedTileFrame = makeNesTileFrame(snapshot);
+    NesTileTokenizer tokenizer;
+    const auto buildResult = tokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>(
+            expectedTileFrame.tilePatternHashes.begin(),
+            expectedTileFrame.tilePatternHashes.end()));
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+    const auto expectedTokenResult =
+        tokenizer.tokenForHash(expectedTileFrame.tilePatternHashes[screenTileIndex(0u, 0u)]);
+    ASSERT_TRUE(expectedTokenResult.isValue()) << expectedTokenResult.errorValue();
+
+    const auto sensoryResult = makeNesTileSensoryDataFromPpuSnapshot(
+        snapshot,
+        tokenizer,
+        NesTileSensoryBuilderInput{
+            .playerScreenX = pixelForTile(0u),
+            .playerScreenY = pixelForTile(0u),
+        });
+
+    ASSERT_TRUE(sensoryResult.isValue()) << sensoryResult.errorValue();
+    const NesTileSensoryData& sensory = sensoryResult.value();
+    EXPECT_EQ(sensory.tileFrame.frameId, 7u);
+    EXPECT_EQ(
+        sensory.tileFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        expectedTokenResult.value());
+}

--- a/apps/src/core/scenarios/tests/NesTileSensoryData_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileSensoryData_test.cpp
@@ -1,0 +1,124 @@
+#include "core/scenarios/nes/NesTileSensoryData.h"
+
+#include "core/organisms/evolution/NesPolicyLayout.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+using namespace DirtSim;
+
+namespace {
+
+size_t relativeTileIndex(uint16_t column, uint16_t row)
+{
+    return static_cast<size_t>(row) * NesPlayerRelativeTileFrame::RelativeTileColumns + column;
+}
+
+} // namespace
+
+TEST(NesTileSensoryDataTest, DefaultsAreNeutral)
+{
+    const NesTileSensoryData sensory;
+
+    EXPECT_EQ(sensory.tileFrame.frameId, 0u);
+    EXPECT_EQ(sensory.facingX, 0.0f);
+    EXPECT_EQ(sensory.selfViewX, 0.5f);
+    EXPECT_EQ(sensory.selfViewY, 0.5f);
+    EXPECT_EQ(sensory.previousControlX, 0.0f);
+    EXPECT_EQ(sensory.previousControlY, 0.0f);
+    EXPECT_FALSE(sensory.previousA);
+    EXPECT_FALSE(sensory.previousB);
+    EXPECT_EQ(sensory.energy, 1.0f);
+    EXPECT_EQ(sensory.health, 1.0f);
+    EXPECT_EQ(sensory.deltaTimeSeconds, 0.0);
+    for (double sense : sensory.specialSenses) {
+        EXPECT_EQ(sense, 0.0);
+    }
+}
+
+TEST(NesTileSensoryDataTest, ControllerMaskMapsDirectionalButtonsAndAB)
+{
+    NesTileSensoryData sensory;
+
+    setNesTilePreviousControlFromControllerMask(
+        sensory,
+        NesPolicyLayout::ButtonLeft | NesPolicyLayout::ButtonUp | NesPolicyLayout::ButtonA);
+
+    EXPECT_EQ(sensory.previousControlX, -1.0f);
+    EXPECT_EQ(sensory.previousControlY, -1.0f);
+    EXPECT_TRUE(sensory.previousA);
+    EXPECT_FALSE(sensory.previousB);
+
+    setNesTilePreviousControlFromControllerMask(
+        sensory,
+        NesPolicyLayout::ButtonRight | NesPolicyLayout::ButtonDown | NesPolicyLayout::ButtonB);
+
+    EXPECT_EQ(sensory.previousControlX, 1.0f);
+    EXPECT_EQ(sensory.previousControlY, 1.0f);
+    EXPECT_FALSE(sensory.previousA);
+    EXPECT_TRUE(sensory.previousB);
+}
+
+TEST(NesTileSensoryDataTest, ConflictingDirectionsResetAxesToZero)
+{
+    NesTileSensoryData sensory;
+    sensory.previousControlX = 1.0f;
+    sensory.previousControlY = -1.0f;
+
+    setNesTilePreviousControlFromControllerMask(
+        sensory,
+        NesPolicyLayout::ButtonLeft | NesPolicyLayout::ButtonRight | NesPolicyLayout::ButtonUp
+            | NesPolicyLayout::ButtonDown);
+
+    EXPECT_EQ(sensory.previousControlX, 0.0f);
+    EXPECT_EQ(sensory.previousControlY, 0.0f);
+    EXPECT_FALSE(sensory.previousA);
+    EXPECT_FALSE(sensory.previousB);
+}
+
+TEST(NesTileSensoryDataTest, TileFrameIsStoredWithoutHistogramPayload)
+{
+    NesTileSensoryData sensory;
+    sensory.tileFrame.frameId = 123u;
+    sensory.tileFrame.playerScreenX = 40;
+    sensory.tileFrame.playerScreenY = 80;
+    sensory.tileFrame.playerTileColumn = 5;
+    sensory.tileFrame.playerTileRow = 10;
+    sensory.tileFrame.tokens[relativeTileIndex(
+        NesPlayerRelativeTileFrame::AnchorTileColumn, NesPlayerRelativeTileFrame::AnchorTileRow)] =
+        42u;
+
+    EXPECT_EQ(sensory.tileFrame.frameId, 123u);
+    EXPECT_EQ(sensory.tileFrame.playerScreenX, 40);
+    EXPECT_EQ(sensory.tileFrame.playerScreenY, 80);
+    EXPECT_EQ(sensory.tileFrame.playerTileColumn, 5);
+    EXPECT_EQ(sensory.tileFrame.playerTileRow, 10);
+    EXPECT_EQ(
+        sensory.tileFrame.tokens[relativeTileIndex(
+            NesPlayerRelativeTileFrame::AnchorTileColumn,
+            NesPlayerRelativeTileFrame::AnchorTileRow)],
+        42u);
+}
+
+TEST(NesTileSensoryDataTest, StoresRamDerivedScalarSenses)
+{
+    NesTileSensoryData sensory;
+    sensory.facingX = -1.0f;
+    sensory.selfViewX = 0.25f;
+    sensory.selfViewY = 0.75f;
+    sensory.specialSenses[0u] = 0.125;
+    sensory.specialSenses[17u] = -1.0;
+    sensory.energy = 0.5f;
+    sensory.health = 0.25f;
+    sensory.deltaTimeSeconds = 1.0 / 60.0;
+
+    EXPECT_EQ(sensory.facingX, -1.0f);
+    EXPECT_EQ(sensory.selfViewX, 0.25f);
+    EXPECT_EQ(sensory.selfViewY, 0.75f);
+    EXPECT_EQ(sensory.specialSenses[0u], 0.125);
+    EXPECT_EQ(sensory.specialSenses[17u], -1.0);
+    EXPECT_EQ(sensory.energy, 0.5f);
+    EXPECT_EQ(sensory.health, 0.25f);
+    EXPECT_DOUBLE_EQ(sensory.deltaTimeSeconds, 1.0 / 60.0);
+}

--- a/apps/src/core/scenarios/tests/NesTileTokenFrame_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenFrame_test.cpp
@@ -1,0 +1,79 @@
+#include "core/scenarios/nes/NesTileTokenFrame.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace DirtSim;
+
+namespace {
+
+NesTileFrame makeTileFrame(uint64_t frameId, uint16_t scrollX, uint16_t scrollY, uint64_t fillHash)
+{
+    NesTileFrame frame;
+    frame.frameId = frameId;
+    frame.scrollX = scrollX;
+    frame.scrollY = scrollY;
+    frame.tilePatternHashes.fill(fillHash);
+    return frame;
+}
+
+uint64_t hashForIndex(uint64_t index)
+{
+    return 0xD6E8FEB86659FD93ull ^ (index * 0x100000001B3ull);
+}
+
+} // namespace
+
+TEST(NesTileTokenFrameTest, BuildsTokenFrameAndPreservesMetadata)
+{
+    NesTileTokenizer tokenizer;
+    NesTileFrame tileFrame = makeTileFrame(44u, 12u, 96u, hashForIndex(1u));
+    tileFrame.tilePatternHashes[0u] = hashForIndex(2u);
+    tileFrame.tilePatternHashes[1u] = hashForIndex(3u);
+    tileFrame.tilePatternHashes[2u] = hashForIndex(2u);
+
+    const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+
+    ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
+    const NesTileTokenFrame& tokenFrame = tokenFrameResult.value();
+    EXPECT_EQ(tokenFrame.frameId, 44u);
+    EXPECT_EQ(tokenFrame.scrollX, 12u);
+    EXPECT_EQ(tokenFrame.scrollY, 96u);
+    EXPECT_EQ(tokenFrame.tokens[0u], tokenFrame.tokens[2u]);
+    EXPECT_NE(tokenFrame.tokens[0u], tokenFrame.tokens[1u]);
+    EXPECT_NE(tokenFrame.tokens[0u], NesTileTokenizer::VoidToken);
+}
+
+TEST(NesTileTokenFrameTest, ReappearingHashesKeepStableTokensAcrossFrames)
+{
+    NesTileTokenizer tokenizer;
+    NesTileFrame firstTileFrame = makeTileFrame(1u, 0u, 0u, hashForIndex(10u));
+    firstTileFrame.tilePatternHashes[0u] = hashForIndex(11u);
+    const auto firstTokenFrameResult = makeNesTileTokenFrame(firstTileFrame, tokenizer);
+    ASSERT_TRUE(firstTokenFrameResult.isValue()) << firstTokenFrameResult.errorValue();
+    const auto stableToken = firstTokenFrameResult.value().tokens[0u];
+
+    NesTileFrame secondTileFrame = makeTileFrame(2u, 8u, 0u, hashForIndex(12u));
+    secondTileFrame.tilePatternHashes[5u] = hashForIndex(11u);
+    const auto secondTokenFrameResult = makeNesTileTokenFrame(secondTileFrame, tokenizer);
+
+    ASSERT_TRUE(secondTokenFrameResult.isValue()) << secondTokenFrameResult.errorValue();
+    EXPECT_EQ(secondTokenFrameResult.value().tokens[5u], stableToken);
+    EXPECT_NE(secondTokenFrameResult.value().tokens[0u], stableToken);
+}
+
+TEST(NesTileTokenFrameTest, TokenizerOverflowPropagatesAsError)
+{
+    NesTileTokenizer tokenizer(3u);
+    NesTileFrame tileFrame = makeTileFrame(1u, 0u, 0u, hashForIndex(1u));
+    tileFrame.tilePatternHashes[1u] = hashForIndex(2u);
+    tileFrame.tilePatternHashes[2u] = hashForIndex(3u);
+
+    const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+
+    ASSERT_TRUE(tokenFrameResult.isError());
+    EXPECT_NE(tokenFrameResult.errorValue().find("cell 2"), std::string::npos);
+    EXPECT_NE(tokenFrameResult.errorValue().find("vocabulary exhausted"), std::string::npos);
+}

--- a/apps/src/core/scenarios/tests/NesTileTokenFrame_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenFrame_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 
 using namespace DirtSim;
 
@@ -46,6 +47,29 @@ TEST(NesTileTokenFrameTest, BuildsTokenFrameAndPreservesMetadata)
     EXPECT_NE(tokenFrame.tokens[0u], NesTileTokenizer::VoidToken);
 }
 
+TEST(NesTileTokenFrameTest, FrozenVocabularyUsesDeterministicTokenIds)
+{
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 30u, 10u, 20u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    NesTileFrame tileFrame = makeTileFrame(44u, 12u, 96u, 20u);
+    tileFrame.tilePatternHashes[0u] = 30u;
+    tileFrame.tilePatternHashes[1u] = 10u;
+    tileFrame.tilePatternHashes[2u] = 30u;
+
+    const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+
+    ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
+    const NesTileTokenFrame& tokenFrame = tokenFrameResult.value();
+    EXPECT_EQ(tokenFrame.tokens[0u], 3u);
+    EXPECT_EQ(tokenFrame.tokens[1u], 1u);
+    EXPECT_EQ(tokenFrame.tokens[2u], 3u);
+    EXPECT_EQ(tokenFrame.tokens[3u], 2u);
+}
+
 TEST(NesTileTokenFrameTest, ReappearingHashesKeepStableTokensAcrossFrames)
 {
     NesTileTokenizer tokenizer;
@@ -62,6 +86,24 @@ TEST(NesTileTokenFrameTest, ReappearingHashesKeepStableTokensAcrossFrames)
     ASSERT_TRUE(secondTokenFrameResult.isValue()) << secondTokenFrameResult.errorValue();
     EXPECT_EQ(secondTokenFrameResult.value().tokens[5u], stableToken);
     EXPECT_NE(secondTokenFrameResult.value().tokens[0u], stableToken);
+}
+
+TEST(NesTileTokenFrameTest, FrozenTokenizerUnknownHashPropagatesAsError)
+{
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    NesTileFrame tileFrame = makeTileFrame(1u, 0u, 0u, 10u);
+    tileFrame.tilePatternHashes[2u] = 20u;
+
+    const auto tokenFrameResult = makeNesTileTokenFrame(tileFrame, tokenizer);
+
+    ASSERT_TRUE(tokenFrameResult.isError());
+    EXPECT_NE(tokenFrameResult.errorValue().find("cell 2"), std::string::npos);
+    EXPECT_NE(tokenFrameResult.errorValue().find("Frozen vocabulary missing"), std::string::npos);
 }
 
 TEST(NesTileTokenFrameTest, TokenizerOverflowPropagatesAsError)

--- a/apps/src/core/scenarios/tests/NesTileTokenizerBootstrapper_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenizerBootstrapper_test.cpp
@@ -1,0 +1,52 @@
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
+
+#include "core/scenarios/nes/NesTileTokenizer.h"
+#include "core/scenarios/tests/NesTestRomPath.h"
+
+#include <gtest/gtest.h>
+
+using namespace DirtSim;
+
+TEST(NesTileTokenizerBootstrapperTest, RejectsNonPositiveBootstrapFrameCount)
+{
+    const auto result = NesTileTokenizerBootstrapper::build(
+        Scenario::EnumType::NesFlappyParatroopa,
+        std::nullopt,
+        NesTileTokenizerBootstrapper::Config{ .bootstrapFrames = 0 });
+
+    ASSERT_TRUE(result.isError());
+    EXPECT_NE(result.errorValue().find("bootstrapFrames must be positive"), std::string::npos);
+}
+
+TEST(NesTileTokenizerBootstrapperTest, RejectsScenarioConfigMismatch)
+{
+    Config::NesSuperMarioBros smbConfig = std::get<Config::NesSuperMarioBros>(
+        makeDefaultConfig(Scenario::EnumType::NesSuperMarioBros));
+
+    const auto result = NesTileTokenizerBootstrapper::build(
+        Scenario::EnumType::NesFlappyParatroopa, ScenarioConfig{ smbConfig });
+
+    ASSERT_TRUE(result.isError());
+    EXPECT_NE(result.errorValue().find("config rejected"), std::string::npos);
+}
+
+TEST(NesTileTokenizerBootstrapperTest, BuildsFrozenTokenizerFromRuntime)
+{
+    const auto romPath = DirtSim::Test::resolveFlappyRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing for NES tile tokenizer bootstrapper test.";
+    }
+
+    Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
+        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
+    nesConfig.romPath = romPath.value().string();
+    nesConfig.requireSmolnesMapper = true;
+
+    auto result = NesTileTokenizerBootstrapper::build(
+        Scenario::EnumType::NesFlappyParatroopa, ScenarioConfig{ nesConfig });
+
+    ASSERT_TRUE(result.isValue()) << result.errorValue();
+    ASSERT_NE(result.value(), nullptr);
+    EXPECT_EQ(result.value()->getMode(), NesTileTokenizer::Mode::Frozen);
+    EXPECT_GT(result.value()->getMappedHashCount(), 0u);
+}

--- a/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
@@ -1,0 +1,130 @@
+#include "core/scenarios/nes/NesTileTokenizer.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+
+using namespace DirtSim;
+
+namespace {
+
+NesTileTokenizer::TilePatternHash hashForIndex(uint64_t index)
+{
+    return 0x9E3779B97F4A7C15ull ^ (index * 0x100000001B3ull);
+}
+
+} // namespace
+
+TEST(NesTileTokenizerTest, VoidMapsToZero)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto tokenResult = tokenizer.tokenForHash(std::nullopt);
+
+    ASSERT_TRUE(tokenResult.isValue()) << tokenResult.errorValue();
+    EXPECT_EQ(tokenResult.value(), NesTileTokenizer::VoidToken);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 0u);
+}
+
+TEST(NesTileTokenizerTest, RepeatedHashGetsSameToken)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto firstTokenResult = tokenizer.tokenForHash(hashForIndex(1u));
+    const auto secondTokenResult = tokenizer.tokenForHash(hashForIndex(1u));
+
+    ASSERT_TRUE(firstTokenResult.isValue()) << firstTokenResult.errorValue();
+    ASSERT_TRUE(secondTokenResult.isValue()) << secondTokenResult.errorValue();
+    EXPECT_EQ(firstTokenResult.value(), secondTokenResult.value());
+    EXPECT_NE(firstTokenResult.value(), NesTileTokenizer::VoidToken);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 1u);
+}
+
+TEST(NesTileTokenizerTest, DistinctHashesGetDistinctTokens)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto firstTokenResult = tokenizer.tokenForHash(hashForIndex(1u));
+    const auto secondTokenResult = tokenizer.tokenForHash(hashForIndex(2u));
+    const auto thirdTokenResult = tokenizer.tokenForHash(hashForIndex(3u));
+
+    ASSERT_TRUE(firstTokenResult.isValue()) << firstTokenResult.errorValue();
+    ASSERT_TRUE(secondTokenResult.isValue()) << secondTokenResult.errorValue();
+    ASSERT_TRUE(thirdTokenResult.isValue()) << thirdTokenResult.errorValue();
+    EXPECT_NE(firstTokenResult.value(), secondTokenResult.value());
+    EXPECT_NE(firstTokenResult.value(), thirdTokenResult.value());
+    EXPECT_NE(secondTokenResult.value(), thirdTokenResult.value());
+}
+
+TEST(NesTileTokenizerTest, ResetClearsMapping)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto firstTokenResult = tokenizer.tokenForHash(hashForIndex(1u));
+    ASSERT_TRUE(firstTokenResult.isValue()) << firstTokenResult.errorValue();
+    tokenizer.reset();
+
+    const auto secondTokenResult = tokenizer.tokenForHash(hashForIndex(1u));
+
+    ASSERT_TRUE(secondTokenResult.isValue()) << secondTokenResult.errorValue();
+    EXPECT_EQ(firstTokenResult.value(), 1u);
+    EXPECT_EQ(secondTokenResult.value(), 1u);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 1u);
+}
+
+TEST(NesTileTokenizerTest, SameHashAcrossDifferentFramesStaysStable)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto frameOneTokenResult = tokenizer.tokenForHash(hashForIndex(10u));
+    const auto frameOneNewTokenResult = tokenizer.tokenForHash(hashForIndex(11u));
+    const auto frameTwoTokenResult = tokenizer.tokenForHash(hashForIndex(10u));
+    const auto frameTwoNewTokenResult = tokenizer.tokenForHash(hashForIndex(12u));
+    const auto frameThreeTokenResult = tokenizer.tokenForHash(hashForIndex(10u));
+
+    ASSERT_TRUE(frameOneTokenResult.isValue()) << frameOneTokenResult.errorValue();
+    ASSERT_TRUE(frameOneNewTokenResult.isValue()) << frameOneNewTokenResult.errorValue();
+    ASSERT_TRUE(frameTwoTokenResult.isValue()) << frameTwoTokenResult.errorValue();
+    ASSERT_TRUE(frameTwoNewTokenResult.isValue()) << frameTwoNewTokenResult.errorValue();
+    ASSERT_TRUE(frameThreeTokenResult.isValue()) << frameThreeTokenResult.errorValue();
+    EXPECT_EQ(frameOneTokenResult.value(), frameTwoTokenResult.value());
+    EXPECT_EQ(frameOneTokenResult.value(), frameThreeTokenResult.value());
+    EXPECT_NE(frameOneTokenResult.value(), frameOneNewTokenResult.value());
+    EXPECT_NE(frameOneTokenResult.value(), frameTwoNewTokenResult.value());
+}
+
+TEST(NesTileTokenizerTest, OverflowIsExplicit)
+{
+    NesTileTokenizer tokenizer(4u);
+
+    EXPECT_TRUE(tokenizer.tokenForHash(hashForIndex(1u)).isValue());
+    EXPECT_TRUE(tokenizer.tokenForHash(hashForIndex(2u)).isValue());
+    EXPECT_TRUE(tokenizer.tokenForHash(hashForIndex(3u)).isValue());
+
+    const auto overflowResult = tokenizer.tokenForHash(hashForIndex(4u));
+
+    ASSERT_TRUE(overflowResult.isError());
+    EXPECT_NE(overflowResult.errorValue().find("vocabulary exhausted"), std::string::npos);
+}
+
+TEST(NesTileTokenizerTest, TileIdTokenRemapCollapsesEquivalentPatterns)
+{
+    NesTileTokenizer tokenizer;
+    NesTileTokenizer::TileIdPatternHashTable tilePatternHashes{};
+    for (size_t i = 0; i < tilePatternHashes.size(); ++i) {
+        tilePatternHashes[i] = hashForIndex(static_cast<uint64_t>(i));
+    }
+    tilePatternHashes[3u] = hashForIndex(1234u);
+    tilePatternHashes[7u] = hashForIndex(1234u);
+
+    const auto remapResult = tokenizer.tileIdTokenRemapBuild(tilePatternHashes);
+
+    ASSERT_TRUE(remapResult.isValue()) << remapResult.errorValue();
+    const auto& remap = remapResult.value();
+    EXPECT_EQ(remap[3u], remap[7u]);
+    EXPECT_NE(remap[3u], NesTileTokenizer::VoidToken);
+    EXPECT_NE(remap[2u], remap[3u]);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 255u);
+}

--- a/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 using namespace DirtSim;
 
@@ -58,6 +59,61 @@ TEST(NesTileTokenizerTest, DistinctHashesGetDistinctTokens)
     EXPECT_NE(secondTokenResult.value(), thirdTokenResult.value());
 }
 
+TEST(NesTileTokenizerTest, BuildVocabularyAssignsTokensBySortedHash)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto buildResult = tokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>{
+            30u,
+            10u,
+            20u,
+        });
+
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    EXPECT_EQ(buildResult.value(), 3u);
+    EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Learning);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 3u);
+    EXPECT_EQ(tokenizer.tokenForHash(10u).value(), 1u);
+    EXPECT_EQ(tokenizer.tokenForHash(20u).value(), 2u);
+    EXPECT_EQ(tokenizer.tokenForHash(30u).value(), 3u);
+}
+
+TEST(NesTileTokenizerTest, BuildVocabularyIsIndependentOfInputOrder)
+{
+    NesTileTokenizer firstTokenizer;
+    NesTileTokenizer secondTokenizer;
+
+    const auto firstBuildResult = firstTokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>{ 30u, 10u, 20u });
+    const auto secondBuildResult = secondTokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>{ 20u, 30u, 10u });
+
+    ASSERT_TRUE(firstBuildResult.isValue()) << firstBuildResult.errorValue();
+    ASSERT_TRUE(secondBuildResult.isValue()) << secondBuildResult.errorValue();
+    EXPECT_EQ(firstTokenizer.tokenForHash(10u).value(), secondTokenizer.tokenForHash(10u).value());
+    EXPECT_EQ(firstTokenizer.tokenForHash(20u).value(), secondTokenizer.tokenForHash(20u).value());
+    EXPECT_EQ(firstTokenizer.tokenForHash(30u).value(), secondTokenizer.tokenForHash(30u).value());
+}
+
+TEST(NesTileTokenizerTest, BuildVocabularyCollapsesDuplicateHashes)
+{
+    NesTileTokenizer tokenizer;
+
+    const auto buildResult = tokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>{
+            20u,
+            10u,
+            20u,
+            10u,
+        });
+
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    EXPECT_EQ(buildResult.value(), 2u);
+    EXPECT_EQ(tokenizer.tokenForHash(10u).value(), 1u);
+    EXPECT_EQ(tokenizer.tokenForHash(20u).value(), 2u);
+}
+
 TEST(NesTileTokenizerTest, ResetClearsMapping)
 {
     NesTileTokenizer tokenizer;
@@ -71,6 +127,7 @@ TEST(NesTileTokenizerTest, ResetClearsMapping)
     ASSERT_TRUE(secondTokenResult.isValue()) << secondTokenResult.errorValue();
     EXPECT_EQ(firstTokenResult.value(), 1u);
     EXPECT_EQ(secondTokenResult.value(), 1u);
+    EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Learning);
     EXPECT_EQ(tokenizer.getMappedHashCount(), 1u);
 }
 
@@ -107,6 +164,40 @@ TEST(NesTileTokenizerTest, OverflowIsExplicit)
 
     ASSERT_TRUE(overflowResult.isError());
     EXPECT_NE(overflowResult.errorValue().find("vocabulary exhausted"), std::string::npos);
+}
+
+TEST(NesTileTokenizerTest, BuildVocabularyOverflowIsExplicit)
+{
+    NesTileTokenizer tokenizer(4u);
+
+    const auto buildResult = tokenizer.buildVocabulary(
+        std::vector<NesTileTokenizer::TilePatternHash>{
+            10u,
+            20u,
+            30u,
+            40u,
+        });
+
+    ASSERT_TRUE(buildResult.isError());
+    EXPECT_NE(buildResult.errorValue().find("vocabulary exhausted"), std::string::npos);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 0u);
+}
+
+TEST(NesTileTokenizerTest, FrozenTokenizerRejectsUnknownHash)
+{
+    NesTileTokenizer tokenizer;
+    const auto buildResult =
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u, 20u });
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    tokenizer.freeze();
+
+    const auto knownTokenResult = tokenizer.tokenForHash(20u);
+    const auto unknownTokenResult = tokenizer.tokenForHash(30u);
+
+    ASSERT_TRUE(knownTokenResult.isValue()) << knownTokenResult.errorValue();
+    EXPECT_EQ(knownTokenResult.value(), 2u);
+    ASSERT_TRUE(unknownTokenResult.isError());
+    EXPECT_NE(unknownTokenResult.errorValue().find("Frozen vocabulary missing"), std::string::npos);
 }
 
 TEST(NesTileTokenizerTest, TileIdTokenRemapCollapsesEquivalentPatterns)

--- a/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileTokenizer_test.cpp
@@ -1,3 +1,5 @@
+#include "core/scenarios/nes/NesTileBrainMetadata.h"
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
 
 #include <array>
@@ -94,6 +96,89 @@ TEST(NesTileTokenizerTest, BuildVocabularyIsIndependentOfInputOrder)
     EXPECT_EQ(firstTokenizer.tokenForHash(10u).value(), secondTokenizer.tokenForHash(10u).value());
     EXPECT_EQ(firstTokenizer.tokenForHash(20u).value(), secondTokenizer.tokenForHash(20u).value());
     EXPECT_EQ(firstTokenizer.tokenForHash(30u).value(), secondTokenizer.tokenForHash(30u).value());
+}
+
+TEST(NesTileTokenizerTest, VocabularyHashIsDeterministic)
+{
+    NesTileTokenizer firstTokenizer;
+    NesTileTokenizer secondTokenizer;
+    NesTileTokenizer differentTokenizer;
+
+    ASSERT_TRUE(
+        firstTokenizer
+            .buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 30u, 10u, 20u })
+            .isValue());
+    ASSERT_TRUE(
+        secondTokenizer
+            .buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 20u, 30u, 10u })
+            .isValue());
+    ASSERT_TRUE(
+        differentTokenizer
+            .buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 20u, 30u, 40u })
+            .isValue());
+    firstTokenizer.freeze();
+    secondTokenizer.freeze();
+    differentTokenizer.freeze();
+
+    EXPECT_EQ(firstTokenizer.getVocabularyHash(), secondTokenizer.getVocabularyHash());
+    EXPECT_NE(firstTokenizer.getVocabularyHash(), differentTokenizer.getVocabularyHash());
+}
+
+TEST(NesTileTokenizerTest, BrainCompatibilityMetadataCapturesTileBrainContract)
+{
+    NesTileTokenizer tokenizer;
+    ASSERT_TRUE(
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u, 20u })
+            .isValue());
+    tokenizer.freeze();
+
+    const NesTileBrainCompatibilityMetadata metadata =
+        makeNesTileBrainCompatibilityMetadata(tokenizer);
+
+    EXPECT_EQ(metadata.schemaVersion, NesTileBrainCompatibilityMetadata::CurrentSchemaVersion);
+    EXPECT_EQ(metadata.tileVocabularySize, NesTileRecurrentBrain::TileVocabularySize);
+    EXPECT_EQ(metadata.tileEmbeddingDim, NesTileRecurrentBrain::TileEmbeddingDim);
+    EXPECT_EQ(metadata.scalarInputSize, NesTileRecurrentBrain::ScalarInputSize);
+    EXPECT_EQ(metadata.voidTokenId, NesTileTokenizer::VoidToken);
+    EXPECT_EQ(metadata.tokenizerVocabularyHash, tokenizer.getVocabularyHash());
+}
+
+TEST(NesTileTokenizerTest, BrainCompatibilityMetadataRejectsMismatchedTokenizerHash)
+{
+    NesTileTokenizer tokenizer;
+    ASSERT_TRUE(
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u, 20u })
+            .isValue());
+    tokenizer.freeze();
+
+    const NesTileBrainCompatibilityMetadata expected =
+        makeNesTileBrainCompatibilityMetadata(tokenizer);
+    NesTileBrainCompatibilityMetadata actual = expected;
+    actual.tokenizerVocabularyHash = "different";
+
+    const auto validation = validateNesTileBrainCompatibilityMetadata(actual, expected);
+
+    ASSERT_TRUE(validation.isError());
+    EXPECT_NE(validation.errorValue().find("tokenizerVocabularyHash"), std::string::npos);
+}
+
+TEST(NesTileTokenizerTest, BrainCompatibilityMetadataRejectsMismatchedWindowShape)
+{
+    NesTileTokenizer tokenizer;
+    ASSERT_TRUE(
+        tokenizer.buildVocabulary(std::vector<NesTileTokenizer::TilePatternHash>{ 10u, 20u })
+            .isValue());
+    tokenizer.freeze();
+
+    const NesTileBrainCompatibilityMetadata expected =
+        makeNesTileBrainCompatibilityMetadata(tokenizer);
+    NesTileBrainCompatibilityMetadata actual = expected;
+    actual.relativeTileColumns += 1;
+
+    const auto validation = validateNesTileBrainCompatibilityMetadata(actual, expected);
+
+    ASSERT_TRUE(validation.isError());
+    EXPECT_NE(validation.errorValue().find("relativeTileColumns"), std::string::npos);
 }
 
 TEST(NesTileTokenizerTest, BuildVocabularyCollapsesDuplicateHashes)

--- a/apps/src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
@@ -1,0 +1,137 @@
+#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
+
+#include "core/scenarios/nes/NesTileFrame.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace DirtSim;
+
+namespace {
+
+NesTileFrame makeTileFrame(std::vector<uint64_t> hashes)
+{
+    NesTileFrame frame;
+    frame.tilePatternHashes.fill(10u);
+    for (size_t i = 0; i < hashes.size() && i < frame.tilePatternHashes.size(); ++i) {
+        frame.tilePatternHashes[i] = hashes[i];
+    }
+    return frame;
+}
+
+void setSolidTilePattern(NesPpuSnapshot& snapshot, uint8_t tileId, uint8_t color)
+{
+    const size_t base = static_cast<size_t>(tileId) * 16u;
+    const uint8_t lo = (color & 0x01u) != 0u ? 0xFFu : 0x00u;
+    const uint8_t hi = (color & 0x02u) != 0u ? 0xFFu : 0x00u;
+    for (size_t row = 0; row < 8u; ++row) {
+        snapshot.chr[base + row] = lo;
+        snapshot.chr[base + 8u + row] = hi;
+    }
+}
+
+size_t visibleTileCount()
+{
+    return static_cast<size_t>(NesTileFrame::VisibleTileColumns) * NesTileFrame::VisibleTileRows;
+}
+
+} // namespace
+
+TEST(NesTileVocabularyBuilderTest, BuildsDeterministicTokensRegardlessOfSampleOrder)
+{
+    NesTileVocabularyBuilder firstBuilder;
+    firstBuilder.addFrame(makeTileFrame({ 30u, 10u }));
+    firstBuilder.addFrame(makeTileFrame({ 20u, 10u }));
+
+    NesTileVocabularyBuilder secondBuilder;
+    secondBuilder.addFrame(makeTileFrame({ 20u, 10u }));
+    secondBuilder.addFrame(makeTileFrame({ 30u, 10u }));
+
+    auto firstTokenizerResult = firstBuilder.buildFrozenTokenizer();
+    auto secondTokenizerResult = secondBuilder.buildFrozenTokenizer();
+
+    ASSERT_TRUE(firstTokenizerResult.isValue()) << firstTokenizerResult.errorValue();
+    ASSERT_TRUE(secondTokenizerResult.isValue()) << secondTokenizerResult.errorValue();
+    NesTileTokenizer& firstTokenizer = firstTokenizerResult.value();
+    NesTileTokenizer& secondTokenizer = secondTokenizerResult.value();
+    EXPECT_EQ(firstTokenizer.getMode(), NesTileTokenizer::Mode::Frozen);
+    EXPECT_EQ(secondTokenizer.getMode(), NesTileTokenizer::Mode::Frozen);
+    EXPECT_EQ(firstTokenizer.tokenForHash(10u).value(), secondTokenizer.tokenForHash(10u).value());
+    EXPECT_EQ(firstTokenizer.tokenForHash(20u).value(), secondTokenizer.tokenForHash(20u).value());
+    EXPECT_EQ(firstTokenizer.tokenForHash(30u).value(), secondTokenizer.tokenForHash(30u).value());
+}
+
+TEST(NesTileVocabularyBuilderTest, DuplicatePatternsCollapse)
+{
+    NesTileVocabularyBuilder builder;
+    builder.addFrame(makeTileFrame({ 20u, 10u, 20u, 10u }));
+
+    NesTileTokenizer tokenizer;
+    const auto buildResult = builder.buildFrozenTokenizer(tokenizer);
+
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    EXPECT_EQ(buildResult.value().sampledTileCount, visibleTileCount());
+    EXPECT_EQ(buildResult.value().uniquePatternCount, 2u);
+    EXPECT_EQ(tokenizer.getMappedHashCount(), 2u);
+}
+
+TEST(NesTileVocabularyBuilderTest, BuildsFromPpuSnapshot)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    snapshot.vram[32u] = 1u;
+
+    NesTileVocabularyBuilder builder;
+    builder.addSnapshot(snapshot);
+
+    NesTileTokenizer tokenizer;
+    const auto buildResult = builder.buildFrozenTokenizer(tokenizer);
+
+    ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
+    EXPECT_EQ(buildResult.value().sampledTileCount, visibleTileCount());
+    EXPECT_EQ(buildResult.value().uniquePatternCount, 2u);
+    EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Frozen);
+}
+
+TEST(NesTileVocabularyBuilderTest, OverflowFailsClearly)
+{
+    NesTileVocabularyBuilder builder;
+    builder.addFrame(makeTileFrame({ 10u, 20u }));
+
+    NesTileTokenizer tokenizer(2u);
+    const auto buildResult = builder.buildFrozenTokenizer(tokenizer);
+
+    ASSERT_TRUE(buildResult.isError());
+    EXPECT_NE(buildResult.errorValue().find("Failed to build vocabulary"), std::string::npos);
+    EXPECT_NE(buildResult.errorValue().find("vocabulary exhausted"), std::string::npos);
+    EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Learning);
+}
+
+TEST(NesTileVocabularyBuilderTest, FrozenTokenizerRejectsUnseenHashes)
+{
+    NesTileVocabularyBuilder builder;
+    builder.addFrame(makeTileFrame({ 10u, 20u }));
+
+    auto tokenizerResult = builder.buildFrozenTokenizer();
+
+    ASSERT_TRUE(tokenizerResult.isValue()) << tokenizerResult.errorValue();
+    NesTileTokenizer& tokenizer = tokenizerResult.value();
+    EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Frozen);
+    const auto unknownResult = tokenizer.tokenForHash(30u);
+    ASSERT_TRUE(unknownResult.isError());
+    EXPECT_NE(unknownResult.errorValue().find("Frozen vocabulary missing"), std::string::npos);
+}
+
+TEST(NesTileVocabularyBuilderTest, RejectsEmptySamples)
+{
+    NesTileVocabularyBuilder builder;
+    NesTileTokenizer tokenizer;
+
+    const auto buildResult = builder.buildFrozenTokenizer(tokenizer);
+
+    ASSERT_TRUE(buildResult.isError());
+    EXPECT_NE(buildResult.errorValue().find("without tile samples"), std::string::npos);
+}

--- a/apps/src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
+++ b/apps/src/core/scenarios/tests/NesTileVocabularyBuilder_test.cpp
@@ -1,6 +1,7 @@
 #include "core/scenarios/nes/NesTileVocabularyBuilder.h"
 
 #include "core/scenarios/nes/NesTileFrame.h"
+#include "core/scenarios/nes/NesTileTokenFrame.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -35,6 +36,11 @@ void setSolidTilePattern(NesPpuSnapshot& snapshot, uint8_t tileId, uint8_t color
 size_t visibleTileCount()
 {
     return static_cast<size_t>(NesTileFrame::VisibleTileColumns) * NesTileFrame::VisibleTileRows;
+}
+
+size_t snapshotTileSampleCount()
+{
+    return visibleTileCount() + 256u;
 }
 
 } // namespace
@@ -91,9 +97,32 @@ TEST(NesTileVocabularyBuilderTest, BuildsFromPpuSnapshot)
     const auto buildResult = builder.buildFrozenTokenizer(tokenizer);
 
     ASSERT_TRUE(buildResult.isValue()) << buildResult.errorValue();
-    EXPECT_EQ(buildResult.value().sampledTileCount, visibleTileCount());
+    EXPECT_EQ(buildResult.value().sampledTileCount, snapshotTileSampleCount());
     EXPECT_EQ(buildResult.value().uniquePatternCount, 2u);
     EXPECT_EQ(tokenizer.getMode(), NesTileTokenizer::Mode::Frozen);
+}
+
+TEST(NesTileVocabularyBuilderTest, SnapshotVocabularyCoversTilesBeforeTheyBecomeVisible)
+{
+    NesPpuSnapshot snapshot;
+    snapshot.mirror = 2u;
+    setSolidTilePattern(snapshot, 1u, 1u);
+    setSolidTilePattern(snapshot, 7u, 2u);
+    snapshot.vram[32u] = 1u;
+
+    NesTileVocabularyBuilder builder;
+    builder.addSnapshot(snapshot);
+
+    auto tokenizerResult = builder.buildFrozenTokenizer();
+    ASSERT_TRUE(tokenizerResult.isValue()) << tokenizerResult.errorValue();
+
+    NesPpuSnapshot laterSnapshot = snapshot;
+    laterSnapshot.vram[33u] = 7u;
+    const NesTileFrame laterFrame = makeNesTileFrame(laterSnapshot);
+    const auto tokenFrameResult = makeNesTileTokenFrame(laterFrame, tokenizerResult.value());
+
+    ASSERT_TRUE(tokenFrameResult.isValue()) << tokenFrameResult.errorValue();
+    EXPECT_NE(tokenFrameResult.value().tokens[1u], NesTileTokenizer::VoidToken);
 }
 
 TEST(NesTileVocabularyBuilderTest, OverflowFailsClearly)

--- a/apps/src/core/scenarios/tests/SmolnesRuntime_test.cpp
+++ b/apps/src/core/scenarios/tests/SmolnesRuntime_test.cpp
@@ -261,3 +261,25 @@ TEST(SmolnesRuntimeTest, SpriteMaskDisablesSpritePixelsAndSpriteZeroHit)
     EXPECT_TRUE(spritesEnabled.sawSpritePalette);
     EXPECT_EQ(spritesEnabled.spriteHitResult, 1u);
 }
+
+TEST(SmolnesRuntimeTest, CopyPpuSnapshotProvidesChrAndNametableState)
+{
+    const std::filesystem::path romPath = writeSpriteMaskTestRom("smolnes_ppu_snapshot", true);
+
+    SmolnesRuntime runtime;
+    ASSERT_TRUE(runtime.start(romPath.string())) << runtime.getLastError();
+    runtime.setApuEnabled(false);
+    ASSERT_TRUE(runtime.runFrames(3u, 2000u)) << runtime.getLastError();
+
+    const auto snapshot = runtime.copyPpuSnapshot();
+    runtime.stop();
+
+    ASSERT_TRUE(snapshot.has_value());
+    EXPECT_GT(snapshot->frameId, 0u);
+    EXPECT_EQ(snapshot->chr.size(), NesPpuSnapshot::ChrBytes);
+    EXPECT_EQ(snapshot->oam.size(), NesPpuSnapshot::OamBytes);
+    EXPECT_EQ(snapshot->vram.size(), NesPpuSnapshot::VramBytes);
+    EXPECT_TRUE(std::any_of(snapshot->chr.begin(), snapshot->chr.end(), [](uint8_t value) {
+        return value != 0u;
+    }));
+}

--- a/apps/src/server/StateMachine.cpp
+++ b/apps/src/server/StateMachine.cpp
@@ -243,6 +243,11 @@ UserSettings sanitizeUserSettings(
         recordUpdate("uiTraining.bestPlaybackIntervalMs clamped to 1");
     }
 
+    if (!isNesTileDebugViewValid(settings.uiTraining.nesTileDebugView)) {
+        settings.uiTraining.nesTileDebugView = NesTileDebugView::NormalVideo;
+        recordUpdate("uiTraining.nesTileDebugView reset to NormalVideo");
+    }
+
     if (settings.trainingResumePolicy > TrainingResumePolicy::WarmFromBest) {
         settings.trainingResumePolicy = TrainingResumePolicy::WarmFromBest;
         recordUpdate("trainingResumePolicy reset to WarmFromBest");

--- a/apps/src/server/StateMachine.cpp
+++ b/apps/src/server/StateMachine.cpp
@@ -1673,6 +1673,8 @@ void StateMachine::handleEvent(const Event& event)
                 .brainKind = std::nullopt,
                 .brainVariant = std::nullopt,
                 .trainingSessionId = std::nullopt,
+                .genomePoolId = GenomePoolId::DirtSim,
+                .nesTileBrainCompatibility = std::nullopt,
             });
 
         repo.store(cwc.command.id, genome, meta);

--- a/apps/src/server/StateMachine.cpp
+++ b/apps/src/server/StateMachine.cpp
@@ -628,7 +628,16 @@ void applyScenarioConfigUpdatesToActiveState(
                     }
                 }
 
-                if (state.bestPlayback_.runner && state.bestPlayback_.individual.has_value()
+                if (state.bestPlayback_.individual.has_value()
+                    && state.bestPlayback_.individual.value().scenarioId
+                        == state.trainingSpec.scenarioId
+                    && state.bestPlayback_.individual.value().brainKind
+                        == TrainingBrainKind::NesTileRecurrent) {
+                    state.bestPlayback_.clearRunner();
+                    state.bestPlayback_.nesTileTokenizer.reset();
+                }
+                else if (
+                    state.bestPlayback_.runner && state.bestPlayback_.individual.has_value()
                     && state.bestPlayback_.individual.value().scenarioId
                         == state.trainingSpec.scenarioId) {
                     const auto result = state.bestPlayback_.runner->setScenarioConfig(*config);

--- a/apps/src/server/UserSettings.h
+++ b/apps/src/server/UserSettings.h
@@ -8,6 +8,7 @@
 #include "core/scenarios/RainingConfig.h"
 #include "core/scenarios/SandboxConfig.h"
 #include "core/scenarios/TreeGerminationConfig.h"
+#include "core/scenarios/nes/NesTileDebugView.h"
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 #include <zpp_bits.h>
@@ -25,8 +26,9 @@ struct UiTrainingConfig {
     bool bestPlaybackEnabled = false;
     int bestPlaybackIntervalMs = 16;
     std::optional<bool> nesControllerOverlayEnabled = std::nullopt;
+    NesTileDebugView nesTileDebugView = NesTileDebugView::NormalVideo;
 
-    using serialize = zpp::bits::members<4>;
+    using serialize = zpp::bits::members<5>;
 };
 
 struct NesSessionSettings {

--- a/apps/src/server/evolution/EvaluationExecutor.cpp
+++ b/apps/src/server/evolution/EvaluationExecutor.cpp
@@ -854,8 +854,10 @@ void EvaluationExecutor::generationBatchSubmit(
 
     std::vector<QueuedEvaluation> queuedEvaluations;
     queuedEvaluations.reserve(requests.size());
-    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer;
-    std::optional<Scenario::EnumType> sharedNesTileScenarioId = std::nullopt;
+    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer = impl_->config.nesTileTokenizer;
+    std::optional<Scenario::EnumType> sharedNesTileScenarioId = sharedNesTileTokenizer
+        ? std::optional<Scenario::EnumType>(impl_->config.trainingSpec.scenarioId)
+        : std::nullopt;
     for (const auto& request : requests) {
         auto nesTileTokenizer = resolveNesTileTokenizerForQueuedRequest(
             request, scenarioConfigOverride, sharedNesTileTokenizer, sharedNesTileScenarioId);
@@ -892,8 +894,10 @@ void EvaluationExecutor::robustnessPassSubmit(
 
     std::vector<QueuedEvaluation> queuedEvaluations;
     queuedEvaluations.reserve(static_cast<size_t>(resolvedEvalCount));
-    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer;
-    std::optional<Scenario::EnumType> sharedNesTileScenarioId = std::nullopt;
+    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer = impl_->config.nesTileTokenizer;
+    std::optional<Scenario::EnumType> sharedNesTileScenarioId = sharedNesTileTokenizer
+        ? std::optional<Scenario::EnumType>(impl_->config.trainingSpec.scenarioId)
+        : std::nullopt;
     for (int sampleOrdinal = 1; sampleOrdinal <= resolvedEvalCount; ++sampleOrdinal) {
         EvaluationRequest sampleRequest = request;
         sampleRequest.robustSampleOrdinal = sampleOrdinal;
@@ -936,6 +940,7 @@ std::optional<std::string> EvaluationExecutor::scenarioConfigOverrideSet(
                 return tokenizerResult.errorValue();
             }
             sharedNesTileTokenizer = std::move(tokenizerResult).value();
+            impl_->config.nesTileTokenizer = sharedNesTileTokenizer;
         }
 
         for (auto& queued : impl_->taskQueue) {

--- a/apps/src/server/evolution/EvaluationExecutor.cpp
+++ b/apps/src/server/evolution/EvaluationExecutor.cpp
@@ -7,6 +7,11 @@
 #include "core/organisms/evolution/FitnessResult.h"
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingRunner.h"
+#include "core/scenarios/nes/NesGameAdapter.h"
+#include "core/scenarios/nes/NesGameAdapterRegistry.h"
+#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
 
 #include <algorithm>
 #include <array>
@@ -14,6 +19,7 @@
 #include <cmath>
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -22,10 +28,124 @@ namespace DirtSim::Server::EvolutionSupport {
 namespace {
 
 constexpr size_t kTopCommandSignatureLimit = 20;
+constexpr int kNesTileVocabularyBootstrapFrames = 16;
 
 bool isDuckClockScenario(OrganismType organismType, Scenario::EnumType scenarioId)
 {
     return organismType == OrganismType::DUCK && scenarioId == Scenario::EnumType::Clock;
+}
+
+bool requiresNesTileTokenizer(const EvaluationIndividual& individual)
+{
+    return individual.brainKind == TrainingBrainKind::NesTileRecurrent;
+}
+
+Result<std::shared_ptr<NesTileTokenizer>, std::string> buildNesTileTokenizerForEvaluation(
+    Scenario::EnumType scenarioId, const std::optional<ScenarioConfig>& scenarioConfigOverride)
+{
+    NesSmolnesScenarioDriver driver(scenarioId);
+    if (scenarioConfigOverride.has_value()) {
+        const auto configResult = driver.setConfig(scenarioConfigOverride.value());
+        if (configResult.isError()) {
+            return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+                "EvaluationExecutor: NES tile tokenizer config rejected: "
+                + configResult.errorValue());
+        }
+    }
+
+    const auto setupResult = driver.setup();
+    if (setupResult.isError()) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "EvaluationExecutor: NES tile tokenizer runtime setup failed: "
+            + setupResult.errorValue());
+    }
+
+    auto adapter = NesGameAdapterRegistry::createDefault().createAdapter(scenarioId);
+    if (!adapter) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "EvaluationExecutor: Missing NES game adapter for tile tokenizer bootstrap");
+    }
+    adapter->reset(driver.getRuntimeResolvedRomId());
+
+    NesTileVocabularyBuilder builder;
+    Timers timers;
+    std::optional<uint8_t> lastGameState = std::nullopt;
+
+    for (int frameIndex = 0; frameIndex < kNesTileVocabularyBootstrapFrames; ++frameIndex) {
+        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
+            builder.addSnapshot(snapshot.value());
+        }
+
+        const NesGameAdapterControllerOutput controllerOutput = adapter->resolveControllerMask(
+            NesGameAdapterControllerInput{ .inferredControllerMask = 0,
+                                           .lastGameState = lastGameState });
+        auto stepResult = driver.step(timers, controllerOutput.resolvedControllerMask);
+        if (!stepResult.runtimeHealthy || !stepResult.runtimeRunning) {
+            if (builder.getSampledTileCount() == 0) {
+                return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+                    "EvaluationExecutor: NES tile tokenizer runtime stopped before samples: "
+                    + stepResult.lastError);
+            }
+            break;
+        }
+
+        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
+            builder.addSnapshot(snapshot.value());
+        }
+
+        if (stepResult.advancedFrames == 0) {
+            continue;
+        }
+
+        const NesGameAdapterFrameInput frameInput{
+            .advancedFrames = stepResult.advancedFrames,
+            .controllerMask = controllerOutput.resolvedControllerMask,
+            .paletteFrame =
+                stepResult.paletteFrame.has_value() ? &stepResult.paletteFrame.value() : nullptr,
+            .memorySnapshot = std::move(stepResult.memorySnapshot),
+        };
+        const NesGameAdapterFrameOutput frameOutput = adapter->evaluateFrame(frameInput);
+        if (frameOutput.gameState.has_value()) {
+            lastGameState = frameOutput.gameState;
+        }
+        if (frameOutput.done) {
+            break;
+        }
+    }
+
+    auto tokenizer = std::make_shared<NesTileTokenizer>();
+    const auto buildResult = builder.buildFrozenTokenizer(*tokenizer);
+    if (buildResult.isError()) {
+        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
+            "EvaluationExecutor: NES tile tokenizer bootstrap failed: " + buildResult.errorValue());
+    }
+
+    return Result<std::shared_ptr<NesTileTokenizer>, std::string>::okay(std::move(tokenizer));
+}
+
+std::shared_ptr<NesTileTokenizer> resolveNesTileTokenizerForQueuedRequest(
+    const EvaluationRequest& request,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    std::shared_ptr<NesTileTokenizer>& sharedNesTileTokenizer,
+    std::optional<Scenario::EnumType>& sharedNesTileScenarioId)
+{
+    if (!requiresNesTileTokenizer(request.individual)) {
+        return nullptr;
+    }
+
+    if (sharedNesTileTokenizer) {
+        DIRTSIM_ASSERT(
+            sharedNesTileScenarioId == request.individual.scenarioId,
+            "EvaluationExecutor: NES tile tokenizer cannot be shared across scenarios");
+        return sharedNesTileTokenizer;
+    }
+
+    auto tokenizerResult =
+        buildNesTileTokenizerForEvaluation(request.individual.scenarioId, scenarioConfigOverride);
+    DIRTSIM_ASSERT(tokenizerResult.isValue(), tokenizerResult.errorValue());
+    sharedNesTileTokenizer = std::move(tokenizerResult).value();
+    sharedNesTileScenarioId = request.individual.scenarioId;
+    return sharedNesTileTokenizer;
 }
 
 LightMode resolveVisibleLightMode(OrganismType organismType)
@@ -168,6 +288,7 @@ struct EvaluationPassResult {
 struct QueuedEvaluation {
     EvaluationRequest request;
     EvolutionConfig evolutionConfig;
+    std::shared_ptr<NesTileTokenizer> nesTileTokenizer = nullptr;
     std::optional<ScenarioConfig> scenarioConfigOverride = std::nullopt;
 };
 
@@ -248,6 +369,7 @@ std::optional<EvaluationPassResult> runEvaluationPass(
     GenomeRepository& genomeRepository,
     const TrainingBrainRegistry& brainRegistry,
     const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    const std::shared_ptr<NesTileTokenizer>& nesTileTokenizer,
     std::optional<bool> duckClockSpawnLeftFirst,
     const FitnessModelBundle& fitnessModel,
     bool includeGenerationDetails,
@@ -259,6 +381,7 @@ std::optional<EvaluationPassResult> runEvaluationPass(
 {
     const TrainingRunner::Config runnerConfig{
         .brainRegistry = brainRegistry,
+        .nesTileTokenizer = nesTileTokenizer,
         .duckClockSpawnLeftFirst = duckClockSpawnLeftFirst,
         .duckClockSpawnRngSeed = std::nullopt,
         .nesRgbaOutputEnabled = visibleHandle != nullptr,
@@ -612,6 +735,7 @@ std::optional<CompletedEvaluation> runEvaluationTask(
         *impl.config.genomeRepository,
         impl.config.brainRegistry,
         initialQueued.scenarioConfigOverride,
+        initialQueued.nesTileTokenizer,
         primarySpawnSide,
         impl.config.fitnessModel,
         includeGenerationDetails,
@@ -648,6 +772,7 @@ std::optional<CompletedEvaluation> runEvaluationTask(
             *impl.config.genomeRepository,
             impl.config.brainRegistry,
             passQueued.scenarioConfigOverride,
+            passQueued.nesTileTokenizer,
             spawnSide,
             impl.config.fitnessModel,
             includeGenerationDetails,
@@ -673,11 +798,13 @@ std::optional<CompletedEvaluation> runEvaluationTask(
 QueuedEvaluation queuedEvaluationMake(
     const EvaluationRequest& request,
     const EvolutionConfig& evolutionConfig,
-    const std::optional<ScenarioConfig>& scenarioConfigOverride)
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    std::shared_ptr<NesTileTokenizer> nesTileTokenizer = nullptr)
 {
     return QueuedEvaluation{
         .request = request,
         .evolutionConfig = evolutionConfig,
+        .nesTileTokenizer = std::move(nesTileTokenizer),
         .scenarioConfigOverride = scenarioConfigOverride,
     };
 }
@@ -812,13 +939,23 @@ void EvaluationExecutor::generationBatchSubmit(
             "EvaluationExecutor: generation batch submission requires no active preview task");
     }
 
+    std::vector<QueuedEvaluation> queuedEvaluations;
+    queuedEvaluations.reserve(requests.size());
+    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer;
+    std::optional<Scenario::EnumType> sharedNesTileScenarioId = std::nullopt;
+    for (const auto& request : requests) {
+        auto nesTileTokenizer = resolveNesTileTokenizerForQueuedRequest(
+            request, scenarioConfigOverride, sharedNesTileTokenizer, sharedNesTileScenarioId);
+        queuedEvaluations.push_back(queuedEvaluationMake(
+            request, evolutionConfig, scenarioConfigOverride, std::move(nesTileTokenizer)));
+    }
+
     {
         std::lock_guard<std::mutex> lock(impl_->taskMutex);
         impl_->taskQueue.clear();
 
-        for (const auto& request : requests) {
-            impl_->taskQueue.push_back(
-                queuedEvaluationMake(request, evolutionConfig, scenarioConfigOverride));
+        for (auto& queued : queuedEvaluations) {
+            impl_->taskQueue.push_back(std::move(queued));
         }
     }
 
@@ -840,13 +977,23 @@ void EvaluationExecutor::robustnessPassSubmit(
 
     const int resolvedEvalCount = std::max(0, targetEvalCount);
 
+    std::vector<QueuedEvaluation> queuedEvaluations;
+    queuedEvaluations.reserve(static_cast<size_t>(resolvedEvalCount));
+    std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer;
+    std::optional<Scenario::EnumType> sharedNesTileScenarioId = std::nullopt;
+    for (int sampleOrdinal = 1; sampleOrdinal <= resolvedEvalCount; ++sampleOrdinal) {
+        EvaluationRequest sampleRequest = request;
+        sampleRequest.robustSampleOrdinal = sampleOrdinal;
+        auto nesTileTokenizer = resolveNesTileTokenizerForQueuedRequest(
+            sampleRequest, scenarioConfigOverride, sharedNesTileTokenizer, sharedNesTileScenarioId);
+        queuedEvaluations.push_back(queuedEvaluationMake(
+            sampleRequest, evolutionConfig, scenarioConfigOverride, std::move(nesTileTokenizer)));
+    }
+
     {
         std::lock_guard<std::mutex> lock(impl_->taskMutex);
-        for (int sampleOrdinal = 1; sampleOrdinal <= resolvedEvalCount; ++sampleOrdinal) {
-            EvaluationRequest sampleRequest = request;
-            sampleRequest.robustSampleOrdinal = sampleOrdinal;
-            impl_->taskQueue.push_back(
-                queuedEvaluationMake(sampleRequest, evolutionConfig, scenarioConfigOverride));
+        for (auto& queued : queuedEvaluations) {
+            impl_->taskQueue.push_back(std::move(queued));
         }
     }
 
@@ -863,9 +1010,27 @@ std::optional<std::string> EvaluationExecutor::scenarioConfigOverrideSet(
 {
     {
         std::lock_guard<std::mutex> lock(impl_->taskMutex);
+        std::shared_ptr<NesTileTokenizer> sharedNesTileTokenizer = nullptr;
+        const bool needsNesTileTokenizer = std::any_of(
+            impl_->taskQueue.begin(), impl_->taskQueue.end(), [scenarioId](const auto& queued) {
+                return queued.request.individual.scenarioId == scenarioId
+                    && requiresNesTileTokenizer(queued.request.individual);
+            });
+        if (needsNesTileTokenizer) {
+            auto tokenizerResult =
+                buildNesTileTokenizerForEvaluation(scenarioId, scenarioConfigOverride);
+            if (tokenizerResult.isError()) {
+                return tokenizerResult.errorValue();
+            }
+            sharedNesTileTokenizer = std::move(tokenizerResult).value();
+        }
+
         for (auto& queued : impl_->taskQueue) {
             if (queued.request.individual.scenarioId == scenarioId) {
                 queued.scenarioConfigOverride = scenarioConfigOverride;
+                queued.nesTileTokenizer = requiresNesTileTokenizer(queued.request.individual)
+                    ? sharedNesTileTokenizer
+                    : nullptr;
             }
         }
     }
@@ -883,6 +1048,9 @@ std::optional<std::string> EvaluationExecutor::scenarioConfigOverrideSet(
     std::lock_guard<std::mutex> lock(activeHandle->mutex);
     if (activeHandle->queued.request.individual.scenarioId != scenarioId) {
         return std::nullopt;
+    }
+    if (requiresNesTileTokenizer(activeHandle->queued.request.individual)) {
+        return "EvaluationExecutor: Active NES tile evaluations cannot change scenario config";
     }
 
     activeHandle->queued.scenarioConfigOverride = scenarioConfigOverride;

--- a/apps/src/server/evolution/EvaluationExecutor.cpp
+++ b/apps/src/server/evolution/EvaluationExecutor.cpp
@@ -7,11 +7,8 @@
 #include "core/organisms/evolution/FitnessResult.h"
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingRunner.h"
-#include "core/scenarios/nes/NesGameAdapter.h"
-#include "core/scenarios/nes/NesGameAdapterRegistry.h"
-#include "core/scenarios/nes/NesSmolnesScenarioDriver.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
-#include "core/scenarios/nes/NesTileVocabularyBuilder.h"
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
 
 #include <algorithm>
 #include <array>
@@ -28,7 +25,6 @@ namespace DirtSim::Server::EvolutionSupport {
 namespace {
 
 constexpr size_t kTopCommandSignatureLimit = 20;
-constexpr int kNesTileVocabularyBootstrapFrames = 16;
 
 bool isDuckClockScenario(OrganismType organismType, Scenario::EnumType scenarioId)
 {
@@ -38,89 +34,6 @@ bool isDuckClockScenario(OrganismType organismType, Scenario::EnumType scenarioI
 bool requiresNesTileTokenizer(const EvaluationIndividual& individual)
 {
     return individual.brainKind == TrainingBrainKind::NesTileRecurrent;
-}
-
-Result<std::shared_ptr<NesTileTokenizer>, std::string> buildNesTileTokenizerForEvaluation(
-    Scenario::EnumType scenarioId, const std::optional<ScenarioConfig>& scenarioConfigOverride)
-{
-    NesSmolnesScenarioDriver driver(scenarioId);
-    if (scenarioConfigOverride.has_value()) {
-        const auto configResult = driver.setConfig(scenarioConfigOverride.value());
-        if (configResult.isError()) {
-            return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
-                "EvaluationExecutor: NES tile tokenizer config rejected: "
-                + configResult.errorValue());
-        }
-    }
-
-    const auto setupResult = driver.setup();
-    if (setupResult.isError()) {
-        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
-            "EvaluationExecutor: NES tile tokenizer runtime setup failed: "
-            + setupResult.errorValue());
-    }
-
-    auto adapter = NesGameAdapterRegistry::createDefault().createAdapter(scenarioId);
-    if (!adapter) {
-        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
-            "EvaluationExecutor: Missing NES game adapter for tile tokenizer bootstrap");
-    }
-    adapter->reset(driver.getRuntimeResolvedRomId());
-
-    NesTileVocabularyBuilder builder;
-    Timers timers;
-    std::optional<uint8_t> lastGameState = std::nullopt;
-
-    for (int frameIndex = 0; frameIndex < kNesTileVocabularyBootstrapFrames; ++frameIndex) {
-        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
-            builder.addSnapshot(snapshot.value());
-        }
-
-        const NesGameAdapterControllerOutput controllerOutput = adapter->resolveControllerMask(
-            NesGameAdapterControllerInput{ .inferredControllerMask = 0,
-                                           .lastGameState = lastGameState });
-        auto stepResult = driver.step(timers, controllerOutput.resolvedControllerMask);
-        if (!stepResult.runtimeHealthy || !stepResult.runtimeRunning) {
-            if (builder.getSampledTileCount() == 0) {
-                return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
-                    "EvaluationExecutor: NES tile tokenizer runtime stopped before samples: "
-                    + stepResult.lastError);
-            }
-            break;
-        }
-
-        if (const auto snapshot = driver.copyRuntimePpuSnapshot(); snapshot.has_value()) {
-            builder.addSnapshot(snapshot.value());
-        }
-
-        if (stepResult.advancedFrames == 0) {
-            continue;
-        }
-
-        const NesGameAdapterFrameInput frameInput{
-            .advancedFrames = stepResult.advancedFrames,
-            .controllerMask = controllerOutput.resolvedControllerMask,
-            .paletteFrame =
-                stepResult.paletteFrame.has_value() ? &stepResult.paletteFrame.value() : nullptr,
-            .memorySnapshot = std::move(stepResult.memorySnapshot),
-        };
-        const NesGameAdapterFrameOutput frameOutput = adapter->evaluateFrame(frameInput);
-        if (frameOutput.gameState.has_value()) {
-            lastGameState = frameOutput.gameState;
-        }
-        if (frameOutput.done) {
-            break;
-        }
-    }
-
-    auto tokenizer = std::make_shared<NesTileTokenizer>();
-    const auto buildResult = builder.buildFrozenTokenizer(*tokenizer);
-    if (buildResult.isError()) {
-        return Result<std::shared_ptr<NesTileTokenizer>, std::string>::error(
-            "EvaluationExecutor: NES tile tokenizer bootstrap failed: " + buildResult.errorValue());
-    }
-
-    return Result<std::shared_ptr<NesTileTokenizer>, std::string>::okay(std::move(tokenizer));
 }
 
 std::shared_ptr<NesTileTokenizer> resolveNesTileTokenizerForQueuedRequest(
@@ -141,7 +54,7 @@ std::shared_ptr<NesTileTokenizer> resolveNesTileTokenizerForQueuedRequest(
     }
 
     auto tokenizerResult =
-        buildNesTileTokenizerForEvaluation(request.individual.scenarioId, scenarioConfigOverride);
+        NesTileTokenizerBootstrapper::build(request.individual.scenarioId, scenarioConfigOverride);
     DIRTSIM_ASSERT(tokenizerResult.isValue(), tokenizerResult.errorValue());
     sharedNesTileTokenizer = std::move(tokenizerResult).value();
     sharedNesTileScenarioId = request.individual.scenarioId;
@@ -1018,7 +931,7 @@ std::optional<std::string> EvaluationExecutor::scenarioConfigOverrideSet(
             });
         if (needsNesTileTokenizer) {
             auto tokenizerResult =
-                buildNesTileTokenizerForEvaluation(scenarioId, scenarioConfigOverride);
+                NesTileTokenizerBootstrapper::build(scenarioId, scenarioConfigOverride);
             if (tokenizerResult.isError()) {
                 return tokenizerResult.errorValue();
             }

--- a/apps/src/server/evolution/EvaluationExecutor.h
+++ b/apps/src/server/evolution/EvaluationExecutor.h
@@ -25,6 +25,7 @@
 namespace DirtSim {
 
 class GenomeRepository;
+class NesTileTokenizer;
 
 namespace Server::EvolutionSupport {
 
@@ -98,6 +99,7 @@ public:
         TrainingBrainRegistry brainRegistry;
         GenomeRepository* genomeRepository = nullptr;
         FitnessModelBundle fitnessModel;
+        std::shared_ptr<NesTileTokenizer> nesTileTokenizer = nullptr;
     };
 
     explicit EvaluationExecutor(Config config);

--- a/apps/src/server/states/Evolution.cpp
+++ b/apps/src/server/states/Evolution.cpp
@@ -2150,7 +2150,22 @@ void Evolution::stepBestPlayback(StateMachine& dsm)
         DIRTSIM_ASSERT(
             organismGrid != nullptr, "Evolution: Best playback runner missing organism grid");
 
-        const auto& videoFrame = bestPlayback_.runner->getScenarioVideoFrame();
+        std::optional<ScenarioVideoFrame> videoFrame =
+            bestPlayback_.runner->getScenarioVideoFrame();
+        if (bestPlayback_.runner->isNesScenario()
+            && uiTraining.nesTileDebugView != NesTileDebugView::NormalVideo) {
+            auto debugFrameResult = bestPlayback_.runner->makeNesTileDebugScenarioVideoFrame(
+                uiTraining.nesTileDebugView);
+            if (debugFrameResult.isValue()) {
+                videoFrame = std::move(debugFrameResult).value();
+            }
+            else {
+                LOG_WARN(
+                    State,
+                    "Evolution: Failed to render NES tile debug best playback frame: {}",
+                    debugFrameResult.errorValue());
+            }
+        }
         if (!bestPlayback_.runner->isNesScenario() || videoFrame.has_value()) {
             broadcastTrainingBestPlaybackFrame(
                 dsm,

--- a/apps/src/server/states/Evolution.cpp
+++ b/apps/src/server/states/Evolution.cpp
@@ -15,6 +15,8 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/Mutation.h"
 #include "core/scenarios/ScenarioRegistry.h"
+#include "core/scenarios/nes/NesTileBrainMetadata.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
 #include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
 #include "server/StateMachine.h"
 #include "server/api/EvolutionMutationControlsSet.h"
@@ -441,6 +443,24 @@ bool requiresNesTileTokenizer(const Evolution::Individual& individual)
     return individual.brainKind == TrainingBrainKind::NesTileRecurrent;
 }
 
+bool trainingRequiresNesTileTokenizer(const TrainingSpec& trainingSpec)
+{
+    return std::any_of(
+        trainingSpec.population.begin(), trainingSpec.population.end(), [](const auto& spec) {
+            return spec.brainKind == TrainingBrainKind::NesTileRecurrent;
+        });
+}
+
+std::optional<NesTileBrainCompatibilityMetadata> brainCompatibilityMetadataForIndividual(
+    const Evolution::Individual& individual,
+    const std::optional<NesTileBrainCompatibilityMetadata>& nesTileCompatibility)
+{
+    if (individual.brainKind == TrainingBrainKind::NesTileRecurrent) {
+        return nesTileCompatibility;
+    }
+    return std::nullopt;
+}
+
 EvolutionSupport::EvaluationIndividual makeEvaluationIndividual(
     const Evolution::Individual& individual)
 {
@@ -704,6 +724,18 @@ void Evolution::onEnter(StateMachine& dsm)
     }
     genomePoolId_ = scenarioMeta ? scenarioMeta->genomePoolId : GenomePoolId::DirtSim;
 
+    nesTileTokenizer_.reset();
+    nesTileBrainCompatibility_.reset();
+    if (trainingRequiresNesTileTokenizer(trainingSpec)) {
+        auto tokenizerResult =
+            NesTileTokenizerBootstrapper::build(trainingSpec.scenarioId, scenarioConfigOverride_);
+        DIRTSIM_ASSERT(
+            tokenizerResult.isValue(),
+            "Evolution: Failed to bootstrap NES tile tokenizer: " + tokenizerResult.errorValue());
+        nesTileTokenizer_ = std::move(tokenizerResult).value();
+        nesTileBrainCompatibility_ = makeNesTileBrainCompatibilityMetadata(*nesTileTokenizer_);
+    }
+
     bestPlayback_.reset();
     executor_.reset();
 
@@ -732,6 +764,7 @@ void Evolution::onEnter(StateMachine& dsm)
             .brainRegistry = brainRegistry_,
             .genomeRepository = &dsm.getGenomeRepository(),
             .fitnessModel = fitnessModel_,
+            .nesTileTokenizer = nesTileTokenizer_,
         });
     executor_->start(evolutionConfig.maxParallelEvaluations);
     queueGenerationTasks();
@@ -1305,6 +1338,8 @@ void Evolution::finalizePendingBestWithoutRobustnessPass(StateMachine& dsm)
         .brainVariant = individual.brainVariant,
         .trainingSessionId = trainingSessionId_,
         .genomePoolId = genomePoolId_,
+        .nesTileBrainCompatibility =
+            brainCompatibilityMetadataForIndividual(individual, nesTileBrainCompatibility_),
     };
 
     bestFitnessThisGen = bestFitness;
@@ -1459,6 +1494,8 @@ void Evolution::finalizeRobustnessPass(StateMachine& dsm)
         .brainVariant = individual.brainVariant,
         .trainingSessionId = trainingSessionId_,
         .genomePoolId = genomePoolId_,
+        .nesTileBrainCompatibility =
+            brainCompatibilityMetadataForIndividual(individual, nesTileBrainCompatibility_),
     };
 
     bestFitnessThisGen = robustFitness;
@@ -2087,16 +2124,21 @@ void Evolution::stepBestPlayback(StateMachine& dsm)
     const auto startRunner = [&](std::optional<bool> spawnSideOverride) {
         if (requiresNesTileTokenizer(bestPlayback_.individual.value())
             && !bestPlayback_.nesTileTokenizer) {
-            auto tokenizerResult = NesTileTokenizerBootstrapper::build(
-                bestPlayback_.individual->scenarioId, scenarioConfigOverride_);
-            if (tokenizerResult.isError()) {
-                LOG_WARN(
-                    State,
-                    "Evolution: Failed to bootstrap NES tile tokenizer for best playback: {}",
-                    tokenizerResult.errorValue());
-                return;
+            if (nesTileTokenizer_) {
+                bestPlayback_.nesTileTokenizer = nesTileTokenizer_;
             }
-            bestPlayback_.nesTileTokenizer = std::move(tokenizerResult).value();
+            else {
+                auto tokenizerResult = NesTileTokenizerBootstrapper::build(
+                    bestPlayback_.individual->scenarioId, scenarioConfigOverride_);
+                if (tokenizerResult.isError()) {
+                    LOG_WARN(
+                        State,
+                        "Evolution: Failed to bootstrap NES tile tokenizer for best playback: {}",
+                        tokenizerResult.errorValue());
+                    return;
+                }
+                bestPlayback_.nesTileTokenizer = std::move(tokenizerResult).value();
+            }
         }
 
         const TrainingRunner::Config runnerConfig{
@@ -2417,6 +2459,8 @@ void Evolution::storeBestGenome(StateMachine& dsm)
         .brainVariant = population[bestIdx].brainVariant,
         .trainingSessionId = trainingSessionId_,
         .genomePoolId = genomePoolId_,
+        .nesTileBrainCompatibility = brainCompatibilityMetadataForIndividual(
+            population[bestIdx], nesTileBrainCompatibility_),
     };
     const auto storeResult = storeManagedGenome(
         dsm,
@@ -2493,6 +2537,9 @@ UnsavedTrainingResult Evolution::buildUnsavedTrainingResult()
             .brainKind = candidate.brainKind,
             .brainVariant = candidate.brainVariant,
             .trainingSessionId = trainingSessionId_,
+            .genomePoolId = genomePoolId_,
+            .nesTileBrainCompatibility =
+                brainCompatibilityMetadataForIndividual(population[i], nesTileBrainCompatibility_),
         };
         result.candidates.push_back(candidate);
     }

--- a/apps/src/server/states/Evolution.cpp
+++ b/apps/src/server/states/Evolution.cpp
@@ -15,6 +15,7 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/Mutation.h"
 #include "core/scenarios/ScenarioRegistry.h"
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
 #include "server/StateMachine.h"
 #include "server/api/EvolutionMutationControlsSet.h"
 #include "server/api/EvolutionPauseSet.h"
@@ -435,6 +436,11 @@ TrainingRunner::Individual makeRunnerIndividual(const Evolution::Individual& ind
     return runner;
 }
 
+bool requiresNesTileTokenizer(const Evolution::Individual& individual)
+{
+    return individual.brainKind == TrainingBrainKind::NesTileRecurrent;
+}
+
 EvolutionSupport::EvaluationIndividual makeEvaluationIndividual(
     const Evolution::Individual& individual)
 {
@@ -576,6 +582,7 @@ GenomeRepository::StoreByHashResult storeManagedGenome(
 void Evolution::BestPlaybackState::reset()
 {
     individual.reset();
+    nesTileTokenizer.reset();
     runner.reset();
     fitness = 0.0;
     generation = 0;
@@ -2057,6 +2064,7 @@ void Evolution::setBestPlaybackSource(const Individual& individual, double fitne
 {
     bestPlayback_.individual = individual;
     bestPlayback_.individual->parentFitness.reset();
+    bestPlayback_.nesTileTokenizer.reset();
     bestPlayback_.fitness = fitness;
     bestPlayback_.generation = generation;
     bestPlayback_.duckNextPrimarySpawnLeftFirst = true;
@@ -2077,8 +2085,23 @@ void Evolution::stepBestPlayback(StateMachine& dsm)
     }
 
     const auto startRunner = [&](std::optional<bool> spawnSideOverride) {
+        if (requiresNesTileTokenizer(bestPlayback_.individual.value())
+            && !bestPlayback_.nesTileTokenizer) {
+            auto tokenizerResult = NesTileTokenizerBootstrapper::build(
+                bestPlayback_.individual->scenarioId, scenarioConfigOverride_);
+            if (tokenizerResult.isError()) {
+                LOG_WARN(
+                    State,
+                    "Evolution: Failed to bootstrap NES tile tokenizer for best playback: {}",
+                    tokenizerResult.errorValue());
+                return;
+            }
+            bestPlayback_.nesTileTokenizer = std::move(tokenizerResult).value();
+        }
+
         const TrainingRunner::Config runnerConfig{
             .brainRegistry = brainRegistry_,
+            .nesTileTokenizer = bestPlayback_.nesTileTokenizer,
             .duckClockSpawnLeftFirst = spawnSideOverride,
             .duckClockSpawnRngSeed = std::nullopt,
             .scenarioConfigOverride = scenarioConfigOverride_,
@@ -2100,6 +2123,9 @@ void Evolution::stepBestPlayback(StateMachine& dsm)
         bestPlayback_.duckPrimarySpawnLeftFirst = primarySpawnSide.value_or(true);
         bestPlayback_.duckSecondPassActive = false;
         startRunner(primarySpawnSide);
+        if (!bestPlayback_.runner) {
+            return;
+        }
     }
 
     // Advance the sim at real-time pace: one step per TIMESTEP of wall-clock time.

--- a/apps/src/server/states/Evolution.h
+++ b/apps/src/server/states/Evolution.h
@@ -116,6 +116,8 @@ struct Evolution {
 
     std::optional<ScenarioConfig> scenarioConfigOverride_ = std::nullopt;
     std::unique_ptr<EvolutionSupport::EvaluationExecutor> executor_;
+    std::shared_ptr<NesTileTokenizer> nesTileTokenizer_ = nullptr;
+    std::optional<NesTileBrainCompatibilityMetadata> nesTileBrainCompatibility_ = std::nullopt;
 
     // Training timing.
     std::chrono::steady_clock::time_point trainingStartTime_;

--- a/apps/src/server/states/Evolution.h
+++ b/apps/src/server/states/Evolution.h
@@ -37,6 +37,7 @@
 
 namespace DirtSim {
 class GenomeRepository;
+class NesTileTokenizer;
 namespace Server {
 namespace State {
 
@@ -139,6 +140,7 @@ struct Evolution {
 
     struct BestPlaybackState {
         std::optional<Individual> individual;
+        std::shared_ptr<NesTileTokenizer> nesTileTokenizer = nullptr;
         std::unique_ptr<TrainingRunner> runner;
         double fitness = 0.0;
         int generation = 0;

--- a/apps/src/server/states/Idle.cpp
+++ b/apps/src/server/states/Idle.cpp
@@ -9,6 +9,8 @@
 #include "core/organisms/evolution/TrainingSpec.h"
 #include "core/scenarios/ClockScenario.h"
 #include "core/scenarios/ScenarioRegistry.h"
+#include "core/scenarios/nes/NesTileBrainMetadata.h"
+#include "core/scenarios/nes/NesTileTokenizerBootstrapper.h"
 #include "server/PlanRepository.h"
 #include "server/StateMachine.h"
 #include "server/api/ApiError.h"
@@ -55,10 +57,15 @@ ScenarioConfig buildScenarioConfigForRun(StateMachine& dsm, Scenario::EnumType s
 
 bool isWarmGenomeCompatibleForPopulation(
     const GenomeMetadata& metadata,
+    Scenario::EnumType scenarioId,
     OrganismType organismType,
     const PopulationSpec& populationSpec,
     GenomePoolId genomePoolId)
 {
+    if (metadata.scenarioId != scenarioId) {
+        return false;
+    }
+
     if (!metadata.organismType.has_value() || metadata.organismType.value() != organismType) {
         return false;
     }
@@ -76,6 +83,46 @@ bool isWarmGenomeCompatibleForPopulation(
     }
 
     return true;
+}
+
+bool isNesTilePopulation(const PopulationSpec& populationSpec)
+{
+    return populationSpec.brainKind == TrainingBrainKind::NesTileRecurrent;
+}
+
+std::optional<ApiError> ensureNesTileCompatibilityMetadata(
+    Scenario::EnumType scenarioId,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
+    std::optional<NesTileBrainCompatibilityMetadata>& expected)
+{
+    if (expected.has_value()) {
+        return std::nullopt;
+    }
+
+    auto tokenizerResult = NesTileTokenizerBootstrapper::build(scenarioId, scenarioConfigOverride);
+    if (tokenizerResult.isError()) {
+        return ApiError(
+            "Failed to build current NES tile compatibility metadata: "
+            + tokenizerResult.errorValue());
+    }
+
+    expected = makeNesTileBrainCompatibilityMetadata(*tokenizerResult.value());
+    return std::nullopt;
+}
+
+std::optional<std::string> validateNesTileWarmSeedMetadata(
+    const GenomeMetadata& metadata, const NesTileBrainCompatibilityMetadata& expected)
+{
+    if (!metadata.nesTileBrainCompatibility.has_value()) {
+        return std::nullopt;
+    }
+
+    const auto validation = validateNesTileBrainCompatibilityMetadata(
+        metadata.nesTileBrainCompatibility.value(), expected);
+    if (validation.isError()) {
+        return validation.errorValue();
+    }
+    return std::nullopt;
 }
 
 struct WarmSeedCandidate {
@@ -336,6 +383,7 @@ std::optional<ApiError> validateTrainingConfig(
     const Api::EvolutionStart::Command& command,
     ScenarioRegistry& registry,
     GenomeRepository& repo,
+    const std::optional<ScenarioConfig>& scenarioConfigOverride,
     TrainingSpec& outSpec,
     int& outPopulationSize,
     int& outWarmSeedInjectedCount)
@@ -403,6 +451,7 @@ std::optional<ApiError> validateTrainingConfig(
     const int warmStartMinRobustEvalCount =
         resolveWarmStartMinRobustEvalCount(command, *scenarioMetadata);
     std::mt19937 warmSeedSamplingRng(std::random_device{}());
+    std::optional<NesTileBrainCompatibilityMetadata> expectedNesTileCompatibility;
     if (command.resumePolicy == TrainingResumePolicy::WarmFromBest) {
         warmSeedCandidates = collectWarmSeedCandidates(repo, warmStartMinRobustEvalCount);
     }
@@ -439,10 +488,31 @@ std::optional<ApiError> validateTrainingConfig(
                     for (const auto& candidate : warmSeedCandidates) {
                         if (!isWarmGenomeCompatibleForPopulation(
                                 candidate.metadata,
+                                outSpec.scenarioId,
                                 outSpec.organismType,
                                 spec,
                                 scenarioMetadata->genomePoolId)) {
                             continue;
+                        }
+                        if (isNesTilePopulation(spec)
+                            && candidate.metadata.nesTileBrainCompatibility.has_value()) {
+                            if (auto error = ensureNesTileCompatibilityMetadata(
+                                    outSpec.scenarioId,
+                                    scenarioConfigOverride,
+                                    expectedNesTileCompatibility);
+                                error.has_value()) {
+                                return error.value();
+                            }
+                            const auto mismatch = validateNesTileWarmSeedMetadata(
+                                candidate.metadata, expectedNesTileCompatibility.value());
+                            if (mismatch.has_value()) {
+                                LOG_WARN(
+                                    State,
+                                    "Skipping incompatible NES tile warm seed {}: {}",
+                                    candidate.id.toShortString(),
+                                    mismatch.value());
+                                continue;
+                            }
                         }
                         if (std::find(
                                 spec.seedGenomes.begin(), spec.seedGenomes.end(), candidate.id)
@@ -520,6 +590,35 @@ std::optional<ApiError> validateTrainingConfig(
                 if (!repo.exists(id)) {
                     return ApiError("Seed genome not found: " + id.toShortString());
                 }
+                auto metadata = repo.getMetadata(id);
+                if (!metadata.has_value()) {
+                    return ApiError("Seed genome metadata not found: " + id.toShortString());
+                }
+                if (!isWarmGenomeCompatibleForPopulation(
+                        metadata.value(),
+                        outSpec.scenarioId,
+                        outSpec.organismType,
+                        spec,
+                        scenarioMetadata->genomePoolId)) {
+                    return ApiError(
+                        "Seed genome metadata incompatible with population: " + id.toShortString());
+                }
+                if (isNesTilePopulation(spec) && metadata->nesTileBrainCompatibility.has_value()) {
+                    if (auto error = ensureNesTileCompatibilityMetadata(
+                            outSpec.scenarioId,
+                            scenarioConfigOverride,
+                            expectedNesTileCompatibility);
+                        error.has_value()) {
+                        return error.value();
+                    }
+                    const auto mismatch = validateNesTileWarmSeedMetadata(
+                        metadata.value(), expectedNesTileCompatibility.value());
+                    if (mismatch.has_value()) {
+                        return ApiError(
+                            "Seed genome NES tile compatibility mismatch for " + id.toShortString()
+                            + ": " + mismatch.value());
+                    }
+                }
                 if (entry->isGenomeCompatible) {
                     auto genome = repo.get(id);
                     if (!genome.has_value()) {
@@ -592,6 +691,7 @@ State::Any Idle::onEvent(const Api::EvolutionStart::Cwc& cwc, StateMachine& dsm)
         cwc.command,
         dsm.getScenarioRegistry(),
         dsm.getGenomeRepository(),
+        std::nullopt,
         trainingSpec,
         populationSize,
         warmSeedInjectedCount);

--- a/apps/src/server/states/Idle.cpp
+++ b/apps/src/server/states/Idle.cpp
@@ -355,19 +355,23 @@ std::optional<ApiError> validateTrainingConfig(
 
         switch (outSpec.organismType) {
             case OrganismType::TREE:
-                defaultSpec.brainKind = TrainingBrainKind::NeuralNet;
+                defaultSpec.brainKind =
+                    defaultTrainingBrainKind(outSpec.organismType, outSpec.scenarioId);
                 defaultSpec.randomCount = defaultSpec.count;
                 break;
             case OrganismType::DUCK:
-                defaultSpec.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
+                defaultSpec.brainKind =
+                    defaultTrainingBrainKind(outSpec.organismType, outSpec.scenarioId);
                 defaultSpec.randomCount = defaultSpec.count;
                 break;
             case OrganismType::NES_DUCK:
-                defaultSpec.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
+                defaultSpec.brainKind =
+                    defaultTrainingBrainKind(outSpec.organismType, outSpec.scenarioId);
                 defaultSpec.randomCount = defaultSpec.count;
                 break;
             case OrganismType::GOOSE:
-                defaultSpec.brainKind = TrainingBrainKind::Random;
+                defaultSpec.brainKind =
+                    defaultTrainingBrainKind(outSpec.organismType, outSpec.scenarioId);
                 break;
             default:
                 return ApiError("Unsupported organismType for training");

--- a/apps/src/server/tests/EvaluationExecutor_test.cpp
+++ b/apps/src/server/tests/EvaluationExecutor_test.cpp
@@ -4,6 +4,7 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/scenarios/nes/NesTileRecurrentBrain.h"
 #include "core/scenarios/tests/NesTestRomPath.h"
 #include "server/evolution/EvaluationExecutor.h"
 #include "server/evolution/FitnessModelBundle.h"
@@ -587,4 +588,77 @@ TEST(EvaluationExecutorTest, NesVisibleEvaluationProducesNonEmptyVideoFrame)
             return b == std::byte{ 0 };
         });
     EXPECT_FALSE(allZero) << "ScenarioVideoFrame pixels are all zero (RGBA output not working).";
+}
+
+TEST(EvaluationExecutorTest, NesTileVisibleEvaluationBootstrapsTokenizer)
+{
+    const auto romPath = DirtSim::Test::resolveFlappyRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing for NES tile visible evaluation test.";
+    }
+
+    TestStateMachineFixture fixture;
+
+    TrainingSpec trainingSpec;
+    trainingSpec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    trainingSpec.organismType = OrganismType::NES_DUCK;
+    PopulationSpec population;
+    population.brainKind = TrainingBrainKind::NesTileRecurrent;
+    population.count = 1;
+    population.randomCount = 1;
+    trainingSpec.population.push_back(population);
+
+    EvaluationExecutor executor =
+        makeExecutor(trainingSpec, fixture.stateMachine->getGenomeRepository());
+    const EvolutionConfig evolutionConfig = makeEvolutionConfig(1, 0.25);
+
+    Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
+        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
+    nesConfig.romPath = romPath.value().string();
+    nesConfig.requireSmolnesMapper = true;
+
+    std::mt19937 rng(43);
+    const std::vector<EvaluationRequest> requests{
+        EvaluationRequest{
+            .taskType = EvaluationTaskType::GenerationEval,
+            .index = 0,
+            .individual =
+                EvaluationIndividual{
+                    .brainKind = TrainingBrainKind::NesTileRecurrent,
+                    .brainVariant = std::nullopt,
+                    .scenarioId = Scenario::EnumType::NesFlappyParatroopa,
+                    .genome = NesTileRecurrentBrain::randomGenome(rng),
+                },
+        },
+    };
+
+    executor.start(1);
+    executor.generationBatchSubmit(requests, evolutionConfig, ScenarioConfig{ nesConfig });
+
+    bool sawTileBrainFrame = false;
+    bool completed = false;
+    std::optional<uint64_t> lastFrameId = std::nullopt;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline && !sawTileBrainFrame && !completed) {
+        const auto tick = executor.visibleTick(std::chrono::steady_clock::now(), 0);
+        completed = !tick.completed.empty();
+        if (tick.frame.has_value() && tick.frame->scenarioVideoFrame.has_value()) {
+            lastFrameId = tick.frame->scenarioVideoFrame->frame_id;
+            if (tick.frame->nesControllerTelemetry.has_value()) {
+                sawTileBrainFrame = true;
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ASSERT_TRUE(sawTileBrainFrame)
+        << "NES tile visible evaluation did not produce a telemetry frame before completion. "
+        << "completed=" << completed << ", last frame_id=" << lastFrameId.value_or(0);
+    ASSERT_TRUE(executor.hasVisibleEvaluation());
+
+    const auto configError = executor.scenarioConfigOverrideSet(
+        ScenarioConfig{ nesConfig }, Scenario::EnumType::NesFlappyParatroopa);
+    ASSERT_TRUE(configError.has_value());
+    EXPECT_NE(configError->find("Active NES tile evaluations"), std::string::npos);
 }

--- a/apps/src/server/tests/StateEvolution_test.cpp
+++ b/apps/src/server/tests/StateEvolution_test.cpp
@@ -4,6 +4,8 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/scenarios/nes/NesTileTokenizer.h"
+#include "core/scenarios/tests/NesTestRomPath.h"
 #include "server/Event.h"
 #include "server/api/EventSubscribe.h"
 #include "server/api/EvolutionMutationControlsSet.h"
@@ -56,6 +58,20 @@ TrainingSpec makeTrainingSpec(int populationSize)
     spec.organismType = OrganismType::TREE;
     spec.population.push_back(population);
 
+    return spec;
+}
+
+TrainingSpec makeNesTileTrainingSpec(int populationSize)
+{
+    PopulationSpec population;
+    population.brainKind = TrainingBrainKind::NesTileRecurrent;
+    population.count = populationSize;
+    population.randomCount = populationSize;
+
+    TrainingSpec spec;
+    spec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
+    spec.organismType = OrganismType::NES_DUCK;
+    spec.population.push_back(population);
     return spec;
 }
 
@@ -1871,6 +1887,56 @@ TEST(StateEvolutionTest, TickAdvancesEvaluationIncrementally)
     ASSERT_TRUE(sawStateAdvance)
         << "Expected polling tick() to eventually drain completed work or advance the generation";
     EXPECT_TRUE(evolutionState.currentEval >= 1 || evolutionState.generation >= 1);
+}
+
+TEST(StateEvolutionTest, NesTileBestPlaybackBootstrapsTokenizer)
+{
+    const auto romPath = DirtSim::Test::resolveFlappyRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing for NES tile best playback test.";
+    }
+
+    TestStateMachineFixture fixture;
+    fixture.stateMachine->getUserSettings().uiTraining.bestPlaybackEnabled = true;
+    fixture.stateMachine->getUserSettings().uiTraining.bestPlaybackIntervalMs = 1;
+
+    Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
+        makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
+    nesConfig.romPath = romPath.value().string();
+    nesConfig.requireSmolnesMapper = true;
+
+    Evolution evolutionState;
+    evolutionState.evolutionConfig.populationSize = 1;
+    evolutionState.evolutionConfig.maxGenerations = 100;
+    evolutionState.evolutionConfig.maxSimulationTime = 60.0;
+    evolutionState.evolutionConfig.maxParallelEvaluations = 1;
+    evolutionState.scenarioConfigOverride_ = ScenarioConfig{ nesConfig };
+    evolutionState.trainingSpec = makeNesTileTrainingSpec(1);
+
+    evolutionState.onEnter(*fixture.stateMachine);
+    EvolutionWorkerGuard guard{ .evolution = &evolutionState,
+                                .stateMachine = fixture.stateMachine.get() };
+    ASSERT_EQ(evolutionState.population.size(), 1u);
+
+    evolutionState.bestPlayback_.individual = evolutionState.population.front();
+    evolutionState.bestPlayback_.fitness = 1.0;
+    evolutionState.bestPlayback_.generation = 0;
+
+    bool sawTelemetry = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline && !sawTelemetry) {
+        evolutionState.tick(*fixture.stateMachine);
+        sawTelemetry = evolutionState.bestPlayback_.runner
+            && evolutionState.bestPlayback_.runner->getNesLastControllerTelemetry().has_value();
+        if (!sawTelemetry) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    ASSERT_TRUE(sawTelemetry);
+    ASSERT_NE(evolutionState.bestPlayback_.nesTileTokenizer, nullptr);
+    EXPECT_EQ(
+        evolutionState.bestPlayback_.nesTileTokenizer->getMode(), NesTileTokenizer::Mode::Frozen);
 }
 
 /**

--- a/apps/src/server/tests/StateEvolution_test.cpp
+++ b/apps/src/server/tests/StateEvolution_test.cpp
@@ -4,6 +4,8 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/scenarios/nes/NesPlayerRelativeTileFrame.h"
+#include "core/scenarios/nes/NesTileDebugView.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
 #include "core/scenarios/tests/NesTestRomPath.h"
 #include "server/Event.h"
@@ -14,6 +16,7 @@
 #include "server/api/EvolutionStart.h"
 #include "server/api/EvolutionStop.h"
 #include "server/api/TimerStatsGet.h"
+#include "server/api/TrainingBestPlaybackFrame.h"
 #include "server/api/TrainingResult.h"
 #include "server/states/Evolution.h"
 #include "server/states/Idle.h"
@@ -138,6 +141,19 @@ std::optional<Api::EvolutionProgress> latestEvolutionProgress(const MockWebSocke
         const auto envelope = Network::deserialize_envelope(it->data);
         if (envelope.message_type == Api::EvolutionProgress::name()) {
             return Network::deserialize_payload<Api::EvolutionProgress>(envelope.payload);
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<Api::TrainingBestPlaybackFrame> latestTrainingBestPlaybackFrame(
+    const MockWebSocketService& mockWs)
+{
+    for (auto it = mockWs.sentClientBinaries().rbegin(); it != mockWs.sentClientBinaries().rend();
+         ++it) {
+        const auto envelope = Network::deserialize_envelope(it->data);
+        if (envelope.message_type == Api::TrainingBestPlaybackFrame::name()) {
+            return Network::deserialize_payload<Api::TrainingBestPlaybackFrame>(envelope.payload);
         }
     }
     return std::nullopt;
@@ -1965,8 +1981,11 @@ TEST(StateEvolutionTest, NesTileBestPlaybackBootstrapsTokenizer)
     }
 
     TestStateMachineFixture fixture;
+    eventSubscribe(fixture, "events");
     fixture.stateMachine->getUserSettings().uiTraining.bestPlaybackEnabled = true;
     fixture.stateMachine->getUserSettings().uiTraining.bestPlaybackIntervalMs = 1;
+    fixture.stateMachine->getUserSettings().uiTraining.nesTileDebugView =
+        NesTileDebugView::PlayerRelativeTokens;
 
     Config::NesFlappyParatroopa nesConfig = std::get<Config::NesFlappyParatroopa>(
         makeDefaultConfig(Scenario::EnumType::NesFlappyParatroopa));
@@ -1991,17 +2010,31 @@ TEST(StateEvolutionTest, NesTileBestPlaybackBootstrapsTokenizer)
     evolutionState.bestPlayback_.generation = 0;
 
     bool sawTelemetry = false;
+    std::optional<Api::TrainingBestPlaybackFrame> debugFrame;
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (std::chrono::steady_clock::now() < deadline && !sawTelemetry) {
+    while (std::chrono::steady_clock::now() < deadline
+           && (!sawTelemetry || !debugFrame.has_value()
+               || !debugFrame->scenarioVideoFrame.has_value())) {
         evolutionState.tick(*fixture.stateMachine);
         sawTelemetry = evolutionState.bestPlayback_.runner
             && evolutionState.bestPlayback_.runner->getNesLastControllerTelemetry().has_value();
-        if (!sawTelemetry) {
+        debugFrame = latestTrainingBestPlaybackFrame(*fixture.mockWebSocketService);
+        if (!sawTelemetry || !debugFrame.has_value()
+            || !debugFrame->scenarioVideoFrame.has_value()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
 
     ASSERT_TRUE(sawTelemetry);
+    ASSERT_TRUE(debugFrame.has_value());
+    ASSERT_TRUE(debugFrame->scenarioVideoFrame.has_value());
+    EXPECT_EQ(
+        debugFrame->scenarioVideoFrame->width,
+        NesPlayerRelativeTileFrame::RelativeTileColumns
+            * NesPlayerRelativeTileFrame::TileSizePixels);
+    EXPECT_EQ(
+        debugFrame->scenarioVideoFrame->height,
+        NesPlayerRelativeTileFrame::RelativeTileRows * NesPlayerRelativeTileFrame::TileSizePixels);
     ASSERT_NE(evolutionState.bestPlayback_.nesTileTokenizer, nullptr);
     EXPECT_EQ(
         evolutionState.bestPlayback_.nesTileTokenizer->getMode(), NesTileTokenizer::Mode::Frozen);

--- a/apps/src/server/tests/StateEvolution_test.cpp
+++ b/apps/src/server/tests/StateEvolution_test.cpp
@@ -272,6 +272,74 @@ TEST(StateEvolutionTest, EvolutionStartDefaultsToDuckRecurrentBrainForNesFlappyO
     EXPECT_EQ(population.randomCount, 3);
 }
 
+TEST(StateEvolutionTest, EvolutionStartDefaultsToNesTileRecurrentBrainForNesSuperMarioBros)
+{
+    TestStateMachineFixture fixture;
+    Idle idleState;
+
+    Api::EvolutionStart::Response capturedResponse;
+    Api::EvolutionStart::Command cmd;
+    cmd.evolution.populationSize = 3;
+    cmd.evolution.maxGenerations = 1;
+    cmd.evolution.maxSimulationTime = 0.1;
+    cmd.scenarioId = Scenario::EnumType::NesSuperMarioBros;
+    cmd.organismType = OrganismType::NES_DUCK;
+
+    Api::EvolutionStart::Cwc cwc(cmd, [&](Api::EvolutionStart::Response&& response) {
+        capturedResponse = std::move(response);
+    });
+
+    State::Any newState = idleState.onEvent(cwc, *fixture.stateMachine);
+
+    ASSERT_TRUE(std::holds_alternative<Evolution>(newState.getVariant()));
+    ASSERT_TRUE(capturedResponse.isValue());
+
+    const Evolution& evolution = std::get<Evolution>(newState.getVariant());
+    ASSERT_EQ(evolution.trainingSpec.population.size(), 1u);
+    const PopulationSpec& population = evolution.trainingSpec.population.front();
+    EXPECT_EQ(population.brainKind, TrainingBrainKind::NesTileRecurrent);
+    EXPECT_EQ(population.count, 3);
+    EXPECT_EQ(population.randomCount, 3);
+}
+
+TEST(StateEvolutionTest, EvolutionStartPreservesExplicitDuckRecurrentBrainForNesSuperMarioBros)
+{
+    TestStateMachineFixture fixture;
+    Idle idleState;
+
+    Api::EvolutionStart::Response capturedResponse;
+    Api::EvolutionStart::Command cmd;
+    cmd.evolution.populationSize = 3;
+    cmd.evolution.maxGenerations = 1;
+    cmd.evolution.maxSimulationTime = 0.1;
+    cmd.scenarioId = Scenario::EnumType::NesSuperMarioBros;
+    cmd.organismType = OrganismType::NES_DUCK;
+    cmd.population.push_back(
+        PopulationSpec{
+            .brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2,
+            .brainVariant = std::nullopt,
+            .count = 3,
+            .seedGenomes = {},
+            .randomCount = 3,
+        });
+
+    Api::EvolutionStart::Cwc cwc(cmd, [&](Api::EvolutionStart::Response&& response) {
+        capturedResponse = std::move(response);
+    });
+
+    State::Any newState = idleState.onEvent(cwc, *fixture.stateMachine);
+
+    ASSERT_TRUE(std::holds_alternative<Evolution>(newState.getVariant()));
+    ASSERT_TRUE(capturedResponse.isValue());
+
+    const Evolution& evolution = std::get<Evolution>(newState.getVariant());
+    ASSERT_EQ(evolution.trainingSpec.population.size(), 1u);
+    const PopulationSpec& population = evolution.trainingSpec.population.front();
+    EXPECT_EQ(population.brainKind, TrainingBrainKind::DuckNeuralNetRecurrentV2);
+    EXPECT_EQ(population.count, 3);
+    EXPECT_EQ(population.randomCount, 3);
+}
+
 TEST(StateEvolutionTest, EvolutionStartDefaultsToDuckRecurrentBrainForDuckClockScenario)
 {
     TestStateMachineFixture fixture;

--- a/apps/src/server/tests/StateEvolution_test.cpp
+++ b/apps/src/server/tests/StateEvolution_test.cpp
@@ -100,6 +100,7 @@ GenomeMetadata makeManagedGenomeMetadata(
         .brainVariant = std::nullopt,
         .trainingSessionId = UUID::generate(),
         .genomePoolId = genomePoolId,
+        .nesTileBrainCompatibility = std::nullopt,
     };
 }
 
@@ -532,6 +533,8 @@ TEST(StateEvolutionTest, EvolutionStartWarmResumeInjectsBestGenomeSeed)
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(bestId, bestGenome, bestMetadata);
     repo.markAsBest(bestId);
@@ -591,6 +594,8 @@ TEST(StateEvolutionTest, EvolutionStartFreshResumeDoesNotInjectBestGenomeSeed)
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(bestId, bestGenome, bestMetadata);
     repo.markAsBest(bestId);
@@ -654,6 +659,8 @@ TEST(StateEvolutionTest, EvolutionStartWarmResumeInjectsMultipleRobustSeeds)
             .brainKind = TrainingBrainKind::NeuralNet,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
     };
 
@@ -737,6 +744,8 @@ TEST(StateEvolutionTest, EvolutionStartWarmResumeSkipsIncompatibleGenomeLayouts)
             .brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2,
             .brainVariant = std::nullopt,
             .trainingSessionId = std::nullopt,
+            .genomePoolId = GenomePoolId::DirtSim,
+            .nesTileBrainCompatibility = std::nullopt,
         };
     };
 
@@ -803,6 +812,7 @@ TEST(StateEvolutionTest, EvolutionStartWarmResumeUsesSingleEvalSeedsForDetermini
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
         .genomePoolId = GenomePoolId::Smb,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(smbBestId, makeDuckRecurrentV2Genome(0.5f), smbBestMetadata);
 
@@ -1517,6 +1527,8 @@ TEST(StateEvolutionTest, TiedFitnessKeepsExistingBestGenomeId)
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(seedId, seedGenome, seedMeta);
     repo.markAsBest(seedId);
@@ -1646,6 +1658,8 @@ TEST(StateEvolutionTest, NeuralNetMutationCanSurviveWithPositiveFitness)
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(seedId, seedGenome, seedMeta);
 
@@ -1734,6 +1748,8 @@ TEST(StateEvolutionTest, AdaptiveBudgetedMutationTracksPhaseAndKeepsPopulationSi
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = std::nullopt,
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     repo.store(seedId, seedGenome, seedMeta);
 

--- a/apps/src/server/tests/StateUnsavedTrainingResult_test.cpp
+++ b/apps/src/server/tests/StateUnsavedTrainingResult_test.cpp
@@ -36,6 +36,8 @@ UnsavedTrainingResult::Candidate makeCandidate(double fitness, double weightValu
         .brainKind = TrainingBrainKind::NeuralNet,
         .brainVariant = std::nullopt,
         .trainingSessionId = UUID::generate(),
+        .genomePoolId = GenomePoolId::DirtSim,
+        .nesTileBrainCompatibility = std::nullopt,
     };
     candidate.brainKind = TrainingBrainKind::NeuralNet;
     candidate.fitness = fitness;

--- a/apps/src/server/tests/UserSettings_test.cpp
+++ b/apps/src/server/tests/UserSettings_test.cpp
@@ -133,6 +133,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     legacyJson.erase("treeGerminationScenarioConfig");
     legacyJson["nesSessionSettings"].erase("frameDelayMs");
     legacyJson["uiTraining"].erase("bestPlaybackIntervalMs");
+    legacyJson["uiTraining"].erase("nesTileDebugView");
     legacyJson["futureSetting"] = 123;
     legacyJson["clockScenarioConfig"]["futureClockToggle"] = true;
     legacyJson["uiTraining"]["futureOverlayMode"] = "on";
@@ -158,6 +159,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_EQ(inMemory.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
     EXPECT_EQ(inMemory.uiTraining.streamIntervalMs, 24);
     EXPECT_EQ(inMemory.uiTraining.bestPlaybackIntervalMs, 16);
+    EXPECT_EQ(inMemory.uiTraining.nesTileDebugView, NesTileDebugView::NormalVideo);
 
     const UserSettings fromDisk = readUserSettingsFromDisk(settingsPath);
     EXPECT_EQ(fromDisk.clockScenarioConfig.timezone, Config::ClockTimezone::Paris);
@@ -169,6 +171,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_EQ(fromDisk.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
     EXPECT_EQ(fromDisk.uiTraining.streamIntervalMs, 24);
     EXPECT_EQ(fromDisk.uiTraining.bestPlaybackIntervalMs, 16);
+    EXPECT_EQ(fromDisk.uiTraining.nesTileDebugView, NesTileDebugView::NormalVideo);
 
     const nlohmann::json canonicalJson = readUserSettingsJsonFromDisk(settingsPath);
     EXPECT_FALSE(canonicalJson.contains("futureSetting"));
@@ -181,6 +184,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_TRUE(canonicalJson.contains("treeGerminationScenarioConfig"));
     EXPECT_TRUE(canonicalJson["nesSessionSettings"].contains("frameDelayMs"));
     EXPECT_TRUE(canonicalJson["uiTraining"].contains("bestPlaybackIntervalMs"));
+    EXPECT_TRUE(canonicalJson["uiTraining"].contains("nesTileDebugView"));
 }
 
 TEST(UserSettingsTest, UserSettingsSetJsonRemainsStrictForMissingFields)
@@ -220,6 +224,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
         .warmStartFitnessFloorPercentile = 999.0,
     };
     requestedSettings.trainingResumePolicy = static_cast<TrainingResumePolicy>(99);
+    requestedSettings.uiTraining.nesTileDebugView = static_cast<NesTileDebugView>(255);
 
     Api::UserSettingsSet::Command command{ .settings = requestedSettings };
     Api::UserSettingsSet::Cwc cwc(command, [&](Api::UserSettingsSet::Response&& result) {
@@ -240,6 +245,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(response.value().settings.defaultScenario, Scenario::EnumType::Clock);
     EXPECT_EQ(response.value().settings.startMenuIdleTimeoutMs, 3600000);
     EXPECT_EQ(response.value().settings.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
+    EXPECT_EQ(response.value().settings.uiTraining.nesTileDebugView, NesTileDebugView::NormalVideo);
     EXPECT_EQ(response.value().settings.evolutionConfig.genomeArchiveMaxSize, 1000);
     EXPECT_DOUBLE_EQ(response.value().settings.evolutionConfig.warmStartSeedPercent, 100.0);
     EXPECT_DOUBLE_EQ(
@@ -257,6 +263,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Clock);
     EXPECT_EQ(fromDisk.startMenuIdleTimeoutMs, 3600000);
     EXPECT_EQ(fromDisk.trainingResumePolicy, TrainingResumePolicy::WarmFromBest);
+    EXPECT_EQ(fromDisk.uiTraining.nesTileDebugView, NesTileDebugView::NormalVideo);
     EXPECT_EQ(fromDisk.evolutionConfig.genomeArchiveMaxSize, 1000);
     EXPECT_DOUBLE_EQ(fromDisk.evolutionConfig.warmStartSeedPercent, 100.0);
     EXPECT_DOUBLE_EQ(fromDisk.evolutionConfig.warmStartFitnessFloorPercentile, 100.0);

--- a/apps/src/ui/TrainingActiveView.cpp
+++ b/apps/src/ui/TrainingActiveView.cpp
@@ -1263,6 +1263,7 @@ void TrainingActiveView::destroyUI()
     streamIntervalStepper_ = nullptr;
     bestPlaybackToggle_ = nullptr;
     bestPlaybackIntervalStepper_ = nullptr;
+    nesTileDebugViewDropdown_ = nullptr;
     mutationControlsButton_ = nullptr;
     mutationControlsOverlay_ = nullptr;
     mutationControlsOverlayContent_ = nullptr;
@@ -1568,6 +1569,16 @@ void TrainingActiveView::setBestPlaybackEnabled(bool enabled)
             lv_obj_set_style_opa(bestPlaybackIntervalStepper_, LV_OPA_50, 0);
         }
     }
+    if (nesTileDebugViewDropdown_) {
+        if (enabled) {
+            lv_obj_clear_state(nesTileDebugViewDropdown_, LV_STATE_DISABLED);
+            lv_obj_set_style_opa(nesTileDebugViewDropdown_, LV_OPA_COVER, 0);
+        }
+        else {
+            lv_obj_add_state(nesTileDebugViewDropdown_, LV_STATE_DISABLED);
+            lv_obj_set_style_opa(nesTileDebugViewDropdown_, LV_OPA_50, 0);
+        }
+    }
 
     if (!enabled) {
         bestNesControllerTelemetry_.reset();
@@ -1588,6 +1599,17 @@ void TrainingActiveView::setBestPlaybackIntervalMs(int value)
     if (bestPlaybackIntervalStepper_) {
         LVGLBuilder::ActionStepperBuilder::setValue(
             bestPlaybackIntervalStepper_, userSettings_.uiTraining.bestPlaybackIntervalMs);
+    }
+}
+
+void TrainingActiveView::setNesTileDebugView(NesTileDebugView view)
+{
+    userSettings_.uiTraining.nesTileDebugView =
+        isNesTileDebugViewValid(view) ? view : NesTileDebugView::NormalVideo;
+    if (nesTileDebugViewDropdown_) {
+        LVGLBuilder::ActionDropdownBuilder::setSelected(
+            nesTileDebugViewDropdown_,
+            nesTileDebugViewIndex(userSettings_.uiTraining.nesTileDebugView));
     }
 }
 
@@ -2688,6 +2710,7 @@ void TrainingActiveView::setEvolutionStarted(bool started)
     setTrainingPaused(false);
     setBestPlaybackEnabled(userSettings_.uiTraining.bestPlaybackEnabled);
     setBestPlaybackIntervalMs(userSettings_.uiTraining.bestPlaybackIntervalMs);
+    setNesTileDebugView(userSettings_.uiTraining.nesTileDebugView);
     setMutationControls(
         userSettings_.mutationConfig, userSettings_.evolutionConfig, mutationControlMode_);
     setNesControllerOverlayEnabled(isNesControllerOverlayEnabled(userSettings_));
@@ -2862,6 +2885,15 @@ void TrainingActiveView::createStreamPanel(lv_obj_t* parent)
             .callback(onBestPlaybackIntervalChanged, this)
             .buildOrLog();
 
+    nesTileDebugViewDropdown_ =
+        LVGLBuilder::actionDropdown(streamPanel_)
+            .label("NES View")
+            .options(nesTileDebugViewOptions())
+            .selected(nesTileDebugViewIndex(userSettings_.uiTraining.nesTileDebugView))
+            .width(LV_PCT(100))
+            .callback(onNesTileDebugViewChanged, this)
+            .buildOrLog();
+
     scenarioControlsButton_ = LVGLBuilder::actionButton(streamPanel_)
                                   .text("Scenario Controls")
                                   .icon(LV_SYMBOL_RIGHT)
@@ -2951,6 +2983,7 @@ void TrainingActiveView::createStreamPanel(lv_obj_t* parent)
     updateScenarioButtonState();
     setBestPlaybackEnabled(userSettings_.uiTraining.bestPlaybackEnabled);
     setBestPlaybackIntervalMs(userSettings_.uiTraining.bestPlaybackIntervalMs);
+    setNesTileDebugView(userSettings_.uiTraining.nesTileDebugView);
     setMutationControls(
         userSettings_.mutationConfig, userSettings_.evolutionConfig, mutationControlMode_);
     setNesControllerOverlayEnabled(isNesControllerOverlayEnabled(userSettings_));
@@ -2972,6 +3005,7 @@ void TrainingActiveView::onStreamIntervalChanged(lv_event_t* e)
             .bestPlaybackIntervalMs = self->userSettings_.uiTraining.bestPlaybackIntervalMs,
             .nesControllerOverlayEnabled =
                 self->userSettings_.uiTraining.nesControllerOverlayEnabled,
+            .nesTileDebugView = self->userSettings_.uiTraining.nesTileDebugView,
         });
 }
 
@@ -2991,6 +3025,7 @@ void TrainingActiveView::onBestPlaybackToggled(lv_event_t* e)
             .bestPlaybackIntervalMs = self->userSettings_.uiTraining.bestPlaybackIntervalMs,
             .nesControllerOverlayEnabled =
                 self->userSettings_.uiTraining.nesControllerOverlayEnabled,
+            .nesTileDebugView = self->userSettings_.uiTraining.nesTileDebugView,
         });
 }
 
@@ -3011,6 +3046,27 @@ void TrainingActiveView::onBestPlaybackIntervalChanged(lv_event_t* e)
             .bestPlaybackIntervalMs = self->userSettings_.uiTraining.bestPlaybackIntervalMs,
             .nesControllerOverlayEnabled =
                 self->userSettings_.uiTraining.nesControllerOverlayEnabled,
+            .nesTileDebugView = self->userSettings_.uiTraining.nesTileDebugView,
+        });
+}
+
+void TrainingActiveView::onNesTileDebugViewChanged(lv_event_t* e)
+{
+    auto* self = static_cast<TrainingActiveView*>(lv_event_get_user_data(e));
+    if (!self || !self->nesTileDebugViewDropdown_) {
+        return;
+    }
+
+    self->setNesTileDebugView(nesTileDebugViewFromIndex(
+        LVGLBuilder::ActionDropdownBuilder::getSelected(self->nesTileDebugViewDropdown_)));
+    self->eventSink_.queueEvent(
+        TrainingStreamConfigChangedEvent{
+            .intervalMs = self->userSettings_.uiTraining.streamIntervalMs,
+            .bestPlaybackEnabled = self->userSettings_.uiTraining.bestPlaybackEnabled,
+            .bestPlaybackIntervalMs = self->userSettings_.uiTraining.bestPlaybackIntervalMs,
+            .nesControllerOverlayEnabled =
+                self->userSettings_.uiTraining.nesControllerOverlayEnabled,
+            .nesTileDebugView = self->userSettings_.uiTraining.nesTileDebugView,
         });
 }
 
@@ -3123,6 +3179,7 @@ void TrainingActiveView::onNesControllerOverlayToggled(lv_event_t* e)
             .bestPlaybackEnabled = self->userSettings_.uiTraining.bestPlaybackEnabled,
             .bestPlaybackIntervalMs = self->userSettings_.uiTraining.bestPlaybackIntervalMs,
             .nesControllerOverlayEnabled = enabled,
+            .nesTileDebugView = self->userSettings_.uiTraining.nesTileDebugView,
         });
 }
 

--- a/apps/src/ui/TrainingActiveView.h
+++ b/apps/src/ui/TrainingActiveView.h
@@ -92,6 +92,7 @@ public:
     void setStreamIntervalMs(int value);
     void setBestPlaybackEnabled(bool enabled);
     void setBestPlaybackIntervalMs(int value);
+    void setNesTileDebugView(NesTileDebugView view);
     void setMutationControls(
         const MutationConfig& mutationConfig,
         const EvolutionConfig& evolutionConfig,
@@ -148,6 +149,7 @@ private:
     static void onStreamIntervalChanged(lv_event_t* e);
     static void onBestPlaybackToggled(lv_event_t* e);
     static void onBestPlaybackIntervalChanged(lv_event_t* e);
+    static void onNesTileDebugViewChanged(lv_event_t* e);
     static void onMutationControlModeChanged(lv_event_t* e);
     static void onMutationControlsClicked(lv_event_t* e);
     static void onMutationPerturbationsChanged(lv_event_t* e);
@@ -207,6 +209,7 @@ private:
     lv_obj_t* streamIntervalStepper_ = nullptr;
     lv_obj_t* bestPlaybackToggle_ = nullptr;
     lv_obj_t* bestPlaybackIntervalStepper_ = nullptr;
+    lv_obj_t* nesTileDebugViewDropdown_ = nullptr;
     lv_obj_t* mutationControlsButton_ = nullptr;
     lv_obj_t* mutationControlsOverlay_ = nullptr;
     lv_obj_t* mutationControlsOverlayContent_ = nullptr;

--- a/apps/src/ui/TrainingIdleView.cpp
+++ b/apps/src/ui/TrainingIdleView.cpp
@@ -220,7 +220,8 @@ void TrainingIdleView::createTrainingConfigPanel()
         userSettings_.trainingSpec,
         userSettings_.uiTraining.streamIntervalMs,
         userSettings_.uiTraining.bestPlaybackEnabled,
-        userSettings_.uiTraining.bestPlaybackIntervalMs);
+        userSettings_.uiTraining.bestPlaybackIntervalMs,
+        userSettings_.uiTraining.nesTileDebugView);
     LOG_INFO(Controls, "TrainingIdleView: Created Training config panel");
 }
 
@@ -288,6 +289,15 @@ void TrainingIdleView::setBestPlaybackIntervalMs(int value)
     if (trainingConfigPanel_) {
         trainingConfigPanel_->setBestPlaybackIntervalMs(
             userSettings_.uiTraining.bestPlaybackIntervalMs);
+    }
+}
+
+void TrainingIdleView::setNesTileDebugView(NesTileDebugView view)
+{
+    userSettings_.uiTraining.nesTileDebugView =
+        isNesTileDebugViewValid(view) ? view : NesTileDebugView::NormalVideo;
+    if (trainingConfigPanel_) {
+        trainingConfigPanel_->setNesTileDebugView(userSettings_.uiTraining.nesTileDebugView);
     }
 }
 

--- a/apps/src/ui/TrainingIdleView.cpp
+++ b/apps/src/ui/TrainingIdleView.cpp
@@ -360,16 +360,11 @@ void TrainingIdleView::addGenomeToTraining(const GenomeId& genomeId)
         PopulationSpec spec;
         switch (userSettings_.trainingSpec.organismType) {
             case OrganismType::TREE:
-                spec.brainKind = TrainingBrainKind::NeuralNet;
-                break;
             case OrganismType::DUCK:
-                spec.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
-                break;
             case OrganismType::NES_DUCK:
-                spec.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
-                break;
             case OrganismType::GOOSE:
-                spec.brainKind = TrainingBrainKind::Random;
+                spec.brainKind = defaultTrainingBrainKind(
+                    userSettings_.trainingSpec.organismType, userSettings_.trainingSpec.scenarioId);
                 break;
             default:
                 spec.brainKind = TrainingBrainKind::Random;

--- a/apps/src/ui/TrainingIdleView.h
+++ b/apps/src/ui/TrainingIdleView.h
@@ -60,6 +60,7 @@ public:
     void setStreamIntervalMs(int value);
     void setBestPlaybackEnabled(bool enabled);
     void setBestPlaybackIntervalMs(int value);
+    void setNesTileDebugView(NesTileDebugView view);
     void setEvolutionStarted(bool started);
     Result<GenomeId, std::string> openGenomeDetailByIndex(int index);
     Result<GenomeId, std::string> openGenomeDetailById(const GenomeId& genomeId);

--- a/apps/src/ui/controls/EvolutionConfigPanel.cpp
+++ b/apps/src/ui/controls/EvolutionConfigPanel.cpp
@@ -363,16 +363,10 @@ void EvolutionConfigPanel::onPopulationChanged(lv_event_t* e)
         PopulationSpec entry;
         switch (spec.organismType) {
             case OrganismType::TREE:
-                entry.brainKind = TrainingBrainKind::NeuralNet;
-                break;
             case OrganismType::DUCK:
-                entry.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
-                break;
             case OrganismType::NES_DUCK:
-                entry.brainKind = TrainingBrainKind::DuckNeuralNetRecurrentV2;
-                break;
             case OrganismType::GOOSE:
-                entry.brainKind = TrainingBrainKind::Random;
+                entry.brainKind = defaultTrainingBrainKind(spec.organismType, spec.scenarioId);
                 break;
             default:
                 entry.brainKind = TrainingBrainKind::Random;

--- a/apps/src/ui/controls/TrainingConfigPanel.cpp
+++ b/apps/src/ui/controls/TrainingConfigPanel.cpp
@@ -32,7 +32,8 @@ TrainingConfigPanel::TrainingConfigPanel(
     TrainingSpec& trainingSpec,
     int& streamIntervalMs,
     bool& bestPlaybackEnabled,
-    int& bestPlaybackIntervalMs)
+    int& bestPlaybackIntervalMs,
+    NesTileDebugView& nesTileDebugView)
     : container_(container),
       eventSink_(eventSink),
       uiServices_(uiServices),
@@ -44,7 +45,8 @@ TrainingConfigPanel::TrainingConfigPanel(
       trainingSpec_(trainingSpec),
       streamIntervalMs_(streamIntervalMs),
       bestPlaybackEnabled_(bestPlaybackEnabled),
-      bestPlaybackIntervalMs_(bestPlaybackIntervalMs)
+      bestPlaybackIntervalMs_(bestPlaybackIntervalMs),
+      nesTileDebugView_(nesTileDebugView)
 {
     collapsedWidth_ = ExpandablePanel::DefaultWidth;
     const int displayWidth = lv_disp_get_hor_res(lv_disp_get_default());
@@ -126,6 +128,15 @@ void TrainingConfigPanel::setBestPlaybackIntervalMs(int value)
     if (bestPlaybackIntervalStepper_) {
         LVGLBuilder::ActionStepperBuilder::setValue(
             bestPlaybackIntervalStepper_, bestPlaybackIntervalMs_);
+    }
+}
+
+void TrainingConfigPanel::setNesTileDebugView(NesTileDebugView view)
+{
+    nesTileDebugView_ = isNesTileDebugViewValid(view) ? view : NesTileDebugView::NormalVideo;
+    if (nesTileDebugViewDropdown_) {
+        LVGLBuilder::ActionDropdownBuilder::setSelected(
+            nesTileDebugViewDropdown_, nesTileDebugViewIndex(nesTileDebugView_));
     }
 }
 
@@ -439,6 +450,14 @@ void TrainingConfigPanel::createEvolutionView(lv_obj_t* parent)
                                        .callback(onBestPlaybackIntervalChanged, this)
                                        .buildOrLog();
 
+    nesTileDebugViewDropdown_ = LVGLBuilder::actionDropdown(parent)
+                                    .label("NES View")
+                                    .options(nesTileDebugViewOptions())
+                                    .selected(nesTileDebugViewIndex(nesTileDebugView_))
+                                    .width(LV_PCT(95))
+                                    .callback(onNesTileDebugViewChanged, this)
+                                    .buildOrLog();
+
     statusLabel_ = lv_label_create(parent);
     lv_label_set_text(statusLabel_, "");
     lv_obj_set_style_text_color(statusLabel_, lv_color_hex(kStatusReadyColor), 0);
@@ -517,6 +536,7 @@ void TrainingConfigPanel::updateControlsEnabled()
     setEnabled(streamIntervalStepper_, true);
     setEnabled(bestPlaybackToggle_, true);
     setEnabled(bestPlaybackIntervalStepper_, bestPlaybackEnabled_);
+    setEnabled(nesTileDebugViewDropdown_, bestPlaybackEnabled_);
 
     if (enabled) {
         setEnabled(mutationPerturbationsStepper_, true);
@@ -743,6 +763,7 @@ void TrainingConfigPanel::onStreamIntervalChanged(lv_event_t* e)
             .intervalMs = value,
             .bestPlaybackEnabled = self->bestPlaybackEnabled_,
             .bestPlaybackIntervalMs = self->bestPlaybackIntervalMs_,
+            .nesTileDebugView = self->nesTileDebugView_,
         });
 }
 
@@ -759,6 +780,7 @@ void TrainingConfigPanel::onBestPlaybackToggled(lv_event_t* e)
             .intervalMs = self->streamIntervalMs_,
             .bestPlaybackEnabled = self->bestPlaybackEnabled_,
             .bestPlaybackIntervalMs = self->bestPlaybackIntervalMs_,
+            .nesTileDebugView = self->nesTileDebugView_,
         });
 }
 
@@ -775,6 +797,23 @@ void TrainingConfigPanel::onBestPlaybackIntervalChanged(lv_event_t* e)
             .intervalMs = self->streamIntervalMs_,
             .bestPlaybackEnabled = self->bestPlaybackEnabled_,
             .bestPlaybackIntervalMs = self->bestPlaybackIntervalMs_,
+            .nesTileDebugView = self->nesTileDebugView_,
+        });
+}
+
+void TrainingConfigPanel::onNesTileDebugViewChanged(lv_event_t* e)
+{
+    auto* self = static_cast<TrainingConfigPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->nesTileDebugViewDropdown_) return;
+
+    self->nesTileDebugView_ = nesTileDebugViewFromIndex(
+        LVGLBuilder::ActionDropdownBuilder::getSelected(self->nesTileDebugViewDropdown_));
+    self->eventSink_.queueEvent(
+        TrainingStreamConfigChangedEvent{
+            .intervalMs = self->streamIntervalMs_,
+            .bestPlaybackEnabled = self->bestPlaybackEnabled_,
+            .bestPlaybackIntervalMs = self->bestPlaybackIntervalMs_,
+            .nesTileDebugView = self->nesTileDebugView_,
         });
 }
 

--- a/apps/src/ui/controls/TrainingConfigPanel.h
+++ b/apps/src/ui/controls/TrainingConfigPanel.h
@@ -2,6 +2,7 @@
 
 #include "core/organisms/evolution/EvolutionConfig.h"
 #include "core/organisms/evolution/GenomeMetadata.h"
+#include "core/scenarios/nes/NesTileDebugView.h"
 #include "lvgl/lvgl.h"
 #include <memory>
 
@@ -39,7 +40,8 @@ public:
         TrainingSpec& trainingSpec,
         int& streamIntervalMs,
         bool& bestPlaybackEnabled,
-        int& bestPlaybackIntervalMs);
+        int& bestPlaybackIntervalMs,
+        NesTileDebugView& nesTileDebugView);
     ~TrainingConfigPanel();
 
     void setEvolutionStarted(bool started);
@@ -47,6 +49,7 @@ public:
     void setStreamIntervalMs(int value);
     void setBestPlaybackEnabled(bool enabled);
     void setBestPlaybackIntervalMs(int value);
+    void setNesTileDebugView(NesTileDebugView view);
     void showView(View view);
     void addSeedGenome(const GenomeId& genomeId);
 
@@ -66,6 +69,7 @@ private:
     int& streamIntervalMs_;
     bool& bestPlaybackEnabled_;
     int& bestPlaybackIntervalMs_;
+    NesTileDebugView& nesTileDebugView_;
 
     int collapsedWidth_ = 0;
     int expandedWidth_ = 0;
@@ -95,6 +99,7 @@ private:
     lv_obj_t* streamIntervalStepper_ = nullptr;
     lv_obj_t* bestPlaybackToggle_ = nullptr;
     lv_obj_t* bestPlaybackIntervalStepper_ = nullptr;
+    lv_obj_t* nesTileDebugViewDropdown_ = nullptr;
 
     std::unique_ptr<TrainingPopulationPanel> trainingPopulationPanel_;
 
@@ -126,6 +131,7 @@ private:
     static void onStreamIntervalChanged(lv_event_t* e);
     static void onBestPlaybackToggled(lv_event_t* e);
     static void onBestPlaybackIntervalChanged(lv_event_t* e);
+    static void onNesTileDebugViewChanged(lv_event_t* e);
 };
 
 } // namespace Ui

--- a/apps/src/ui/controls/TrainingPopulationPanel.cpp
+++ b/apps/src/ui/controls/TrainingPopulationPanel.cpp
@@ -48,6 +48,7 @@ std::vector<TrainingPopulationPanel::BrainOption> getBrainOptions(OrganismType o
         case OrganismType::NES_DUCK:
             return {
                 { TrainingBrainKind::DuckNeuralNetRecurrentV2, true },
+                { TrainingBrainKind::NesTileRecurrent, true },
             };
         case OrganismType::GOOSE:
             return {
@@ -813,7 +814,7 @@ void TrainingPopulationPanel::applySpecUpdates()
 }
 
 TrainingPopulationPanel::BrainOption TrainingPopulationPanel::resolveBrainOptionForScenario(
-    Scenario::EnumType /*scenarioId*/) const
+    Scenario::EnumType scenarioId) const
 {
     if (brainOptions_.empty()) {
         return {
@@ -821,6 +822,16 @@ TrainingPopulationPanel::BrainOption TrainingPopulationPanel::resolveBrainOption
             .requiresGenome = false,
         };
     }
+
+    const std::string defaultKind = defaultTrainingBrainKind(selectedOrganism_, scenarioId);
+    auto defaultIt =
+        std::find_if(brainOptions_.begin(), brainOptions_.end(), [&](const BrainOption& opt) {
+            return opt.kind == defaultKind;
+        });
+    if (defaultIt != brainOptions_.end()) {
+        return *defaultIt;
+    }
+
     return brainOptions_.front();
 }
 
@@ -837,13 +848,14 @@ void TrainingPopulationPanel::setBrainOptionsForOrganism(OrganismType organismTy
     auto it = std::find_if(brainOptions_.begin(), brainOptions_.end(), [&](const BrainOption& opt) {
         return opt.kind == brainKind_;
     });
-    if (it != brainOptions_.end()) {
+    if (!trainingSpec_.population.empty() && it != brainOptions_.end()) {
         brainKind_ = it->kind;
         brainRequiresGenome_ = it->requiresGenome;
     }
     else {
-        brainKind_ = brainOptions_.front().kind;
-        brainRequiresGenome_ = brainOptions_.front().requiresGenome;
+        const BrainOption option = resolveBrainOptionForScenario(selectedScenario_);
+        brainKind_ = option.kind;
+        brainRequiresGenome_ = option.requiresGenome;
     }
 
     rebuildBrainListButtons();
@@ -1387,6 +1399,11 @@ void TrainingPopulationPanel::onScenarioSelected(lv_event_t* e)
         return;
     }
     self->selectedScenario_ = selected;
+    if (self->trainingSpec_.population.empty()) {
+        const BrainOption option = self->resolveBrainOptionForScenario(self->selectedScenario_);
+        self->brainKind_ = option.kind;
+        self->brainRequiresGenome_ = option.requiresGenome;
+    }
     self->applySpecUpdates();
     self->syncUiFromState();
     self->setOrganismListVisible(false);
@@ -1406,9 +1423,9 @@ void TrainingPopulationPanel::onOrganismSelected(lv_event_t* e)
     self->selectedOrganism_ = it->second;
     self->selectedScenario_ =
         self->coerceScenarioToOrganism(self->selectedScenario_, self->selectedOrganism_);
-    self->setBrainOptionsForOrganism(self->selectedOrganism_);
     self->trainingSpec_.population.clear();
     self->populationTotal_ = 0;
+    self->setBrainOptionsForOrganism(self->selectedOrganism_);
     self->applySpecUpdates();
     self->syncUiFromState();
     self->setOrganismListVisible(false);

--- a/apps/src/ui/state-machine/Event.h
+++ b/apps/src/ui/state-machine/Event.h
@@ -222,6 +222,7 @@ struct TrainingStreamConfigChangedEvent {
     bool bestPlaybackEnabled = false;
     int bestPlaybackIntervalMs = 16;
     std::optional<bool> nesControllerOverlayEnabled = std::nullopt;
+    NesTileDebugView nesTileDebugView = NesTileDebugView::NormalVideo;
     static constexpr const char* name() { return "TrainingStreamConfigChangedEvent"; }
 };
 

--- a/apps/src/ui/state-machine/states/TrainingActive.cpp
+++ b/apps/src/ui/state-machine/states/TrainingActive.cpp
@@ -465,6 +465,9 @@ State::Any TrainingActive::onEvent(const TrainingStreamConfigChangedEvent& evt, 
     if (evt.nesControllerOverlayEnabled.has_value()) {
         settings.uiTraining.nesControllerOverlayEnabled = evt.nesControllerOverlayEnabled;
     }
+    settings.uiTraining.nesTileDebugView = isNesTileDebugViewValid(evt.nesTileDebugView)
+        ? evt.nesTileDebugView
+        : NesTileDebugView::NormalVideo;
 
     DIRTSIM_ASSERT(view_, "TrainingActiveView must exist");
     view_->setStreamIntervalMs(settings.uiTraining.streamIntervalMs);
@@ -472,6 +475,7 @@ State::Any TrainingActive::onEvent(const TrainingStreamConfigChangedEvent& evt, 
     view_->setBestPlaybackIntervalMs(settings.uiTraining.bestPlaybackIntervalMs);
     view_->setNesControllerOverlayEnabled(
         settings.uiTraining.nesControllerOverlayEnabled.value_or(false));
+    view_->setNesTileDebugView(settings.uiTraining.nesTileDebugView);
 
     Api::UserSettingsPatch::Command patchCmd{ .uiTraining = settings.uiTraining };
     sm.getUserSettingsManager().patchOrAssert(patchCmd, 2000);

--- a/apps/src/ui/state-machine/states/TrainingIdle.cpp
+++ b/apps/src/ui/state-machine/states/TrainingIdle.cpp
@@ -340,11 +340,15 @@ State::Any TrainingIdle::onEvent(const TrainingStreamConfigChangedEvent& evt, St
     if (evt.nesControllerOverlayEnabled.has_value()) {
         settings.uiTraining.nesControllerOverlayEnabled = evt.nesControllerOverlayEnabled;
     }
+    settings.uiTraining.nesTileDebugView = isNesTileDebugViewValid(evt.nesTileDebugView)
+        ? evt.nesTileDebugView
+        : NesTileDebugView::NormalVideo;
 
     DIRTSIM_ASSERT(view_, "TrainingIdleView must exist");
     view_->setStreamIntervalMs(settings.uiTraining.streamIntervalMs);
     view_->setBestPlaybackEnabled(settings.uiTraining.bestPlaybackEnabled);
     view_->setBestPlaybackIntervalMs(settings.uiTraining.bestPlaybackIntervalMs);
+    view_->setNesTileDebugView(settings.uiTraining.nesTileDebugView);
 
     Api::UserSettingsPatch::Command patchCmd{ .uiTraining = settings.uiTraining };
     sm.getUserSettingsManager().patchOrAssert(patchCmd, 2000);

--- a/apps/src/ui/state-machine/tests/StateTraining_test.cpp
+++ b/apps/src/ui/state-machine/tests/StateTraining_test.cpp
@@ -767,6 +767,57 @@ TEST(StateTrainingTest, TrainingIdleConfigUpdatePatchesUserSettings)
     EXPECT_EQ(local.trainingSpec.population.front().brainKind, TrainingBrainKind::NesTileRecurrent);
 }
 
+TEST(StateTrainingTest, TrainingIdleStreamConfigUpdatePatchesNesTileDebugView)
+{
+    LvglTestDisplay lvgl;
+    TestStateMachineFixture fixture;
+
+    fixture.stateMachine->uiManager_ = std::make_unique<UiComponentManager>(lvgl.display);
+    fixture.stateMachine->uiManager_->setEventSink(fixture.stateMachine.get());
+
+    Api::UserSettingsPatch::Okay settingsOkay{
+        .settings = fixture.stateMachine->getUserSettings(),
+    };
+    settingsOkay.settings.uiTraining.streamIntervalMs = 33;
+    settingsOkay.settings.uiTraining.bestPlaybackEnabled = true;
+    settingsOkay.settings.uiTraining.bestPlaybackIntervalMs = 44;
+    settingsOkay.settings.uiTraining.nesTileDebugView = NesTileDebugView::PlayerRelativeTokens;
+    fixture.mockWebSocketService->expectSuccess<Api::UserSettingsPatch::Command>(settingsOkay);
+
+    TrainingIdle trainingState;
+    trainingState.onEnter(*fixture.stateMachine);
+    fixture.mockWebSocketService->clearSentCommands();
+
+    State::Any newState = trainingState.onEvent(
+        TrainingStreamConfigChangedEvent{
+            .intervalMs = 33,
+            .bestPlaybackEnabled = true,
+            .bestPlaybackIntervalMs = 44,
+            .nesTileDebugView = NesTileDebugView::PlayerRelativeTokens,
+        },
+        *fixture.stateMachine);
+
+    ASSERT_TRUE(std::holds_alternative<TrainingIdle>(newState.getVariant()));
+    auto& updatedState = std::get<TrainingIdle>(newState.getVariant());
+
+    ASSERT_EQ(fixture.mockWebSocketService->sentCommands().size(), 1u);
+    EXPECT_EQ(fixture.mockWebSocketService->sentCommands()[0], "UserSettingsPatch");
+    ASSERT_EQ(fixture.mockWebSocketService->sentEnvelopes().size(), 1u);
+    const auto sentPatch = Network::deserialize_payload<Api::UserSettingsPatch::Command>(
+        fixture.mockWebSocketService->sentEnvelopes().back().payload);
+    ASSERT_TRUE(sentPatch.uiTraining.has_value());
+    EXPECT_EQ(sentPatch.uiTraining->nesTileDebugView, NesTileDebugView::PlayerRelativeTokens);
+
+    const auto& local = fixture.stateMachine->getUserSettings().uiTraining;
+    EXPECT_EQ(local.streamIntervalMs, 33);
+    EXPECT_TRUE(local.bestPlaybackEnabled);
+    EXPECT_EQ(local.bestPlaybackIntervalMs, 44);
+    EXPECT_EQ(local.nesTileDebugView, NesTileDebugView::PlayerRelativeTokens);
+
+    updatedState.view_.reset();
+    fixture.stateMachine->uiManager_.reset();
+}
+
 TEST(StateTrainingTest, TrainingActiveConfigUpdatePatchesUserSettings)
 {
     TestStateMachineFixture fixture;
@@ -804,6 +855,63 @@ TEST(StateTrainingTest, TrainingActiveConfigUpdatePatchesUserSettings)
     EXPECT_DOUBLE_EQ(local.mutationConfig.sigma, settingsOkay.settings.mutationConfig.sigma);
     EXPECT_EQ(local.trainingSpec.scenarioId, settingsOkay.settings.trainingSpec.scenarioId);
     EXPECT_EQ(local.trainingSpec.organismType, settingsOkay.settings.trainingSpec.organismType);
+}
+
+TEST(StateTrainingTest, TrainingActiveStreamConfigUpdatePatchesNesTileDebugView)
+{
+    LvglTestDisplay lvgl;
+    TestStateMachineFixture fixture;
+
+    fixture.stateMachine->uiManager_ = std::make_unique<UiComponentManager>(lvgl.display);
+    fixture.stateMachine->uiManager_->setEventSink(fixture.stateMachine.get());
+
+    fixture.mockWebSocketService->expectSuccess<Api::RenderFormatSet::Command>(
+        { .active_format = RenderFormat::EnumType::Basic, .message = "OK" });
+
+    Api::UserSettingsPatch::Okay settingsOkay{
+        .settings = fixture.stateMachine->getUserSettings(),
+    };
+    settingsOkay.settings.uiTraining.streamIntervalMs = 55;
+    settingsOkay.settings.uiTraining.bestPlaybackEnabled = true;
+    settingsOkay.settings.uiTraining.bestPlaybackIntervalMs = 66;
+    settingsOkay.settings.uiTraining.nesControllerOverlayEnabled = true;
+    settingsOkay.settings.uiTraining.nesTileDebugView = NesTileDebugView::Comparison;
+    fixture.mockWebSocketService->expectSuccess<Api::UserSettingsPatch::Command>(settingsOkay);
+
+    TrainingActive trainingState;
+    trainingState.onEnter(*fixture.stateMachine);
+    fixture.mockWebSocketService->clearSentCommands();
+
+    State::Any newState = trainingState.onEvent(
+        TrainingStreamConfigChangedEvent{
+            .intervalMs = 55,
+            .bestPlaybackEnabled = true,
+            .bestPlaybackIntervalMs = 66,
+            .nesControllerOverlayEnabled = true,
+            .nesTileDebugView = NesTileDebugView::Comparison,
+        },
+        *fixture.stateMachine);
+
+    ASSERT_TRUE(std::holds_alternative<TrainingActive>(newState.getVariant()));
+    auto& updatedState = std::get<TrainingActive>(newState.getVariant());
+
+    ASSERT_EQ(fixture.mockWebSocketService->sentCommands().size(), 1u);
+    EXPECT_EQ(fixture.mockWebSocketService->sentCommands()[0], "UserSettingsPatch");
+    ASSERT_EQ(fixture.mockWebSocketService->sentEnvelopes().size(), 1u);
+    const auto sentPatch = Network::deserialize_payload<Api::UserSettingsPatch::Command>(
+        fixture.mockWebSocketService->sentEnvelopes().back().payload);
+    ASSERT_TRUE(sentPatch.uiTraining.has_value());
+    EXPECT_EQ(sentPatch.uiTraining->nesTileDebugView, NesTileDebugView::Comparison);
+
+    const auto& local = fixture.stateMachine->getUserSettings().uiTraining;
+    EXPECT_EQ(local.streamIntervalMs, 55);
+    EXPECT_TRUE(local.bestPlaybackEnabled);
+    EXPECT_EQ(local.bestPlaybackIntervalMs, 66);
+    EXPECT_EQ(local.nesControllerOverlayEnabled, std::optional<bool>(true));
+    EXPECT_EQ(local.nesTileDebugView, NesTileDebugView::Comparison);
+
+    updatedState.view_.reset();
+    fixture.stateMachine->uiManager_.reset();
 }
 
 TEST(StateTrainingTest, TrainingActiveMutationControlsUpdateUsesLiveCommandAndPersistsSettings)

--- a/apps/src/ui/state-machine/tests/StateTraining_test.cpp
+++ b/apps/src/ui/state-machine/tests/StateTraining_test.cpp
@@ -654,6 +654,61 @@ TEST(StateTrainingTest, StartEvolutionAllowsZeroGenerations)
     fixture.stateMachine->uiManager_.reset();
 }
 
+TEST(StateTrainingTest, StartEvolutionSendsExplicitNesTileBrainPopulation)
+{
+    LvglTestDisplay lvgl;
+    TestStateMachineFixture fixture;
+
+    fixture.stateMachine->uiManager_ = std::make_unique<UiComponentManager>(lvgl.display);
+    fixture.stateMachine->uiManager_->setEventSink(fixture.stateMachine.get());
+
+    fixture.mockWebSocketService->expectSuccess<Api::RenderFormatSet::Command>(
+        { .active_format = RenderFormat::EnumType::Basic, .message = "OK" });
+    fixture.mockWebSocketService->expectSuccess<Api::EvolutionStart::Command>({ .started = true });
+
+    TrainingIdle trainingState;
+    trainingState.onEnter(*fixture.stateMachine);
+
+    StartEvolutionButtonClickedEvent evt;
+    evt.evolution.populationSize = 4;
+    evt.evolution.maxGenerations = 1;
+    evt.mutation.perturbationsPerOffspring = 120;
+    evt.mutation.resetsPerOffspring = 2;
+    evt.mutation.sigma = 0.1;
+    evt.training.scenarioId = Scenario::EnumType::NesSuperMarioBros;
+    evt.training.organismType = OrganismType::NES_DUCK;
+    evt.training.population.push_back(
+        PopulationSpec{
+            .brainKind = TrainingBrainKind::NesTileRecurrent,
+            .brainVariant = std::nullopt,
+            .count = 4,
+            .seedGenomes = {},
+            .randomCount = 4,
+        });
+
+    State::Any result = trainingState.onEvent(evt, *fixture.stateMachine);
+
+    auto* activeState = std::get_if<TrainingActive>(&result.getVariant());
+    ASSERT_NE(activeState, nullptr);
+
+    const auto& sentCommands = fixture.mockWebSocketService->sentCommands();
+    ASSERT_GE(sentCommands.size(), 2u);
+    EXPECT_EQ(sentCommands[0], "RenderFormatSet");
+    EXPECT_EQ(sentCommands[1], "EvolutionStart");
+
+    const auto sentStartCommand = Network::deserialize_payload<Api::EvolutionStart::Command>(
+        fixture.mockWebSocketService->sentEnvelopes()[1].payload);
+    EXPECT_EQ(sentStartCommand.scenarioId, Scenario::EnumType::NesSuperMarioBros);
+    EXPECT_EQ(sentStartCommand.organismType, OrganismType::NES_DUCK);
+    ASSERT_EQ(sentStartCommand.population.size(), 1u);
+    EXPECT_EQ(sentStartCommand.population.front().brainKind, TrainingBrainKind::NesTileRecurrent);
+    EXPECT_EQ(sentStartCommand.population.front().count, 4);
+    EXPECT_EQ(sentStartCommand.population.front().randomCount, 4);
+
+    trainingState.view_.reset();
+    fixture.stateMachine->uiManager_.reset();
+}
+
 TEST(StateTrainingTest, TrainingIdleConfigUpdatePatchesUserSettings)
 {
     TestStateMachineFixture fixture;
@@ -668,6 +723,15 @@ TEST(StateTrainingTest, TrainingIdleConfigUpdatePatchesUserSettings)
     settingsOkay.settings.mutationConfig.sigma = 0.123;
     settingsOkay.settings.trainingSpec.scenarioId = Scenario::EnumType::NesFlappyParatroopa;
     settingsOkay.settings.trainingSpec.organismType = OrganismType::NES_DUCK;
+    settingsOkay.settings.trainingSpec.population = {
+        PopulationSpec{
+            .brainKind = TrainingBrainKind::NesTileRecurrent,
+            .brainVariant = std::nullopt,
+            .count = 37,
+            .seedGenomes = {},
+            .randomCount = 37,
+        },
+    };
 
     fixture.mockWebSocketService->expectSuccess<Api::UserSettingsPatch::Command>(settingsOkay);
 
@@ -699,6 +763,8 @@ TEST(StateTrainingTest, TrainingIdleConfigUpdatePatchesUserSettings)
     EXPECT_DOUBLE_EQ(local.mutationConfig.sigma, settingsOkay.settings.mutationConfig.sigma);
     EXPECT_EQ(local.trainingSpec.scenarioId, settingsOkay.settings.trainingSpec.scenarioId);
     EXPECT_EQ(local.trainingSpec.organismType, settingsOkay.settings.trainingSpec.organismType);
+    ASSERT_EQ(local.trainingSpec.population.size(), 1u);
+    EXPECT_EQ(local.trainingSpec.population.front().brainKind, TrainingBrainKind::NesTileRecurrent);
 }
 
 TEST(StateTrainingTest, TrainingActiveConfigUpdatePatchesUserSettings)

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,7 +279,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -644,7 +643,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/timer-stats.sh
+++ b/timer-stats.sh
@@ -45,38 +45,72 @@ fi
 echo "Server timer stats for ${REMOTE_HOST} (sorted by ${SORT_BY})"
 echo
 
-jq -r '
+SUMMARY_ROWS="$(
+    jq -r '
     .value as $timers
-    | [
-        ["training_total", $timers.training_total.avg_ms, $timers.training_total.total_ms, $timers.training_total.calls],
-        ["total_simulation", $timers.total_simulation.avg_ms, $timers.total_simulation.total_ms, $timers.total_simulation.calls],
-        ["advance_time", $timers.advance_time.avg_ms, $timers.advance_time.total_ms, $timers.advance_time.calls]
-    ]
+    | ["training_total", "total_simulation", "advance_time"]
+    | map(select($timers[.] != null))
     | .[]
+    | [., ($timers[.].avg_ms // 0), ($timers[.].total_ms // 0), ($timers[.].calls // 0)]
     | @tsv
-' <<<"$JSON_OUTPUT" | awk -F $'\t' '
+    ' <<<"$JSON_OUTPUT"
+)"
+
+echo "summary"
+if [[ -z "$SUMMARY_ROWS" ]]; then
+    echo "(no summary timers reported)"
+else
+    awk -F $'\t' '
     BEGIN {
-        print "summary";
         printf "%-20s %12s %14s %12s\n", "timer", "avg_ms", "total_ms", "calls";
     }
     {
         printf "%-20s %12.6f %14.3f %12d\n", $1, $2, $3, $4;
     }
-'
+    ' <<<"$SUMMARY_ROWS"
+fi
 
 echo
 
-jq -r --arg sort "$SORT_BY" '
+REFERENCE_TIMER="$(
+    jq -r '
     .value as $timers
-    | $timers.advance_time.total_ms as $advance_total_ms
+    | ["advance_time", "training_total", "total_simulation"]
+    | map(select((($timers[.].total_ms // 0) | tonumber) > 0))
+    | .[0] // ""
+    ' <<<"$JSON_OUTPUT"
+)"
+REFERENCE_TOTAL_MS="$(
+    jq -r --arg reference_timer "$REFERENCE_TIMER" '
+    if $reference_timer == "" then
+        0
+    else
+        (.value[$reference_timer].total_ms // 0)
+    end
+    ' <<<"$JSON_OUTPUT"
+)"
+if [[ -n "$REFERENCE_TIMER" ]]; then
+    echo "percent basis: ${REFERENCE_TIMER}"
+else
+    echo "percent basis: unavailable; pct sort falls back to total_ms"
+fi
+
+jq -r --arg sort "$SORT_BY" --argjson reference_total_ms "$REFERENCE_TOTAL_MS" '
+    .value as $timers
+    | $reference_total_ms as $reference_total_ms
     | $timers
     | to_entries
     | map(select(.key != "training_total" and .key != "total_simulation" and .key != "advance_time"))
+    | map(select(.value.total_ms != null and .value.calls != null))
     | sort_by(
         if $sort == "name" then
             .key
         elif $sort == "pct" then
-            (.value.total_ms / $advance_total_ms)
+            if $reference_total_ms > 0 then
+                (.value.total_ms / $reference_total_ms)
+            else
+                .value.total_ms
+            end
         elif $sort == "calls" then
             .value.calls
         elif $sort == "total" then
@@ -89,18 +123,28 @@ jq -r --arg sort "$SORT_BY" '
     | .[]
     | [
         .key,
-        .value.avg_ms,
-        .value.total_ms,
-        .value.calls,
-        (.value.total_ms / $advance_total_ms * 100.0)
+        (.value.avg_ms // 0),
+        (.value.total_ms // 0),
+        (.value.calls // 0),
+        if $reference_total_ms > 0 then
+            ((.value.total_ms / $reference_total_ms * 100.0) | tostring)
+        else
+            "n/a"
+        end
     ]
     | @tsv
 ' <<<"$JSON_OUTPUT" | awk -F $'\t' '
     BEGIN {
         print "breakdown";
-        printf "%-40s %12s %14s %12s %10s\n", "timer", "avg_ms", "total_ms", "calls", "%adv";
+        printf "%-40s %12s %14s %12s %10s\n", "timer", "avg_ms", "total_ms", "calls", "%ref";
     }
     {
-        printf "%-40s %12.6f %14.3f %12d %9.2f%%\n", $1, $2, $3, $4, $5;
+        if ($5 == "n/a") {
+            pct = "n/a";
+        }
+        else {
+            pct = sprintf("%9.2f%%", $5);
+        }
+        printf "%-40s %12.6f %14.3f %12d %10s\n", $1, $2, $3, $4, pct;
     }
 '


### PR DESCRIPTION
## Summary

- Adds the NES tile sensory pipeline: tile extraction, deterministic tokenization/vocabulary bootstrapping, token frames, player-relative tile windows, and debug renderers/probe diagnostics.
- Adds the NES tile recurrent brain and wires it through training/evaluation, warm starts, SMB default selection, UI selection, and training debug view toggles.
- Adds NES tile checkpoint compatibility metadata so future warm starts validate tokenizer vocabulary hashes and model/window dimensions instead of silently accepting incompatible genomes.
- Optimizes tile training by skipping pattern-pixel extraction during training and skipping void-tile embedding work, with timer instrumentation for profiling the runtime cost.

## Testing

- make format
- cmake --build build-debug --target dirtsim-tests -j4
- make test: 933 passed, 1 skipped, 15 disabled
- Added focused tests for tile extraction, tokenization, vocabulary bootstrapping, sensory data, player-relative windows, recurrent brain behavior, debug rendering, training wiring, checkpoint metadata, and repository persistence.

## Notes

- Legacy NES tile genomes without compatibility metadata are still accepted for now so existing archives are not stranded; newly saved tile checkpoints include and validate the metadata.
- The NES tile recurrent brain is selectable in the UI and is now the default training brain for Super Mario Bros so it can be tested from the idle training flow.