### PR TITLE
Add SMB sub-tile phase senses

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -454,6 +454,7 @@ add_library(dirtsim-server-lib STATIC
     src/core/scenarios/nes/NesSuperMarioBrosResponseProbe.cpp
     src/core/scenarios/nes/NesSuperMarioBrosResponseTelemetry.cpp
     src/core/scenarios/nes/NesSuperMarioBrosSetupPolicy.cpp
+    src/core/scenarios/nes/NesSuperMarioBrosSpecialSenses.cpp
     src/core/scenarios/nes/NesSuperMarioBrosTilePosition.cpp
     src/core/scenarios/nes/NesPlayerRelativeTileFrame.cpp
     src/core/scenarios/nes/NesTileBrainMetadata.cpp

--- a/apps/design_docs/nes-tile-embedding-brain.md
+++ b/apps/design_docs/nes-tile-embedding-brain.md
@@ -303,6 +303,8 @@ the 896 visible tile positions.
   through training, live debug rendering, and the PNG diagnostic.
 - Added tests for SMB 512-pixel scroll wrapping and a ROM-gated regression proving frames 400 and
   500 keep a stable player-relative X anchor.
+- Added SMB sub-tile phase senses in existing `special_senses` slots 18-21, preserving the tile
+  brain genome layout while exposing `absoluteX` and `playerYScreen` modulo 8 and 16.
 
 ### Current Diagnostic
 

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosGameAdapter.cpp
@@ -6,6 +6,7 @@
 #include "core/scenarios/nes/NesSuperMarioBrosEvaluator.h"
 #include "core/scenarios/nes/NesSuperMarioBrosRamExtractor.h"
 #include "core/scenarios/nes/NesSuperMarioBrosSetupPolicy.h"
+#include "core/scenarios/nes/NesSuperMarioBrosSpecialSenses.h"
 #include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
 
 #include <algorithm>
@@ -22,16 +23,6 @@ constexpr int16_t kSmbDefaultTilePlayerScreenX = 128;
 constexpr int16_t kSmbDefaultTilePlayerScreenY =
     120 - static_cast<int16_t>(NesTileFrame::TopCropPixels);
 
-double normalizeSmb(double value, double maxValue)
-{
-    return std::clamp(value / maxValue, 0.0, 1.0);
-}
-
-double normalizeSmbSigned(double value, double maxMagnitude)
-{
-    return std::clamp(value / maxMagnitude, -1.0, 1.0);
-}
-
 float normalizeViewCoordinate(double value, double extent)
 {
     if (extent <= 0.0) {
@@ -39,43 +30,6 @@ float normalizeViewCoordinate(double value, double extent)
     }
 
     return static_cast<float>(std::clamp(value / extent, 0.0, 1.0));
-}
-
-std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> makeSmbSpecialSenses(
-    const NesSuperMarioBrosState& state)
-{
-    std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT> senses{};
-    senses.fill(0.0);
-
-    const double progress =
-        (static_cast<double>(state.world) * 4.0 + static_cast<double>(state.level)) / 32.0;
-    senses[0] = std::clamp(progress, 0.0, 1.0);
-    senses[1] = normalizeSmb(static_cast<double>(state.absoluteX), 4096.0);
-    senses[2] = state.horizontalSpeedNormalized;
-    senses[3] = state.verticalSpeedNormalized;
-
-    if (state.powerupState == SmbPowerupState::Fire) {
-        senses[4] = 1.0;
-    }
-    else if (state.powerupState == SmbPowerupState::Big) {
-        senses[4] = 0.5;
-    }
-
-    senses[5] = state.airborne ? 1.0 : 0.0;
-    senses[6] = normalizeSmb(static_cast<double>(state.playerYScreen), 240.0);
-    senses[7] = normalizeSmb(static_cast<double>(state.lives), 9.0);
-    senses[8] = normalizeSmb(static_cast<double>(state.playerXScreen), 255.0);
-    senses[9] = normalizeSmbSigned(static_cast<double>(state.nearestEnemyDx), 255.0);
-    senses[10] = normalizeSmbSigned(static_cast<double>(state.nearestEnemyDy), 240.0);
-    senses[11] = normalizeSmbSigned(static_cast<double>(state.secondNearestEnemyDx), 255.0);
-    senses[12] = normalizeSmbSigned(static_cast<double>(state.secondNearestEnemyDy), 240.0);
-    senses[13] = state.enemyPresent ? 1.0 : 0.0;
-    senses[14] = state.secondEnemyPresent ? 1.0 : 0.0;
-    senses[15] = normalizeSmb(static_cast<double>(state.world), 7.0);
-    senses[16] = normalizeSmb(static_cast<double>(state.level), 3.0);
-    senses[17] = static_cast<double>(state.movementX);
-
-    return senses;
 }
 
 class NesSuperMarioBrosGameAdapter final : public NesGameAdapter {
@@ -166,7 +120,7 @@ public:
 
         if (state.phase == SmbPhase::Gameplay) {
             cachedFacingX_ = state.facingX;
-            cachedSpecialSenses_ = makeSmbSpecialSenses(state);
+            cachedSpecialSenses_ = makeNesSuperMarioBrosSpecialSenses(state);
             cachedSelfViewX_ =
                 normalizeViewCoordinate(static_cast<double>(state.playerXScreen), kNesFrameWidth);
             cachedSelfViewY_ =

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosSpecialSenses.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosSpecialSenses.cpp
@@ -1,0 +1,76 @@
+#include "core/scenarios/nes/NesSuperMarioBrosSpecialSenses.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace DirtSim {
+
+namespace {
+
+double normalizeSmb(double value, double maxValue)
+{
+    return std::clamp(value / maxValue, 0.0, 1.0);
+}
+
+double normalizeSmbSigned(double value, double maxMagnitude)
+{
+    return std::clamp(value / maxMagnitude, -1.0, 1.0);
+}
+
+double normalizePhase(uint16_t value, uint16_t period)
+{
+    return static_cast<double>(value % period) / static_cast<double>(period - 1u);
+}
+
+} // namespace
+
+SmbSpecialSenses makeNesSuperMarioBrosSpecialSenses(const NesSuperMarioBrosState& state)
+{
+    SmbSpecialSenses senses{};
+    senses.fill(0.0);
+
+    const double progress =
+        (static_cast<double>(state.world) * 4.0 + static_cast<double>(state.level)) / 32.0;
+    senses[SmbSpecialSenseIndex::StageProgress] = std::clamp(progress, 0.0, 1.0);
+    senses[SmbSpecialSenseIndex::AbsoluteX] =
+        normalizeSmb(static_cast<double>(state.absoluteX), 4096.0);
+    senses[SmbSpecialSenseIndex::HorizontalSpeed] = state.horizontalSpeedNormalized;
+    senses[SmbSpecialSenseIndex::VerticalSpeed] = state.verticalSpeedNormalized;
+
+    if (state.powerupState == SmbPowerupState::Fire) {
+        senses[SmbSpecialSenseIndex::Powerup] = 1.0;
+    }
+    else if (state.powerupState == SmbPowerupState::Big) {
+        senses[SmbSpecialSenseIndex::Powerup] = 0.5;
+    }
+
+    senses[SmbSpecialSenseIndex::Airborne] = state.airborne ? 1.0 : 0.0;
+    senses[SmbSpecialSenseIndex::PlayerYScreen] =
+        normalizeSmb(static_cast<double>(state.playerYScreen), 240.0);
+    senses[SmbSpecialSenseIndex::Lives] = normalizeSmb(static_cast<double>(state.lives), 9.0);
+    senses[SmbSpecialSenseIndex::PlayerXScreen] =
+        normalizeSmb(static_cast<double>(state.playerXScreen), 255.0);
+    senses[SmbSpecialSenseIndex::NearestEnemyDx] =
+        normalizeSmbSigned(static_cast<double>(state.nearestEnemyDx), 255.0);
+    senses[SmbSpecialSenseIndex::NearestEnemyDy] =
+        normalizeSmbSigned(static_cast<double>(state.nearestEnemyDy), 240.0);
+    senses[SmbSpecialSenseIndex::SecondNearestEnemyDx] =
+        normalizeSmbSigned(static_cast<double>(state.secondNearestEnemyDx), 255.0);
+    senses[SmbSpecialSenseIndex::SecondNearestEnemyDy] =
+        normalizeSmbSigned(static_cast<double>(state.secondNearestEnemyDy), 240.0);
+    senses[SmbSpecialSenseIndex::EnemyPresent] = state.enemyPresent ? 1.0 : 0.0;
+    senses[SmbSpecialSenseIndex::SecondEnemyPresent] = state.secondEnemyPresent ? 1.0 : 0.0;
+    senses[SmbSpecialSenseIndex::World] = normalizeSmb(static_cast<double>(state.world), 7.0);
+    senses[SmbSpecialSenseIndex::Level] = normalizeSmb(static_cast<double>(state.level), 3.0);
+    senses[SmbSpecialSenseIndex::MovementX] = static_cast<double>(state.movementX);
+    senses[SmbSpecialSenseIndex::AbsoluteXTilePhase8] = normalizePhase(state.absoluteX, 8u);
+    senses[SmbSpecialSenseIndex::PlayerYTilePhase8] =
+        normalizePhase(static_cast<uint16_t>(state.playerYScreen), 8u);
+    senses[SmbSpecialSenseIndex::AbsoluteXTilePhase16] = normalizePhase(state.absoluteX, 16u);
+    senses[SmbSpecialSenseIndex::PlayerYTilePhase16] =
+        normalizePhase(static_cast<uint16_t>(state.playerYScreen), 16u);
+
+    return senses;
+}
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosSpecialSenses.h
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosSpecialSenses.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "core/organisms/DuckSensoryData.h"
+#include "core/scenarios/nes/NesSuperMarioBrosEvaluator.h"
+
+#include <array>
+#include <cstddef>
+
+namespace DirtSim {
+
+namespace SmbSpecialSenseIndex {
+constexpr size_t StageProgress = 0u;
+constexpr size_t AbsoluteX = 1u;
+constexpr size_t HorizontalSpeed = 2u;
+constexpr size_t VerticalSpeed = 3u;
+constexpr size_t Powerup = 4u;
+constexpr size_t Airborne = 5u;
+constexpr size_t PlayerYScreen = 6u;
+constexpr size_t Lives = 7u;
+constexpr size_t PlayerXScreen = 8u;
+constexpr size_t NearestEnemyDx = 9u;
+constexpr size_t NearestEnemyDy = 10u;
+constexpr size_t SecondNearestEnemyDx = 11u;
+constexpr size_t SecondNearestEnemyDy = 12u;
+constexpr size_t EnemyPresent = 13u;
+constexpr size_t SecondEnemyPresent = 14u;
+constexpr size_t World = 15u;
+constexpr size_t Level = 16u;
+constexpr size_t MovementX = 17u;
+constexpr size_t AbsoluteXTilePhase8 = 18u;
+constexpr size_t PlayerYTilePhase8 = 19u;
+constexpr size_t AbsoluteXTilePhase16 = 20u;
+constexpr size_t PlayerYTilePhase16 = 21u;
+} // namespace SmbSpecialSenseIndex
+
+using SmbSpecialSenses = std::array<double, DuckSensoryData::SPECIAL_SENSE_COUNT>;
+
+SmbSpecialSenses makeNesSuperMarioBrosSpecialSenses(const NesSuperMarioBrosState& state);
+
+} // namespace DirtSim

--- a/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
+++ b/apps/src/core/scenarios/tests/NesGameAdapterSpecialSenses_test.cpp
@@ -3,6 +3,7 @@
 #include "core/organisms/evolution/NesPolicyLayout.h"
 #include "core/scenarios/nes/NesFlappyBirdEvaluator.h"
 #include "core/scenarios/nes/NesFlappyParatroopaRamExtractor.h"
+#include "core/scenarios/nes/NesSuperMarioBrosSpecialSenses.h"
 #include "core/scenarios/nes/NesSuperMarioBrosTilePosition.h"
 #include "core/scenarios/nes/NesTileSensoryBuilder.h"
 #include "core/scenarios/nes/NesTileTokenizer.h"
@@ -258,30 +259,56 @@ TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterExposesCuratedSpecial
     const uint16_t absoluteX = (static_cast<uint16_t>(0x03) << 8) | 0x80;
 
     EXPECT_NEAR(sensory.facing_x, 1.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[0], (1.0 * 4.0 + 2.0) / 32.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[1], static_cast<double>(absoluteX) / 4096.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[2], 1.0 * 25.0 / 40.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[3], -40.0 / 128.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[4], 1.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[5], 1.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[6], 120.0 / 240.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[7], 3.0 / 9.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[8], 128.0 / 255.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[9], 16.0 / 255.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[10], -10.0 / 240.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[11], -48.0 / 255.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[12], -20.0 / 240.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[13], 1.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[14], 1.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[15], 1.0 / 7.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[16], 2.0 / 3.0, 1e-6);
-    EXPECT_NEAR(sensory.special_senses[17], 1.0, 1e-6);
+    EXPECT_NEAR(
+        sensory.special_senses[SmbSpecialSenseIndex::StageProgress],
+        (1.0 * 4.0 + 2.0) / 32.0,
+        1e-6);
+    EXPECT_NEAR(
+        sensory.special_senses[SmbSpecialSenseIndex::AbsoluteX],
+        static_cast<double>(absoluteX) / 4096.0,
+        1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::HorizontalSpeed], 25.0 / 40.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::VerticalSpeed], -40.0 / 128.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::Powerup], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::Airborne], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::PlayerYScreen], 120.0 / 240.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::Lives], 3.0 / 9.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::PlayerXScreen], 128.0 / 255.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::NearestEnemyDx], 16.0 / 255.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::NearestEnemyDy], -10.0 / 240.0, 1e-6);
+    EXPECT_NEAR(
+        sensory.special_senses[SmbSpecialSenseIndex::SecondNearestEnemyDx], -48.0 / 255.0, 1e-6);
+    EXPECT_NEAR(
+        sensory.special_senses[SmbSpecialSenseIndex::SecondNearestEnemyDy], -20.0 / 240.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::EnemyPresent], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::SecondEnemyPresent], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::World], 1.0 / 7.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::Level], 2.0 / 3.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::MovementX], 1.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::AbsoluteXTilePhase8], 0.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::PlayerYTilePhase8], 0.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::AbsoluteXTilePhase16], 0.0, 1e-6);
+    EXPECT_NEAR(sensory.special_senses[SmbSpecialSenseIndex::PlayerYTilePhase16], 8.0 / 15.0, 1e-6);
     EXPECT_NEAR(sensory.self_view_x, 128.0 / 256.0, 1e-6);
     EXPECT_NEAR(sensory.self_view_y, 120.0 / 240.0, 1e-6);
 
-    for (int i = 18; i < DuckSensoryData::SPECIAL_SENSE_COUNT; ++i) {
+    for (int i = 22; i < DuckSensoryData::SPECIAL_SENSE_COUNT; ++i) {
         EXPECT_EQ(sensory.special_senses[i], 0.0) << "slot " << i << " should be zero";
     }
+}
+
+TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosSpecialSensesExposeSubTilePhase)
+{
+    NesSuperMarioBrosState state;
+    state.absoluteX = 0x012Du;
+    state.playerYScreen = 123u;
+
+    const SmbSpecialSenses senses = makeNesSuperMarioBrosSpecialSenses(state);
+
+    EXPECT_NEAR(senses[SmbSpecialSenseIndex::AbsoluteXTilePhase8], 5.0 / 7.0, 1e-6);
+    EXPECT_NEAR(senses[SmbSpecialSenseIndex::PlayerYTilePhase8], 3.0 / 7.0, 1e-6);
+    EXPECT_NEAR(senses[SmbSpecialSenseIndex::AbsoluteXTilePhase16], 13.0 / 15.0, 1e-6);
+    EXPECT_NEAR(senses[SmbSpecialSenseIndex::PlayerYTilePhase16], 11.0 / 15.0, 1e-6);
 }
 
 TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterBuildsTileSensoryInput)
@@ -330,8 +357,13 @@ TEST(NesGameAdapterSpecialSensesTest, SuperMarioBrosAdapterBuildsTileSensoryInpu
     EXPECT_NEAR(tileInput.selfViewX, 128.0 / 256.0, 1e-6);
     EXPECT_NEAR(tileInput.selfViewY, 120.0 / 240.0, 1e-6);
     EXPECT_EQ(tileInput.controllerMask, controllerMask);
-    EXPECT_NEAR(tileInput.specialSenses[0], (1.0 * 4.0 + 2.0) / 32.0, 1e-6);
-    EXPECT_NEAR(tileInput.specialSenses[17], 1.0, 1e-6);
+    EXPECT_NEAR(
+        tileInput.specialSenses[SmbSpecialSenseIndex::StageProgress],
+        (1.0 * 4.0 + 2.0) / 32.0,
+        1e-6);
+    EXPECT_NEAR(tileInput.specialSenses[SmbSpecialSenseIndex::MovementX], 1.0, 1e-6);
+    EXPECT_NEAR(
+        tileInput.specialSenses[SmbSpecialSenseIndex::PlayerYTilePhase16], 8.0 / 15.0, 1e-6);
     EXPECT_DOUBLE_EQ(tileInput.deltaTimeSeconds, 0.016);
 
     NesTileTokenizer tokenizer;


### PR DESCRIPTION
## Summary

Adds explicit Super Mario Bros sub-tile phase values to existing NES special-sense slots, preserving the current tile-brain genome/input layout while exposing pixel-level timing cues.

## Changes

- Extracts SMB special-sense mapping into a public helper with named slot constants.
- Populates unused `special_senses` slots 18-21 with `absoluteX` and `playerYScreen` modulo 8 and 16.
- Updates adapter tests to verify the existing SMB senses and new phase slots.
- Updates the NES tile brain design doc with the new slot usage.

## Verification

- `cmake --build build-debug --target dirtsim-tests -j4`
- `./build-debug/bin/dirtsim-tests --gtest_filter='NesGameAdapterSpecialSensesTest.*SuperMarioBros*'`
- `make test` passed: 959 passed, 1 skipped, 18 disabled.