### PR TITLE
Improve SMB DFS falling search pruning

### DIFF
--- a/apps/src/core/scenarios/nes/NesFitnessDetails.h
+++ b/apps/src/core/scenarios/nes/NesFitnessDetails.h
@@ -9,6 +9,7 @@ enum class SmbEpisodeEndReason : uint8_t {
     None = 0,
     LifeLost = 1,
     NoProgressTimeout = 2,
+    FellBelowScreen = 3,
 };
 
 struct NesSuperMarioBrosFitnessSnapshot {

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.cpp
@@ -105,7 +105,10 @@ NesSuperMarioBrosEvaluatorOutput NesSuperMarioBrosEvaluator::evaluate(
         kSmbNoProgressTimeoutFrames,
         SmbEpisodeEndReason::None,
         false);
-    if (input.state.phase != SmbPhase::Gameplay) {
+    const bool concreteTerminalCandidate = hasBestProgress_
+        && (input.state.gameMode == SmbGameMode::EndGame
+            || input.state.lifeState != SmbLifeState::Alive);
+    if (input.state.phase != SmbPhase::Gameplay && !concreteTerminalCandidate) {
         return output;
     }
 
@@ -144,7 +147,8 @@ NesSuperMarioBrosEvaluatorOutput NesSuperMarioBrosEvaluator::evaluate(
         lastLives_ = input.state.lives;
     }
 
-    if (input.state.lifeState == SmbLifeState::Dead && input.state.lives == 0u) {
+    if (input.state.gameMode == SmbGameMode::EndGame
+        || input.state.lifeState != SmbLifeState::Alive) {
         output.done = true;
         output.endReason = SmbEpisodeEndReason::LifeLost;
         output.snapshot = makeSnapshot(
@@ -188,7 +192,11 @@ NesSuperMarioBrosEvaluatorOutput NesSuperMarioBrosEvaluator::evaluate(
         }
     }
 
-    if ((gameplayFrameCount_ - lastProgressFrame_) >= kNoProgressTimeoutFrames) {
+    if (input.state.playerYScreen >= kBelowScreenTerminalPlayerYScreenThreshold) {
+        output.done = true;
+        output.endReason = SmbEpisodeEndReason::FellBelowScreen;
+    }
+    else if ((gameplayFrameCount_ - lastProgressFrame_) >= kNoProgressTimeoutFrames) {
         output.done = true;
         output.endReason = SmbEpisodeEndReason::NoProgressTimeout;
     }

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.h
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.h
@@ -17,6 +17,31 @@ enum class SmbLifeState : uint8_t {
     Dead = 2,
 };
 
+enum class SmbPlayerState : uint8_t {
+    LeftmostOfScreen = 0x00,
+    ClimbingVine = 0x01,
+    EnteringReversedLPipe = 0x02,
+    GoingDownPipe = 0x03,
+    Autowalk = 0x04,
+    AutowalkAlt = 0x05,
+    PlayerDies = 0x06,
+    EnteringArea = 0x07,
+    Normal = 0x08,
+    Growing = 0x09,
+    Shrinking = 0x0A,
+    Dying = 0x0B,
+    BecomingFire = 0x0C,
+    Unknown = 0xFF,
+};
+
+enum class SmbFloatState : uint8_t {
+    GroundedOrOther = 0x00,
+    Jumping = 0x01,
+    WalkedOffLedge = 0x02,
+    SlidingFlagpole = 0x03,
+    Unknown = 0xFF,
+};
+
 enum class SmbPowerupState : uint8_t {
     Small = 0,
     Big = 1,
@@ -26,6 +51,8 @@ enum class SmbPowerupState : uint8_t {
 struct NesSuperMarioBrosState {
     SmbPhase phase = SmbPhase::NonGameplay;
     SmbLifeState lifeState = SmbLifeState::Alive;
+    SmbPlayerState playerState = SmbPlayerState::Unknown;
+    SmbFloatState floatState = SmbFloatState::Unknown;
     SmbPowerupState powerupState = SmbPowerupState::Small;
     bool airborne = false;
     bool enemyPresent = false;

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.h
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosEvaluator.h
@@ -11,6 +11,14 @@ enum class SmbPhase : uint8_t {
     Gameplay = 1,
 };
 
+enum class SmbGameMode : uint8_t {
+    StartDemo = 0x00,
+    Normal = 0x01,
+    EndCurrentWorld = 0x02,
+    EndGame = 0x03,
+    Unknown = 0xFF,
+};
+
 enum class SmbLifeState : uint8_t {
     Alive = 0,
     Dying = 1,
@@ -50,6 +58,7 @@ enum class SmbPowerupState : uint8_t {
 
 struct NesSuperMarioBrosState {
     SmbPhase phase = SmbPhase::NonGameplay;
+    SmbGameMode gameMode = SmbGameMode::Unknown;
     SmbLifeState lifeState = SmbLifeState::Alive;
     SmbPlayerState playerState = SmbPlayerState::Unknown;
     SmbFloatState floatState = SmbFloatState::Unknown;
@@ -100,6 +109,7 @@ public:
     NesSuperMarioBrosEvaluatorOutput evaluate(const NesSuperMarioBrosEvaluatorInput& input);
 
 private:
+    static constexpr uint8_t kBelowScreenTerminalPlayerYScreenThreshold = 224u;
     static constexpr double kDistanceReward = 0.5;
     static constexpr double kLevelClearReward = 1000.0;
     static constexpr uint64_t kNoProgressTimeoutFrames = 1800;

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosRamExtractor.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosRamExtractor.cpp
@@ -40,9 +40,6 @@ constexpr std::array<size_t, kEnemySlotCount> kEnemyYScreenAddrs = {
 };
 
 constexpr uint8_t kGameEngineGameplay = 1;
-constexpr uint8_t kPlayerStateDeathAnimation = 0x0B;
-constexpr uint8_t kPlayerStateReloadScreen = 0x00;
-constexpr uint8_t kPlayerStatePlayerDies = 0x06;
 
 uint16_t decodeAbsoluteX(uint8_t playerXPage, uint8_t playerXScreen)
 {
@@ -66,19 +63,47 @@ float decodeFacingX(uint8_t rawFacingDirection)
     }
 }
 
-SmbLifeState decodeLifeState(uint8_t playerState)
+SmbFloatState decodeFloatState(uint8_t playerFloatState)
+{
+    switch (playerFloatState) {
+        case 0x00u:
+            return SmbFloatState::GroundedOrOther;
+        case 0x01u:
+            return SmbFloatState::Jumping;
+        case 0x02u:
+            return SmbFloatState::WalkedOffLedge;
+        case 0x03u:
+            return SmbFloatState::SlidingFlagpole;
+        default:
+            return SmbFloatState::Unknown;
+    }
+}
+
+SmbLifeState decodeLifeState(SmbPlayerState playerState)
 {
     // 0x000E is a broad player-mode register. For the coarse life-state model we only treat the
     // explicit death lifecycle states as non-alive.
     switch (playerState) {
-        case kPlayerStatePlayerDies:
-        case kPlayerStateDeathAnimation:
-            return SmbLifeState::Dying;
-        case kPlayerStateReloadScreen:
+        case SmbPlayerState::LeftmostOfScreen:
             return SmbLifeState::Dead;
-        default:
+        case SmbPlayerState::ClimbingVine:
+        case SmbPlayerState::EnteringReversedLPipe:
+        case SmbPlayerState::GoingDownPipe:
+        case SmbPlayerState::Autowalk:
+        case SmbPlayerState::AutowalkAlt:
+        case SmbPlayerState::EnteringArea:
+        case SmbPlayerState::Normal:
+        case SmbPlayerState::Growing:
+        case SmbPlayerState::Shrinking:
+        case SmbPlayerState::BecomingFire:
+        case SmbPlayerState::Unknown:
             return SmbLifeState::Alive;
+        case SmbPlayerState::PlayerDies:
+        case SmbPlayerState::Dying:
+            return SmbLifeState::Dying;
     }
+
+    return SmbLifeState::Alive;
 }
 
 SmbPhase decodePhase(uint8_t gameEngine, bool setupComplete)
@@ -96,6 +121,40 @@ SmbPowerupState decodePowerupState(uint8_t powerupState)
         return SmbPowerupState::Big;
     }
     return SmbPowerupState::Small;
+}
+
+SmbPlayerState decodePlayerState(uint8_t playerState)
+{
+    switch (playerState) {
+        case 0x00u:
+            return SmbPlayerState::LeftmostOfScreen;
+        case 0x01u:
+            return SmbPlayerState::ClimbingVine;
+        case 0x02u:
+            return SmbPlayerState::EnteringReversedLPipe;
+        case 0x03u:
+            return SmbPlayerState::GoingDownPipe;
+        case 0x04u:
+            return SmbPlayerState::Autowalk;
+        case 0x05u:
+            return SmbPlayerState::AutowalkAlt;
+        case 0x06u:
+            return SmbPlayerState::PlayerDies;
+        case 0x07u:
+            return SmbPlayerState::EnteringArea;
+        case 0x08u:
+            return SmbPlayerState::Normal;
+        case 0x09u:
+            return SmbPlayerState::Growing;
+        case 0x0Au:
+            return SmbPlayerState::Shrinking;
+        case 0x0Bu:
+            return SmbPlayerState::Dying;
+        case 0x0Cu:
+            return SmbPlayerState::BecomingFire;
+        default:
+            return SmbPlayerState::Unknown;
+    }
 }
 
 double decodeVerticalSpeedNormalized(uint8_t verticalSpeed)
@@ -130,9 +189,10 @@ DecodedEnemy decodeEnemy(
     };
 }
 
-bool isAirborne(uint8_t playerFloatState)
+bool isAirborne(SmbFloatState playerFloatState)
 {
-    return playerFloatState == 0x01u || playerFloatState == 0x02u;
+    return playerFloatState == SmbFloatState::Jumping
+        || playerFloatState == SmbFloatState::WalkedOffLedge;
 }
 
 } // namespace
@@ -140,8 +200,9 @@ bool isAirborne(uint8_t playerFloatState)
 NesSuperMarioBrosState NesSuperMarioBrosRamExtractor::extract(
     const SmolnesRuntime::MemorySnapshot& snapshot, bool setupComplete) const
 {
-    const uint8_t playerState = snapshot.cpuRam.at(kPlayerStateAddr);
-    const uint8_t playerFloatState = snapshot.cpuRam.at(kPlayerFloatStateAddr);
+    const SmbPlayerState playerState = decodePlayerState(snapshot.cpuRam.at(kPlayerStateAddr));
+    const SmbFloatState playerFloatState =
+        decodeFloatState(snapshot.cpuRam.at(kPlayerFloatStateAddr));
     const uint16_t playerAbsoluteX = decodeAbsoluteX(
         snapshot.cpuRam.at(kPlayerXPageAddr), snapshot.cpuRam.at(kPlayerXScreenAddr));
     const uint8_t playerYScreen = snapshot.cpuRam.at(kPlayerYScreenAddr);
@@ -149,6 +210,8 @@ NesSuperMarioBrosState NesSuperMarioBrosRamExtractor::extract(
     NesSuperMarioBrosState output;
     output.phase = decodePhase(snapshot.cpuRam.at(kGameEngineSubroutineAddr), setupComplete);
     output.lifeState = decodeLifeState(playerState);
+    output.playerState = playerState;
+    output.floatState = playerFloatState;
     output.powerupState = decodePowerupState(snapshot.cpuRam.at(kPowerupStateAddr));
     output.airborne = isAirborne(playerFloatState);
     output.facingX = decodeFacingX(snapshot.cpuRam.at(kFacingDirectionAddr));

--- a/apps/src/core/scenarios/nes/NesSuperMarioBrosRamExtractor.cpp
+++ b/apps/src/core/scenarios/nes/NesSuperMarioBrosRamExtractor.cpp
@@ -39,8 +39,6 @@ constexpr std::array<size_t, kEnemySlotCount> kEnemyYScreenAddrs = {
     0x00CF, 0x00D0, 0x00D1, 0x00D2, 0x00D3
 };
 
-constexpr uint8_t kGameEngineGameplay = 1;
-
 uint16_t decodeAbsoluteX(uint8_t playerXPage, uint8_t playerXScreen)
 {
     return (static_cast<uint16_t>(playerXPage) << 8) | static_cast<uint16_t>(playerXScreen);
@@ -60,6 +58,22 @@ float decodeFacingX(uint8_t rawFacingDirection)
             return -1.0f;
         default:
             return 0.0f;
+    }
+}
+
+SmbGameMode decodeGameMode(uint8_t gameEngine)
+{
+    switch (gameEngine) {
+        case 0x00u:
+            return SmbGameMode::StartDemo;
+        case 0x01u:
+            return SmbGameMode::Normal;
+        case 0x02u:
+            return SmbGameMode::EndCurrentWorld;
+        case 0x03u:
+            return SmbGameMode::EndGame;
+        default:
+            return SmbGameMode::Unknown;
     }
 }
 
@@ -106,10 +120,10 @@ SmbLifeState decodeLifeState(SmbPlayerState playerState)
     return SmbLifeState::Alive;
 }
 
-SmbPhase decodePhase(uint8_t gameEngine, bool setupComplete)
+SmbPhase decodePhase(SmbGameMode gameMode, bool setupComplete)
 {
-    return setupComplete && gameEngine == kGameEngineGameplay ? SmbPhase::Gameplay
-                                                              : SmbPhase::NonGameplay;
+    return setupComplete && gameMode == SmbGameMode::Normal ? SmbPhase::Gameplay
+                                                            : SmbPhase::NonGameplay;
 }
 
 SmbPowerupState decodePowerupState(uint8_t powerupState)
@@ -203,12 +217,14 @@ NesSuperMarioBrosState NesSuperMarioBrosRamExtractor::extract(
     const SmbPlayerState playerState = decodePlayerState(snapshot.cpuRam.at(kPlayerStateAddr));
     const SmbFloatState playerFloatState =
         decodeFloatState(snapshot.cpuRam.at(kPlayerFloatStateAddr));
+    const SmbGameMode gameMode = decodeGameMode(snapshot.cpuRam.at(kGameEngineSubroutineAddr));
     const uint16_t playerAbsoluteX = decodeAbsoluteX(
         snapshot.cpuRam.at(kPlayerXPageAddr), snapshot.cpuRam.at(kPlayerXScreenAddr));
     const uint8_t playerYScreen = snapshot.cpuRam.at(kPlayerYScreenAddr);
 
     NesSuperMarioBrosState output;
-    output.phase = decodePhase(snapshot.cpuRam.at(kGameEngineSubroutineAddr), setupComplete);
+    output.phase = decodePhase(gameMode, setupComplete);
+    output.gameMode = gameMode;
     output.lifeState = decodeLifeState(playerState);
     output.playerState = playerState;
     output.floatState = playerFloatState;

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosEvaluator_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosEvaluator_test.cpp
@@ -11,6 +11,7 @@ NesSuperMarioBrosState makeGameplayState(
 {
     NesSuperMarioBrosState state;
     state.phase = SmbPhase::Gameplay;
+    state.gameMode = SmbGameMode::Normal;
     state.lifeState = SmbLifeState::Alive;
     state.world = world;
     state.level = level;
@@ -128,6 +129,102 @@ TEST(NesSuperMarioBrosEvaluatorTest, TerminatesOnFirstLifeLoss)
     EXPECT_TRUE(output.done);
     EXPECT_EQ(output.endReason, SmbEpisodeEndReason::LifeLost);
     EXPECT_TRUE(output.snapshot.done);
+}
+
+TEST(NesSuperMarioBrosEvaluatorTest, IgnoresPregameLifeRegistersBeforeGameplayStarts)
+{
+    NesSuperMarioBrosEvaluator evaluator;
+    evaluator.reset();
+
+    NesSuperMarioBrosState pregameState = makeGameplayState(0, 0, 0, 0);
+    pregameState.phase = SmbPhase::NonGameplay;
+    pregameState.gameMode = SmbGameMode::StartDemo;
+    pregameState.lifeState = SmbLifeState::Dead;
+
+    const NesSuperMarioBrosEvaluatorOutput output = evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = pregameState,
+        });
+    EXPECT_FALSE(output.done);
+    EXPECT_EQ(output.endReason, SmbEpisodeEndReason::None);
+    EXPECT_EQ(output.snapshot.gameplayFrames, 0u);
+    EXPECT_FALSE(output.snapshot.done);
+}
+
+TEST(NesSuperMarioBrosEvaluatorTest, TerminatesOnDyingStateBeforeLivesDecrease)
+{
+    NesSuperMarioBrosEvaluator evaluator;
+    evaluator.reset();
+
+    (void)evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = makeGameplayState(0, 0, 40, 3),
+        });
+
+    NesSuperMarioBrosState deathState = makeGameplayState(0, 0, 40, 3);
+    deathState.lifeState = SmbLifeState::Dying;
+
+    const NesSuperMarioBrosEvaluatorOutput output = evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = deathState,
+        });
+    EXPECT_DOUBLE_EQ(output.rewardDelta, 0.0);
+    EXPECT_TRUE(output.done);
+    EXPECT_EQ(output.endReason, SmbEpisodeEndReason::LifeLost);
+    EXPECT_TRUE(output.snapshot.done);
+}
+
+TEST(NesSuperMarioBrosEvaluatorTest, TerminatesWhenPlayerFallsBelowScreen)
+{
+    NesSuperMarioBrosEvaluator evaluator;
+    evaluator.reset();
+
+    (void)evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = makeGameplayState(0, 0, 40, 3),
+        });
+
+    NesSuperMarioBrosState fallState = makeGameplayState(0, 0, 40, 3);
+    fallState.playerYScreen = 224u;
+
+    const NesSuperMarioBrosEvaluatorOutput output = evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = fallState,
+        });
+    EXPECT_DOUBLE_EQ(output.rewardDelta, 0.0);
+    EXPECT_TRUE(output.done);
+    EXPECT_EQ(output.endReason, SmbEpisodeEndReason::FellBelowScreen);
+    EXPECT_TRUE(output.snapshot.done);
+}
+
+TEST(NesSuperMarioBrosEvaluatorTest, DoesNotTreatLevelEndModeAsLoss)
+{
+    NesSuperMarioBrosEvaluator evaluator;
+    evaluator.reset();
+
+    (void)evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = makeGameplayState(0, 0, 40, 3),
+        });
+
+    NesSuperMarioBrosState levelEndState = makeGameplayState(0, 0, 40, 3);
+    levelEndState.phase = SmbPhase::NonGameplay;
+    levelEndState.gameMode = SmbGameMode::EndCurrentWorld;
+
+    const NesSuperMarioBrosEvaluatorOutput output = evaluator.evaluate(
+        {
+            .advancedFrames = 1,
+            .state = levelEndState,
+        });
+    EXPECT_FALSE(output.done);
+    EXPECT_EQ(output.endReason, SmbEpisodeEndReason::None);
+    EXPECT_FALSE(output.snapshot.done);
 }
 
 TEST(NesSuperMarioBrosEvaluatorTest, TerminatesAfterNoProgressTimeout)

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosRamExtractor_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosRamExtractor_test.cpp
@@ -100,6 +100,8 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractDecodesGameplayState)
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
     EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
+    EXPECT_EQ(state.playerState, SmbPlayerState::Normal);
+    EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
     EXPECT_EQ(state.powerupState, SmbPowerupState::Fire);
     EXPECT_FALSE(state.airborne);
     EXPECT_NEAR(state.horizontalSpeedNormalized, 25.0 / 40.0, 1e-6);
@@ -133,6 +135,8 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractUsesFloatStateForAirborne)
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
     EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
+    EXPECT_EQ(state.playerState, SmbPlayerState::Normal);
+    EXPECT_EQ(state.floatState, SmbFloatState::Jumping);
     EXPECT_EQ(state.powerupState, SmbPowerupState::Big);
     EXPECT_TRUE(state.airborne);
     EXPECT_NEAR(state.horizontalSpeedNormalized, -5.0 / 40.0, 1e-6);
@@ -174,6 +178,8 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractMapsDeathAnimationState)
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
     EXPECT_EQ(state.lifeState, SmbLifeState::Dying);
+    EXPECT_EQ(state.playerState, SmbPlayerState::Dying);
+    EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
     EXPECT_EQ(state.powerupState, SmbPowerupState::Big);
     EXPECT_FALSE(state.airborne);
     EXPECT_NEAR(state.horizontalSpeedNormalized, -5.0 / 40.0, 1e-6);
@@ -201,6 +207,8 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractMapsPlayerDiesState)
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
     EXPECT_EQ(state.lifeState, SmbLifeState::Dying);
+    EXPECT_EQ(state.playerState, SmbPlayerState::PlayerDies);
+    EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
     EXPECT_FALSE(state.airborne);
 }
 
@@ -214,6 +222,8 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractMapsReloadScreenStateAsDead)
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
     EXPECT_EQ(state.lifeState, SmbLifeState::Dead);
+    EXPECT_EQ(state.playerState, SmbPlayerState::LeftmostOfScreen);
+    EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
     EXPECT_EQ(state.powerupState, SmbPowerupState::Small);
     EXPECT_FALSE(state.airborne);
     EXPECT_DOUBLE_EQ(state.horizontalSpeedNormalized, 0.0);
@@ -229,6 +239,37 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractTreatsNonDeathPlayerModesAsAlive)
     const NesSuperMarioBrosState state = extractor.extract(snapshot, true);
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
+    EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
+    EXPECT_EQ(state.playerState, SmbPlayerState::Growing);
+    EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
+    EXPECT_FALSE(state.airborne);
+}
+
+TEST(NesSuperMarioBrosRamExtractorTest, ExtractPreservesKnownFloatStateDistinctions)
+{
+    NesSuperMarioBrosRamExtractor extractor;
+
+    const NesSuperMarioBrosState walkedOffLedge =
+        extractor.extract(makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x02, 3, 1), true);
+    EXPECT_EQ(walkedOffLedge.floatState, SmbFloatState::WalkedOffLedge);
+    EXPECT_TRUE(walkedOffLedge.airborne);
+
+    const NesSuperMarioBrosState slidingFlagpole =
+        extractor.extract(makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x03, 3, 1), true);
+    EXPECT_EQ(slidingFlagpole.floatState, SmbFloatState::SlidingFlagpole);
+    EXPECT_FALSE(slidingFlagpole.airborne);
+}
+
+TEST(NesSuperMarioBrosRamExtractorTest, ExtractMapsUnknownRawPlayerModeFields)
+{
+    const SmolnesRuntime::MemorySnapshot snapshot =
+        makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0xFE, 0xFE, 3, 1);
+
+    NesSuperMarioBrosRamExtractor extractor;
+    const NesSuperMarioBrosState state = extractor.extract(snapshot, true);
+
+    EXPECT_EQ(state.playerState, SmbPlayerState::Unknown);
+    EXPECT_EQ(state.floatState, SmbFloatState::Unknown);
     EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
     EXPECT_FALSE(state.airborne);
 }

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosRamExtractor_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosRamExtractor_test.cpp
@@ -99,6 +99,7 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractDecodesGameplayState)
     const NesSuperMarioBrosState state = extractor.extract(snapshot, true);
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
+    EXPECT_EQ(state.gameMode, SmbGameMode::Normal);
     EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
     EXPECT_EQ(state.playerState, SmbPlayerState::Normal);
     EXPECT_EQ(state.floatState, SmbFloatState::GroundedOrOther);
@@ -134,6 +135,7 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractUsesFloatStateForAirborne)
     const NesSuperMarioBrosState state = extractor.extract(snapshot, true);
 
     EXPECT_EQ(state.phase, SmbPhase::Gameplay);
+    EXPECT_EQ(state.gameMode, SmbGameMode::Normal);
     EXPECT_EQ(state.lifeState, SmbLifeState::Alive);
     EXPECT_EQ(state.playerState, SmbPlayerState::Normal);
     EXPECT_EQ(state.floatState, SmbFloatState::Jumping);
@@ -155,6 +157,31 @@ TEST(NesSuperMarioBrosRamExtractorTest, ExtractDecodesFacingAndMovementDirection
 
     EXPECT_FLOAT_EQ(state.facingX, 1.0f);
     EXPECT_FLOAT_EQ(state.movementX, -1.0f);
+}
+
+TEST(NesSuperMarioBrosRamExtractorTest, ExtractDecodesGameModes)
+{
+    NesSuperMarioBrosRamExtractor extractor;
+
+    const NesSuperMarioBrosState demo =
+        extractor.extract(makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x00, 3, 0), true);
+    EXPECT_EQ(demo.phase, SmbPhase::NonGameplay);
+    EXPECT_EQ(demo.gameMode, SmbGameMode::StartDemo);
+
+    const NesSuperMarioBrosState levelEnd =
+        extractor.extract(makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x00, 3, 2), true);
+    EXPECT_EQ(levelEnd.phase, SmbPhase::NonGameplay);
+    EXPECT_EQ(levelEnd.gameMode, SmbGameMode::EndCurrentWorld);
+
+    const NesSuperMarioBrosState endGame =
+        extractor.extract(makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x00, 3, 3), true);
+    EXPECT_EQ(endGame.phase, SmbPhase::NonGameplay);
+    EXPECT_EQ(endGame.gameMode, SmbGameMode::EndGame);
+
+    const NesSuperMarioBrosState unknown = extractor.extract(
+        makeSmbSnapshot(0, 0, 0x00, 0x20, 0, 0, 100, 0, 0x08, 0x00, 3, 0xFE), true);
+    EXPECT_EQ(unknown.phase, SmbPhase::NonGameplay);
+    EXPECT_EQ(unknown.gameMode, SmbGameMode::Unknown);
 }
 
 TEST(NesSuperMarioBrosRamExtractorTest, ExtractMapsDeathAnimationState)

--- a/apps/src/core/scenarios/tests/NesSuperMarioBrosRamProbe_test.cpp
+++ b/apps/src/core/scenarios/tests/NesSuperMarioBrosRamProbe_test.cpp
@@ -36,7 +36,24 @@ constexpr size_t kPlayerStateAddr = 0x000E;
 constexpr size_t kPlayerXPageAddr = 0x006D;
 constexpr size_t kPlayerXScreenAddr = 0x0086;
 constexpr size_t kPlayerYScreenAddr = 0x00CE;
+constexpr size_t kPlayerVerticalScreenPageAddr = 0x00B5;
+constexpr size_t kPlayerRelativeXAddr = 0x03AD;
+constexpr size_t kPlayerRelativeYAddr = 0x03B8;
+constexpr size_t kPlayerObjectXMoveForceAddr = 0x0400;
+constexpr size_t kPlayerObjectYMoveForceDummyAddr = 0x0416;
+constexpr size_t kPlayerVerticalFractionalVelocityAddr = 0x0433;
+constexpr size_t kPlayerCollisionBitsAddr = 0x0490;
+constexpr size_t kPlayerHitboxAddr = 0x04AC;
 constexpr size_t kPlayerXSpeedAbsoluteAddr = 0x0700;
+constexpr size_t kSwimmingFlagAddr = 0x0704;
+constexpr size_t kPlayerXMoveForceAddr = 0x0705;
+constexpr size_t kCurrentGravityAddr = 0x0709;
+constexpr size_t kCurrentFallGravityAddr = 0x070A;
+constexpr size_t kScreenEdgeXPositionAddr = 0x071C;
+constexpr size_t kScrollPlayerXPositionAddr = 0x071D;
+constexpr size_t kPlayerHitDetectFlagAddr = 0x0722;
+constexpr size_t kScrollLockAddr = 0x0723;
+constexpr size_t kPlayerPositionForScrollAddr = 0x0755;
 constexpr size_t kVerticalSpeedAddr = 0x009F;
 constexpr size_t kP1ButtonsPressedAddr = 0x074A;
 constexpr size_t kP2ButtonsPressedAddr = 0x074B;
@@ -217,6 +234,24 @@ std::string controllerMaskToString(uint8_t controllerMask)
     }
 
     return label;
+}
+
+const char* probeScriptTypeLabel(ProbeScriptType probeScriptType)
+{
+    switch (probeScriptType) {
+        case ProbeScriptType::Baseline:
+            return "baseline";
+        case ProbeScriptType::EnemyValidation:
+            return "enemy_validation";
+        case ProbeScriptType::LeftMovement:
+            return "left_movement";
+        case ProbeScriptType::LifeLoss:
+            return "life_loss";
+        case ProbeScriptType::StandingJump:
+            return "standing_jump";
+    }
+
+    return "unknown";
 }
 
 const char* lifeStateToString(SmbLifeState lifeState)
@@ -1041,6 +1076,145 @@ TEST(NesSuperMarioBrosRamProbeTest, ManualStep_WritesLeftMovementDirectionCsv)
         std::cout << " L" << static_cast<uint32_t>(value);
     }
     std::cout << "\n";
+}
+
+TEST(NesSuperMarioBrosRamProbeTest, ManualStep_WritesMotionPhysicsValidationArtifacts)
+{
+    const std::optional<std::filesystem::path> romPath = resolveNesSmbFixtureRomPath();
+    if (!romPath.has_value()) {
+        GTEST_SKIP() << "ROM fixture missing. Set DIRTSIM_NES_SMB_TEST_ROM_PATH or place "
+                        "smb.nes in testdata/roms/.";
+    }
+
+    const std::filesystem::path csvPath =
+        std::filesystem::path(::testing::TempDir()) / "nes_smb_motion_physics_probe.csv";
+    std::ofstream csvStream(csvPath, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(csvStream.is_open())
+        << "Failed to open SMB motion physics probe trace: " << csvPath.string();
+
+    csvStream
+        << "script,frame,game_frame,controller_mask,controller_label,game_engine,player_state,"
+           "float_state,world,level,lives,absolute_x,player_x_page,player_x_screen,"
+           "player_y_screen,player_vertical_screen_page,player_relative_x,player_relative_y,"
+           "horizontal_speed_raw,horizontal_speed_signed,player_x_speed_absolute,"
+           "vertical_speed_raw,vertical_speed_signed,vertical_fraction_raw,"
+           "player_object_x_move_force,player_object_y_move_force_dummy,player_x_move_force,"
+           "current_gravity,current_fall_gravity,swimming_flag,collision_bits,hitbox_x1,hitbox_y1,"
+           "hitbox_x2,hitbox_y2,screen_edge_x,scroll_player_x,hit_detect,scroll_lock,"
+           "player_position_for_scroll,p1_buttons\n";
+
+    const std::array<ProbeScriptType, 3> scripts = {
+        ProbeScriptType::Baseline,
+        ProbeScriptType::LeftMovement,
+        ProbeScriptType::StandingJump,
+    };
+
+    for (const ProbeScriptType script : scripts) {
+        const std::vector<CapturedFrame> frames =
+            captureSmbProbeFrames(romPath.value(), false, script);
+        ASSERT_FALSE(frames.empty());
+        ASSERT_GT(frames.front().cpuRam.size(), kPlayerHitboxAddr + 3u);
+
+        const size_t analysisStartIndex = kSetupScriptEndFrame < frames.size()
+            ? static_cast<size_t>(kSetupScriptEndFrame)
+            : (frames.size() - 1u);
+
+        std::set<uint8_t> currentFallGravityValues;
+        std::set<uint8_t> currentGravityValues;
+        std::set<uint8_t> swimmingFlagValues;
+        std::set<uint8_t> xMoveForceValues;
+        size_t fallingGravityCopyFrameCount = 0u;
+        size_t fallingFrameCount = 0u;
+
+        for (size_t frameIndex = analysisStartIndex; frameIndex < frames.size(); ++frameIndex) {
+            const CapturedFrame& frame = frames[frameIndex];
+            const int8_t horizontalSpeedSigned =
+                static_cast<int8_t>(frame.cpuRam[kHorizontalSpeedAddr]);
+            const int8_t verticalSpeedSigned =
+                static_cast<int8_t>(frame.cpuRam[kVerticalSpeedAddr]);
+            const uint8_t currentGravity = frame.cpuRam[kCurrentGravityAddr];
+            const uint8_t currentFallGravity = frame.cpuRam[kCurrentFallGravityAddr];
+            const uint64_t gameFrame = frame.frameIndex - kSetupScriptEndFrame;
+
+            currentFallGravityValues.insert(currentFallGravity);
+            currentGravityValues.insert(currentGravity);
+            swimmingFlagValues.insert(frame.cpuRam[kSwimmingFlagAddr]);
+            xMoveForceValues.insert(frame.cpuRam[kPlayerXMoveForceAddr]);
+
+            if (verticalSpeedSigned > 0) {
+                ++fallingFrameCount;
+                if (currentGravity == currentFallGravity) {
+                    ++fallingGravityCopyFrameCount;
+                }
+            }
+
+            csvStream << probeScriptTypeLabel(script) << "," << frame.frameIndex << "," << gameFrame
+                      << "," << static_cast<uint32_t>(frame.controllerMask) << ","
+                      << controllerMaskToString(frame.controllerMask) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kGameEngineAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerStateAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerFloatStateAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kWorldAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kLevelAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kLivesAddr]) << ","
+                      << decodeAbsoluteX(frame.cpuRam) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerXPageAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerXScreenAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerYScreenAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerVerticalScreenPageAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerRelativeXAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerRelativeYAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kHorizontalSpeedAddr]) << ","
+                      << static_cast<int32_t>(horizontalSpeedSigned) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerXSpeedAbsoluteAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kVerticalSpeedAddr]) << ","
+                      << static_cast<int32_t>(verticalSpeedSigned) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerVerticalFractionalVelocityAddr])
+                      << "," << static_cast<uint32_t>(frame.cpuRam[kPlayerObjectXMoveForceAddr])
+                      << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerObjectYMoveForceDummyAddr])
+                      << "," << static_cast<uint32_t>(frame.cpuRam[kPlayerXMoveForceAddr]) << ","
+                      << static_cast<uint32_t>(currentGravity) << ","
+                      << static_cast<uint32_t>(currentFallGravity) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kSwimmingFlagAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerCollisionBitsAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerHitboxAddr + 0u]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerHitboxAddr + 1u]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerHitboxAddr + 2u]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerHitboxAddr + 3u]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kScreenEdgeXPositionAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kScrollPlayerXPositionAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerHitDetectFlagAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kScrollLockAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kPlayerPositionForScrollAddr]) << ","
+                      << static_cast<uint32_t>(frame.cpuRam[kP1ButtonsPressedAddr]) << "\n";
+        }
+
+        std::cout << "Motion probe " << probeScriptTypeLabel(script) << " current gravity:";
+        for (const uint8_t value : currentGravityValues) {
+            std::cout << " " << static_cast<uint32_t>(value);
+        }
+        std::cout << " fall gravity:";
+        for (const uint8_t value : currentFallGravityValues) {
+            std::cout << " " << static_cast<uint32_t>(value);
+        }
+        std::cout << " swim flags:";
+        for (const uint8_t value : swimmingFlagValues) {
+            std::cout << " " << static_cast<uint32_t>(value);
+        }
+        std::cout << " x move force:";
+        for (const uint8_t value : xMoveForceValues) {
+            std::cout << " " << static_cast<uint32_t>(value);
+        }
+        std::cout << " falling gravity copy frames=" << fallingGravityCopyFrameCount << "/"
+                  << fallingFrameCount << "\n";
+    }
+
+    csvStream.close();
+    ASSERT_TRUE(csvStream.good());
+    EXPECT_TRUE(std::filesystem::exists(csvPath));
+    EXPECT_GT(std::filesystem::file_size(csvPath), 0u);
+    std::cout << "Wrote SMB motion physics probe trace: " << csvPath.string() << "\n";
 }
 
 TEST(NesSuperMarioBrosRamProbeTest, ManualStep_WritesStandingJumpValidationArtifacts)

--- a/apps/src/server/StateMachine.cpp
+++ b/apps/src/server/StateMachine.cpp
@@ -224,6 +224,13 @@ UserSettings sanitizeUserSettings(
         recordUpdate("searchSettings.stallFrameLimit clamped to maximum");
     }
 
+    if (settings.searchSettings.planPlaybackFrameDelayMs
+        > SearchSettings::PlanPlaybackFrameDelayMsMax) {
+        settings.searchSettings.planPlaybackFrameDelayMs =
+            SearchSettings::PlanPlaybackFrameDelayMsMax;
+        recordUpdate("searchSettings.planPlaybackFrameDelayMs clamped to maximum");
+    }
+
     if (settings.volumePercent < 0) {
         settings.volumePercent = 0;
         recordUpdate("volumePercent clamped to 0");

--- a/apps/src/server/UserSettings.h
+++ b/apps/src/server/UserSettings.h
@@ -40,16 +40,18 @@ struct NesSessionSettings {
 struct SearchSettings {
     static constexpr uint32_t MaxSearchedNodeCountMin = 100;
     static constexpr uint32_t MaxSearchedNodeCountMax = 500000;
+    static constexpr uint32_t PlanPlaybackFrameDelayMsMax = 1000;
     static constexpr uint32_t StallFrameLimitMin = 1;
     static constexpr uint32_t StallFrameLimitMax = 300;
 
     uint32_t maxSearchedNodeCount = 5000;
     uint32_t stallFrameLimit = 30;
+    uint32_t planPlaybackFrameDelayMs = 0;
     bool velocityPruningEnabled = true;
     bool belowScreenPruningEnabled = true;
     bool groundedVerticalJumpPrioritizationEnabled = true;
 
-    using serialize = zpp::bits::members<5>;
+    using serialize = zpp::bits::members<6>;
 };
 
 struct UserSettings {

--- a/apps/src/server/api/SearchProgress.h
+++ b/apps/src/server/api/SearchProgress.h
@@ -24,6 +24,7 @@ enum class SearchProgressEvent : uint8_t {
     Stopped = 10,
     Error = 11,
     PrunedBelowScreen = 12,
+    PrunedTransposition = 13,
 };
 
 struct SearchProgress {

--- a/apps/src/server/api/SearchProgress.h
+++ b/apps/src/server/api/SearchProgress.h
@@ -25,6 +25,7 @@ enum class SearchProgressEvent : uint8_t {
     Error = 11,
     PrunedBelowScreen = 12,
     PrunedTransposition = 13,
+    PrunedNonGameplay = 14,
 };
 
 struct SearchProgress {

--- a/apps/src/server/evolution/FitnessPresentationGenerator.cpp
+++ b/apps/src/server/evolution/FitnessPresentationGenerator.cpp
@@ -75,6 +75,8 @@ const char* smbEndReasonText(SmbEpisodeEndReason endReason)
             return "life_lost";
         case SmbEpisodeEndReason::NoProgressTimeout:
             return "no_progress_timeout";
+        case SmbEpisodeEndReason::FellBelowScreen:
+            return "fell_below_screen";
     }
 
     return "unknown";

--- a/apps/src/server/search/SmbDfsSearch.cpp
+++ b/apps/src/server/search/SmbDfsSearch.cpp
@@ -20,19 +20,8 @@ namespace DirtSim::Server::SearchSupport {
 namespace {
 
 constexpr uint32_t kLevelsPerWorld = 4u;
-constexpr uint8_t kBelowScreenPrunePlayerYScreenThreshold = 224u;
 constexpr uint8_t kVelocityPruneConsecutiveFrameThreshold = 2u;
 constexpr double kVelocityPruneHorizontalSpeedEpsilon = 0.05;
-
-// Hidden movement, input, collision, scroll, and timer bytes used to keep TT probes exact.
-constexpr std::array<size_t, kFallingTranspositionRamByteCount> kFallingTranspositionRamByteAddrs{
-    0x0000, 0x0003, 0x000A, 0x000B, 0x000E, 0x001D, 0x0057, 0x009F, 0x00B5, 0x00CE, 0x03AD,
-    0x03B8, 0x0400, 0x0416, 0x0433, 0x0490, 0x04AC, 0x04AD, 0x04AE, 0x04AF, 0x06D5, 0x06FC,
-    0x0700, 0x0701, 0x0702, 0x0704, 0x0705, 0x0709, 0x070A, 0x070C, 0x070D, 0x0712, 0x0714,
-    0x071A, 0x071B, 0x071C, 0x071D, 0x071E, 0x071F, 0x0722, 0x0723, 0x072C, 0x072F, 0x0739,
-    0x0747, 0x074A, 0x0752, 0x0753, 0x0755, 0x0775, 0x077F, 0x0781, 0x0782, 0x0783, 0x0784,
-    0x0785, 0x0786, 0x0789, 0x078A, 0x0791, 0x0795, 0x079E, 0x079F,
-};
 
 int8_t encodeAxisSign(float value)
 {
@@ -98,12 +87,28 @@ int16_t quantizeVerticalSpeed(double normalizedSpeed)
     return static_cast<int16_t>(std::clamp(roundedSpeed, -128, 128));
 }
 
-std::array<uint8_t, kFallingTranspositionRamByteCount> buildFallingTranspositionRamBytes(
+bool isClosedLossTranspositionInputMirrorRamAddr(size_t ramAddr)
+{
+    switch (ramAddr) {
+        case 0x000A:
+        case 0x000B:
+        case 0x06FC:
+        case 0x074A:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::array<uint8_t, kClosedLossTranspositionRamByteCount> buildClosedLossTranspositionRamBytes(
     const SmolnesRuntime::MemorySnapshot& memorySnapshot)
 {
-    std::array<uint8_t, kFallingTranspositionRamByteCount> ramBytes{};
-    for (size_t i = 0u; i < kFallingTranspositionRamByteAddrs.size(); ++i) {
-        ramBytes[i] = memorySnapshot.cpuRam.at(kFallingTranspositionRamByteAddrs[i]);
+    std::array<uint8_t, kClosedLossTranspositionRamByteCount> ramBytes{};
+    for (size_t i = 0u; i < kClosedLossTranspositionRamByteAddrs.size(); ++i) {
+        const size_t ramAddr = kClosedLossTranspositionRamByteAddrs[i];
+        ramBytes[i] = isClosedLossTranspositionInputMirrorRamAddr(ramAddr)
+            ? 0u
+            : memorySnapshot.cpuRam.at(ramAddr);
     }
     return ramBytes;
 }
@@ -140,6 +145,8 @@ Api::SearchProgressEvent toSearchProgressEvent(SmbDfsSearchTraceEventType eventT
             return Api::SearchProgressEvent::PrunedBelowScreen;
         case SmbDfsSearchTraceEventType::PrunedTransposition:
             return Api::SearchProgressEvent::PrunedTransposition;
+        case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+            return Api::SearchProgressEvent::PrunedNonGameplay;
         case SmbDfsSearchTraceEventType::RootInitialized:
             return Api::SearchProgressEvent::RootInitialized;
         case SmbDfsSearchTraceEventType::Stopped:
@@ -155,7 +162,8 @@ Api::SearchProgressEvent toSearchProgressEvent(SmbDfsSearchTraceEventType eventT
 SmbDfsSearch::SmbDfsSearch(SmbDfsSearchOptions options) : options_(options)
 {}
 
-bool SmbDfsSearch::FallingTranspositionKey::operator==(const FallingTranspositionKey& other) const
+bool SmbDfsSearch::ClosedLossTranspositionKey::operator==(
+    const ClosedLossTranspositionKey& other) const
 {
     return nearestEnemyDx == other.nearestEnemyDx && nearestEnemyDy == other.nearestEnemyDy
         && secondNearestEnemyDx == other.secondNearestEnemyDx
@@ -168,8 +176,8 @@ bool SmbDfsSearch::FallingTranspositionKey::operator==(const FallingTranspositio
         && secondEnemyPresent == other.secondEnemyPresent;
 }
 
-size_t SmbDfsSearch::FallingTranspositionKeyHash::operator()(
-    const FallingTranspositionKey& key) const
+size_t SmbDfsSearch::ClosedLossTranspositionKeyHash::operator()(
+    const ClosedLossTranspositionKey& key) const
 {
     size_t seed = 0u;
     hashCombine(seed, std::hash<int16_t>{}(key.nearestEnemyDx));
@@ -188,6 +196,42 @@ size_t SmbDfsSearch::FallingTranspositionKeyHash::operator()(
     for (const uint8_t byte : key.ramBytes) {
         hashCombine(seed, std::hash<uint8_t>{}(byte));
     }
+    hashCombine(seed, std::hash<bool>{}(key.enemyPresent));
+    hashCombine(seed, std::hash<bool>{}(key.secondEnemyPresent));
+    return seed;
+}
+
+bool SmbDfsSearch::ClosedLossTranspositionShapeKey::operator==(
+    const ClosedLossTranspositionShapeKey& other) const
+{
+    return nearestEnemyDx == other.nearestEnemyDx && nearestEnemyDy == other.nearestEnemyDy
+        && secondNearestEnemyDx == other.secondNearestEnemyDx
+        && secondNearestEnemyDy == other.secondNearestEnemyDy
+        && verticalSpeed == other.verticalSpeed && facingX == other.facingX
+        && horizontalSpeed == other.horizontalSpeed && movementX == other.movementX
+        && absoluteX == other.absoluteX && level == other.level
+        && playerYScreen == other.playerYScreen && powerupState == other.powerupState
+        && world == other.world && enemyPresent == other.enemyPresent
+        && secondEnemyPresent == other.secondEnemyPresent;
+}
+
+size_t SmbDfsSearch::ClosedLossTranspositionShapeKeyHash::operator()(
+    const ClosedLossTranspositionShapeKey& key) const
+{
+    size_t seed = 0u;
+    hashCombine(seed, std::hash<int16_t>{}(key.nearestEnemyDx));
+    hashCombine(seed, std::hash<int16_t>{}(key.nearestEnemyDy));
+    hashCombine(seed, std::hash<int16_t>{}(key.secondNearestEnemyDx));
+    hashCombine(seed, std::hash<int16_t>{}(key.secondNearestEnemyDy));
+    hashCombine(seed, std::hash<int16_t>{}(key.verticalSpeed));
+    hashCombine(seed, std::hash<int8_t>{}(key.facingX));
+    hashCombine(seed, std::hash<int8_t>{}(key.horizontalSpeed));
+    hashCombine(seed, std::hash<int8_t>{}(key.movementX));
+    hashCombine(seed, std::hash<uint16_t>{}(key.absoluteX));
+    hashCombine(seed, std::hash<uint8_t>{}(key.level));
+    hashCombine(seed, std::hash<uint8_t>{}(key.playerYScreen));
+    hashCombine(seed, std::hash<uint8_t>{}(key.powerupState));
+    hashCombine(seed, std::hash<uint8_t>{}(key.world));
     hashCombine(seed, std::hash<bool>{}(key.enemyPresent));
     hashCombine(seed, std::hash<bool>{}(key.secondEnemyPresent));
     return seed;
@@ -331,7 +375,15 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
         DfsFrame& dfsFrame = dfsStack_.back();
         if (dfsFrame.nextActionIndex >= dfsFrame.actionOrdering.count) {
             const SmbSearchNode& exhaustedNode = nodes_[dfsFrame.nodeIndex];
-            publishFallingTranspositionEntry(dfsFrame.nodeIndex);
+            const SmbSearchNodeOutcome exhaustedOutcome = dfsFrame.closedLossCandidate
+                ? SmbSearchNodeOutcome::ClosedLoss
+                : SmbSearchNodeOutcome::NotClosedLoss;
+            const SmbDfsClosedLossBlockReason exhaustedBlockReason = dfsFrame.closedLossCandidate
+                ? SmbDfsClosedLossBlockReason::None
+                : dfsFrame.closedLossBlockReason;
+            nodeOutcomes_[dfsFrame.nodeIndex] = exhaustedOutcome;
+            closedLossBlockReasons_[dfsFrame.nodeIndex] = exhaustedBlockReason;
+            publishClosedLossTranspositionEntry(dfsFrame.nodeIndex);
             recordTrace(
                 SmbDfsSearchTraceEntry{
                     .eventType = SmbDfsSearchTraceEventType::Backtracked,
@@ -343,12 +395,16 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                     .evaluationScore = exhaustedNode.evaluatorSummary.evaluationScore,
                     .framesSinceProgress =
                         exhaustedNode.evaluatorSummary.gameplayFramesSinceProgress,
+                    .closedLossCandidate = dfsFrame.closedLossCandidate,
+                    .closedLossProven = exhaustedOutcome == SmbSearchNodeOutcome::ClosedLoss,
+                    .closedLossBlockReason = exhaustedBlockReason,
                 });
             const size_t poppedNodeIndex = dfsFrame.nodeIndex;
             dfsStack_.pop_back();
             releaseNodeHeavyData(poppedNodeIndex);
             progress_.lastSearchEvent = Api::SearchProgressEvent::Backtracked;
             if (!dfsStack_.empty()) {
+                noteChildOutcome(dfsStack_.back(), exhaustedOutcome, exhaustedBlockReason);
                 updateRenderableState(nodes_[dfsStack_.back().nodeIndex]);
                 return SmbDfsSearchTickResult{
                     .renderChanged = true,
@@ -445,11 +501,29 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
             scenarioVideoFrame = driver_->copyRuntimeFrameSnapshot();
         }
 
-        const std::optional<FallingTranspositionKey> fallingTranspositionKey =
-            buildFallingTranspositionKey(
-                state, stepResult.memorySnapshot.value(), evaluatorSummary);
-        const bool prunedTransposition = fallingTranspositionKey.has_value()
-            && isFallingTranspositionPruned(fallingTranspositionKey.value(), evaluatorSummary);
+        const bool belowScreen = evaluatorSummary.endReason == SmbEpisodeEndReason::FellBelowScreen;
+        const bool terminalLoss = evaluatorSummary.terminal && !belowScreen;
+        const bool nonGameplay =
+            !evaluatorSummary.terminal && state.gameMode != SmbGameMode::Normal;
+        const std::optional<ClosedLossTranspositionKey> closedLossTranspositionKey =
+            buildClosedLossTranspositionKey(state, stepResult.memorySnapshot.value());
+        const std::optional<ClosedLossTranspositionShapeKey> closedLossTranspositionShapeKey =
+            closedLossTranspositionKey.has_value()
+            ? std::optional<ClosedLossTranspositionShapeKey>(
+                  buildClosedLossTranspositionShapeKey(closedLossTranspositionKey.value()))
+            : std::nullopt;
+        const bool prunedTransposition = !evaluatorSummary.terminal && !nonGameplay
+            && closedLossTranspositionKey.has_value()
+            && isClosedLossTranspositionPruned(
+                closedLossTranspositionKey.value(), evaluatorSummary);
+        const ClosedLossTranspositionShapeProbeResult approximateTranspositionProbe =
+            !evaluatorSummary.terminal && !nonGameplay && closedLossTranspositionKey.has_value()
+                && closedLossTranspositionShapeKey.has_value()
+            ? probeClosedLossTranspositionShape(
+                  closedLossTranspositionShapeKey.value(),
+                  closedLossTranspositionKey.value(),
+                  evaluatorSummary)
+            : ClosedLossTranspositionShapeProbeResult{};
         const size_t childIndex = nodes_.size();
         nodes_.push_back(
             SmbSearchNode{
@@ -463,18 +537,17 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                 .gameplayFrame = evaluatorSummary.gameplayFrames,
                 .playerYScreen = state.playerYScreen,
             });
-        fallingTranspositionKeys_.push_back(fallingTranspositionKey);
+        closedLossTranspositionKeys_.push_back(closedLossTranspositionKey);
+        nodeOutcomes_.push_back(SmbSearchNodeOutcome::Open);
+        closedLossBlockReasons_.push_back(SmbDfsClosedLossBlockReason::None);
         progress_.searchedNodeCount++;
         if (groundedVerticalJumpPriorityAction) {
             progress_.groundedVerticalJumpPriorityActionCount++;
         }
         updateRenderableState(nodes_.back());
 
-        const bool dead = evaluatorSummary.terminal || state.phase != SmbPhase::Gameplay
-            || state.lifeState != SmbLifeState::Alive;
-        const bool belowScreen = options_.belowScreenPruningEnabled && !dead
-            && state.playerYScreen >= kBelowScreenPrunePlayerYScreenThreshold;
         const bool velocityStuckCandidate = options_.velocityPruningEnabled
+            && !evaluatorSummary.terminal && !nonGameplay
             && state.absoluteX == decodeSmbAbsoluteX(parentCurrentFrontier) && !state.airborne
             && state.playerYScreen >= parentPlayerYScreen
             && std::abs(state.horizontalSpeedNormalized) <= kVelocityPruneHorizontalSpeedEpsilon
@@ -486,14 +559,27 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
         nodes_.back().velocityStuckFrameCount = velocityStuckFrameCount;
         const bool velocityStuck =
             velocityStuckFrameCount >= kVelocityPruneConsecutiveFrameThreshold;
-        const bool stalled =
-            evaluatorSummary.gameplayFramesSinceProgress >= options_.stallFrameLimit;
-        const SmbDfsSearchTraceEventType traceEvent = dead ? SmbDfsSearchTraceEventType::PrunedDead
+        const bool stalled = !evaluatorSummary.terminal && !nonGameplay
+            && evaluatorSummary.gameplayFramesSinceProgress >= options_.stallFrameLimit;
+        const SmbDfsSearchTraceEventType traceEvent = belowScreen
+            ? SmbDfsSearchTraceEventType::PrunedBelowScreen
+            : terminalLoss        ? SmbDfsSearchTraceEventType::PrunedDead
             : prunedTransposition ? SmbDfsSearchTraceEventType::PrunedTransposition
-            : belowScreen         ? SmbDfsSearchTraceEventType::PrunedBelowScreen
+            : nonGameplay         ? SmbDfsSearchTraceEventType::PrunedNonGameplay
             : velocityStuck       ? SmbDfsSearchTraceEventType::PrunedVelocityStuck
             : stalled             ? SmbDfsSearchTraceEventType::PrunedStalled
                                   : SmbDfsSearchTraceEventType::ExpandedAlive;
+        const bool expandedAlive = traceEvent == SmbDfsSearchTraceEventType::ExpandedAlive;
+        const bool childClosedLossCandidate = expandedAlive && isClosedLossCandidate(childIndex);
+        const SmbDfsClosedLossBlockReason childInitialBlockReason = expandedAlive
+            ? getInitialClosedLossBlockReason(childIndex)
+            : SmbDfsClosedLossBlockReason::None;
+        const SmbSearchNodeOutcome childOutcome = expandedAlive ? SmbSearchNodeOutcome::Open
+            : nonGameplay ? SmbSearchNodeOutcome::NotClosedLoss
+                          : SmbSearchNodeOutcome::ClosedLoss;
+        const SmbDfsClosedLossBlockReason childBlockReason = expandedAlive ? childInitialBlockReason
+            : nonGameplay ? SmbDfsClosedLossBlockReason::NonGameplay
+                          : SmbDfsClosedLossBlockReason::None;
         recordTrace(
             SmbDfsSearchTraceEntry{
                 .eventType = traceEvent,
@@ -505,10 +591,21 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                 .evaluationScore = evaluatorSummary.evaluationScore,
                 .framesSinceProgress = evaluatorSummary.gameplayFramesSinceProgress,
                 .groundedVerticalJumpPriorityAction = groundedVerticalJumpPriorityAction,
+                .closedLossCandidate = expandedAlive
+                    ? childClosedLossCandidate
+                    : childOutcome == SmbSearchNodeOutcome::ClosedLoss,
+                .closedLossProven = childOutcome == SmbSearchNodeOutcome::ClosedLoss,
+                .closedLossApproximateTranspositionPruned = approximateTranspositionProbe.pruned,
+                .closedLossApproximateTranspositionRamDiffCount =
+                    approximateTranspositionProbe.ramDiffCount,
+                .closedLossApproximateTranspositionRamDiffs =
+                    approximateTranspositionProbe.ramDiffs,
+                .closedLossBlockReason = childBlockReason,
             });
         progress_.lastSearchEvent = toSearchProgressEvent(traceEvent);
 
-        if (!dead && !prunedTransposition && !belowScreen && !velocityStuck && !stalled) {
+        if (!evaluatorSummary.terminal && !prunedTransposition && !nonGameplay && !velocityStuck
+            && !stalled) {
             updateBestLeaf(childIndex);
             const SmbSearchActionOrdering actionOrdering = buildDfsActionOrder(
                 state.airborne,
@@ -521,10 +618,17 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                     .nodeIndex = childIndex,
                     .nextActionIndex = 0,
                     .actionOrdering = actionOrdering,
+                    .closedLossCandidate = childClosedLossCandidate,
+                    .closedLossBlockReason = childInitialBlockReason,
                 });
         }
         else {
-            publishFallingTranspositionEntry(childIndex);
+            nodeOutcomes_[childIndex] = childOutcome;
+            closedLossBlockReasons_[childIndex] = childBlockReason;
+            noteChildOutcome(dfsFrame, childOutcome, childBlockReason);
+            if (childOutcome == SmbSearchNodeOutcome::ClosedLoss) {
+                publishClosedLossTranspositionEntry(childIndex);
+            }
             // Pruned node will never be loaded again. Release heavy data.
             releaseNodeHeavyData(childIndex);
         }
@@ -671,8 +775,11 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRuntime()
     rootPrefixFrames_.clear();
     nodes_.clear();
     dfsStack_.clear();
-    fallingTranspositionKeys_.clear();
-    fallingTranspositionTable_.clear();
+    nodeOutcomes_.clear();
+    closedLossBlockReasons_.clear();
+    closedLossTranspositionKeys_.clear();
+    closedLossTranspositionTable_.clear();
+    closedLossTranspositionShapeTable_.clear();
     trace_.clear();
     bestLeafIndex_.reset();
     bestFrontier_ = 0;
@@ -702,7 +809,9 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRootNode(
             .currentFrontier = evaluatorSummary.bestFrontier,
             .gameplayFrame = evaluatorSummary.gameplayFrames,
         });
-    fallingTranspositionKeys_.push_back(std::nullopt);
+    closedLossTranspositionKeys_.push_back(std::nullopt);
+    nodeOutcomes_.push_back(SmbSearchNodeOutcome::Open);
+    closedLossBlockReasons_.push_back(getInitialClosedLossBlockReason(0u));
     dfsStack_.push_back(
         DfsFrame{
             .nodeIndex = 0u,
@@ -713,6 +822,8 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRootNode(
                 SmbSearchHorizontalDirection::None,
                 std::nullopt,
                 options_.groundedVerticalJumpPrioritizationEnabled),
+            .closedLossCandidate = isClosedLossCandidate(0u),
+            .closedLossBlockReason = getInitialClosedLossBlockReason(0u),
         });
 
     bestLeafIndex_ = 0u;
@@ -729,6 +840,8 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRootNode(
             .frontier = evaluatorSummary.bestFrontier,
             .evaluationScore = evaluatorSummary.evaluationScore,
             .framesSinceProgress = evaluatorSummary.gameplayFramesSinceProgress,
+            .closedLossCandidate = isClosedLossCandidate(0u),
+            .closedLossBlockReason = getInitialClosedLossBlockReason(0u),
         });
     return Result<std::monostate, std::string>::okay(std::monostate{});
 }
@@ -795,28 +908,52 @@ void SmbDfsSearch::completeWithTraceEvent(SmbDfsSearchTraceEventType eventType)
         });
 }
 
-std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingTranspositionKey(
-    const NesSuperMarioBrosState& state,
-    const SmolnesRuntime::MemorySnapshot& memorySnapshot,
-    const SmbSearchEvaluatorSummary& evaluatorSummary) const
+bool SmbDfsSearch::isClosedLossCandidate(size_t nodeIndex) const
+{
+    return nodeIndex < nodes_.size();
+}
+
+void SmbDfsSearch::noteChildOutcome(
+    DfsFrame& dfsFrame,
+    SmbSearchNodeOutcome childOutcome,
+    SmbDfsClosedLossBlockReason childBlockReason)
+{
+    if (childOutcome == SmbSearchNodeOutcome::ClosedLoss) {
+        return;
+    }
+
+    dfsFrame.closedLossCandidate = false;
+    if (dfsFrame.closedLossBlockReason != SmbDfsClosedLossBlockReason::None) {
+        return;
+    }
+
+    dfsFrame.closedLossBlockReason = childBlockReason == SmbDfsClosedLossBlockReason::NonGameplay
+        ? SmbDfsClosedLossBlockReason::NonGameplay
+        : SmbDfsClosedLossBlockReason::ChildNotClosedLoss;
+}
+
+SmbDfsClosedLossBlockReason SmbDfsSearch::getInitialClosedLossBlockReason(size_t nodeIndex) const
+{
+    return isClosedLossCandidate(nodeIndex) ? SmbDfsClosedLossBlockReason::None
+                                            : SmbDfsClosedLossBlockReason::FreshProgress;
+}
+
+std::optional<SmbDfsSearch::ClosedLossTranspositionKey> SmbDfsSearch::
+    buildClosedLossTranspositionKey(
+        const NesSuperMarioBrosState& state,
+        const SmolnesRuntime::MemorySnapshot& memorySnapshot) const
 {
     if (!options_.fallingTranspositionPruningEnabled) {
         return std::nullopt;
     }
-    if (state.phase != SmbPhase::Gameplay || state.lifeState != SmbLifeState::Alive) {
-        return std::nullopt;
-    }
-    if (!state.airborne || state.verticalSpeedNormalized < 0.0) {
+    if (state.gameMode != SmbGameMode::Normal || state.lifeState != SmbLifeState::Alive) {
         return std::nullopt;
     }
     if (state.playerYScreen < options_.fallingTranspositionPlayerYScreenThreshold) {
         return std::nullopt;
     }
-    if (evaluatorSummary.gameplayFramesSinceProgress == 0u) {
-        return std::nullopt;
-    }
 
-    return FallingTranspositionKey{
+    return ClosedLossTranspositionKey{
         .nearestEnemyDx = state.nearestEnemyDx,
         .nearestEnemyDy = state.nearestEnemyDy,
         .secondNearestEnemyDx = state.secondNearestEnemyDx,
@@ -830,58 +967,140 @@ std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingT
         .playerYScreen = state.playerYScreen,
         .powerupState = static_cast<uint8_t>(state.powerupState),
         .world = state.world,
-        .ramBytes = buildFallingTranspositionRamBytes(memorySnapshot),
+        .ramBytes = buildClosedLossTranspositionRamBytes(memorySnapshot),
         .enemyPresent = state.enemyPresent,
         .secondEnemyPresent = state.secondEnemyPresent,
     };
 }
 
-bool SmbDfsSearch::isFallingTranspositionPruned(
-    const FallingTranspositionKey& key, const SmbSearchEvaluatorSummary& evaluatorSummary) const
+SmbDfsSearch::ClosedLossTranspositionShapeKey SmbDfsSearch::buildClosedLossTranspositionShapeKey(
+    const ClosedLossTranspositionKey& key) const
 {
-    const auto entryIt = fallingTranspositionTable_.find(key);
-    if (entryIt == fallingTranspositionTable_.end()) {
+    return ClosedLossTranspositionShapeKey{
+        .nearestEnemyDx = key.nearestEnemyDx,
+        .nearestEnemyDy = key.nearestEnemyDy,
+        .secondNearestEnemyDx = key.secondNearestEnemyDx,
+        .secondNearestEnemyDy = key.secondNearestEnemyDy,
+        .verticalSpeed = key.verticalSpeed,
+        .facingX = key.facingX,
+        .horizontalSpeed = key.horizontalSpeed,
+        .movementX = key.movementX,
+        .absoluteX = key.absoluteX,
+        .level = key.level,
+        .playerYScreen = key.playerYScreen,
+        .powerupState = key.powerupState,
+        .world = key.world,
+        .enemyPresent = key.enemyPresent,
+        .secondEnemyPresent = key.secondEnemyPresent,
+    };
+}
+
+bool SmbDfsSearch::isClosedLossTranspositionPruned(
+    const ClosedLossTranspositionKey& key, const SmbSearchEvaluatorSummary& evaluatorSummary) const
+{
+    const auto entryIt = closedLossTranspositionTable_.find(key);
+    if (entryIt == closedLossTranspositionTable_.end()) {
         return false;
     }
 
-    const FallingTranspositionEntry& entry = entryIt->second;
+    const ClosedLossTranspositionEntry& entry = entryIt->second;
     return entry.bestFrontier >= evaluatorSummary.bestFrontier
         && entry.gameplayFrame <= evaluatorSummary.gameplayFrames
         && entry.framesSinceProgress <= evaluatorSummary.gameplayFramesSinceProgress;
 }
 
-void SmbDfsSearch::publishFallingTranspositionEntry(size_t nodeIndex)
+SmbDfsSearch::ClosedLossTranspositionShapeProbeResult SmbDfsSearch::
+    probeClosedLossTranspositionShape(
+        const ClosedLossTranspositionShapeKey& key,
+        const ClosedLossTranspositionKey& exactKey,
+        const SmbSearchEvaluatorSummary& evaluatorSummary) const
 {
-    if (nodeIndex >= nodes_.size() || nodeIndex >= fallingTranspositionKeys_.size()) {
+    const auto entryIt = closedLossTranspositionShapeTable_.find(key);
+    if (entryIt == closedLossTranspositionShapeTable_.end()) {
+        return {};
+    }
+
+    const ClosedLossTranspositionShapeEntry& shapeEntry = entryIt->second;
+    const ClosedLossTranspositionEntry& proof = shapeEntry.proof;
+    if (proof.bestFrontier < evaluatorSummary.bestFrontier
+        || proof.gameplayFrame > evaluatorSummary.gameplayFrames
+        || proof.framesSinceProgress > evaluatorSummary.gameplayFramesSinceProgress) {
+        return {};
+    }
+
+    ClosedLossTranspositionShapeProbeResult result{
+        .pruned = true,
+    };
+    for (size_t i = 0u; i < exactKey.ramBytes.size(); ++i) {
+        if (exactKey.ramBytes[i] == shapeEntry.ramBytes[i]) {
+            continue;
+        }
+
+        result.ramDiffs[i] = true;
+        result.ramDiffCount++;
+    }
+    return result;
+}
+
+void SmbDfsSearch::publishClosedLossTranspositionEntry(size_t nodeIndex)
+{
+    if (nodeIndex >= nodes_.size() || nodeIndex >= closedLossTranspositionKeys_.size()
+        || nodeIndex >= nodeOutcomes_.size()) {
         return;
     }
 
-    const std::optional<FallingTranspositionKey>& key = fallingTranspositionKeys_[nodeIndex];
+    if (nodeOutcomes_[nodeIndex] != SmbSearchNodeOutcome::ClosedLoss) {
+        return;
+    }
+
+    const std::optional<ClosedLossTranspositionKey>& key = closedLossTranspositionKeys_[nodeIndex];
     if (!key.has_value()) {
         return;
     }
 
     const SmbSearchNode& node = nodes_[nodeIndex];
-    const FallingTranspositionEntry entry{
+    const ClosedLossTranspositionEntry entry{
         .bestFrontier = node.evaluatorSummary.bestFrontier,
         .framesSinceProgress = node.evaluatorSummary.gameplayFramesSinceProgress,
         .gameplayFrame = node.evaluatorSummary.gameplayFrames,
     };
 
-    const auto existingIt = fallingTranspositionTable_.find(key.value());
-    if (existingIt == fallingTranspositionTable_.end()) {
-        fallingTranspositionTable_.emplace(key.value(), entry);
+    const auto existingIt = closedLossTranspositionTable_.find(key.value());
+    if (existingIt == closedLossTranspositionTable_.end()) {
+        closedLossTranspositionTable_.emplace(key.value(), entry);
+    }
+    else {
+        ClosedLossTranspositionEntry& existing = existingIt->second;
+        if (entry.bestFrontier > existing.bestFrontier
+            || (entry.bestFrontier == existing.bestFrontier
+                && entry.gameplayFrame < existing.gameplayFrame)
+            || (entry.bestFrontier == existing.bestFrontier
+                && entry.gameplayFrame == existing.gameplayFrame
+                && entry.framesSinceProgress < existing.framesSinceProgress)) {
+            existing = entry;
+        }
+    }
+
+    const ClosedLossTranspositionShapeKey shapeKey =
+        buildClosedLossTranspositionShapeKey(key.value());
+    const ClosedLossTranspositionShapeEntry shapeEntry{
+        .proof = entry,
+        .ramBytes = key->ramBytes,
+    };
+    const auto existingShapeIt = closedLossTranspositionShapeTable_.find(shapeKey);
+    if (existingShapeIt == closedLossTranspositionShapeTable_.end()) {
+        closedLossTranspositionShapeTable_.emplace(shapeKey, shapeEntry);
         return;
     }
 
-    FallingTranspositionEntry& existing = existingIt->second;
-    if (entry.bestFrontier > existing.bestFrontier
-        || (entry.bestFrontier == existing.bestFrontier
-            && entry.gameplayFrame < existing.gameplayFrame)
-        || (entry.bestFrontier == existing.bestFrontier
-            && entry.gameplayFrame == existing.gameplayFrame
-            && entry.framesSinceProgress < existing.framesSinceProgress)) {
-        existing = entry;
+    ClosedLossTranspositionShapeEntry& existingShape = existingShapeIt->second;
+    if (entry.bestFrontier > existingShape.proof.bestFrontier
+        || (entry.bestFrontier == existingShape.proof.bestFrontier
+            && entry.gameplayFrame < existingShape.proof.gameplayFrame)
+        || (entry.bestFrontier == existingShape.proof.bestFrontier
+            && entry.gameplayFrame == existingShape.proof.gameplayFrame
+            && entry.framesSinceProgress < existingShape.proof.framesSinceProgress)) {
+        existingShape = shapeEntry;
     }
 }
 

--- a/apps/src/server/search/SmbDfsSearch.cpp
+++ b/apps/src/server/search/SmbDfsSearch.cpp
@@ -20,8 +20,6 @@ namespace {
 
 constexpr uint32_t kLevelsPerWorld = 4u;
 constexpr uint8_t kBelowScreenPrunePlayerYScreenThreshold = 224u;
-constexpr uint8_t kFallingTranspositionPlayerYScreenThreshold =
-    kBelowScreenPrunePlayerYScreenThreshold - 8u;
 constexpr uint8_t kVelocityPruneConsecutiveFrameThreshold = 2u;
 constexpr double kVelocityPruneHorizontalSpeedEpsilon = 0.05;
 
@@ -784,7 +782,7 @@ std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingT
     if (!state.airborne || state.verticalSpeedNormalized < 0.0) {
         return std::nullopt;
     }
-    if (state.playerYScreen < kFallingTranspositionPlayerYScreenThreshold) {
+    if (state.playerYScreen < options_.fallingTranspositionPlayerYScreenThreshold) {
         return std::nullopt;
     }
     if (evaluatorSummary.gameplayFramesSinceProgress == 0u) {

--- a/apps/src/server/search/SmbDfsSearch.cpp
+++ b/apps/src/server/search/SmbDfsSearch.cpp
@@ -11,6 +11,7 @@
 #include "server/search/SmbSearchHarness.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 
@@ -22,6 +23,16 @@ constexpr uint32_t kLevelsPerWorld = 4u;
 constexpr uint8_t kBelowScreenPrunePlayerYScreenThreshold = 224u;
 constexpr uint8_t kVelocityPruneConsecutiveFrameThreshold = 2u;
 constexpr double kVelocityPruneHorizontalSpeedEpsilon = 0.05;
+
+// Hidden movement, input, collision, scroll, and timer bytes used to keep TT probes exact.
+constexpr std::array<size_t, kFallingTranspositionRamByteCount> kFallingTranspositionRamByteAddrs{
+    0x0000, 0x0003, 0x000A, 0x000B, 0x000E, 0x001D, 0x0057, 0x009F, 0x00B5, 0x00CE, 0x03AD,
+    0x03B8, 0x0400, 0x0416, 0x0433, 0x0490, 0x04AC, 0x04AD, 0x04AE, 0x04AF, 0x06D5, 0x06FC,
+    0x0700, 0x0701, 0x0702, 0x0704, 0x0705, 0x0709, 0x070A, 0x070C, 0x070D, 0x0712, 0x0714,
+    0x071A, 0x071B, 0x071C, 0x071D, 0x071E, 0x071F, 0x0722, 0x0723, 0x072C, 0x072F, 0x0739,
+    0x0747, 0x074A, 0x0752, 0x0753, 0x0755, 0x0775, 0x077F, 0x0781, 0x0782, 0x0783, 0x0784,
+    0x0785, 0x0786, 0x0789, 0x078A, 0x0791, 0x0795, 0x079E, 0x079F,
+};
 
 int8_t encodeAxisSign(float value)
 {
@@ -87,6 +98,16 @@ int16_t quantizeVerticalSpeed(double normalizedSpeed)
     return static_cast<int16_t>(std::clamp(roundedSpeed, -128, 128));
 }
 
+std::array<uint8_t, kFallingTranspositionRamByteCount> buildFallingTranspositionRamBytes(
+    const SmolnesRuntime::MemorySnapshot& memorySnapshot)
+{
+    std::array<uint8_t, kFallingTranspositionRamByteCount> ramBytes{};
+    for (size_t i = 0u; i < kFallingTranspositionRamByteAddrs.size(); ++i) {
+        ramBytes[i] = memorySnapshot.cpuRam.at(kFallingTranspositionRamByteAddrs[i]);
+    }
+    return ramBytes;
+}
+
 std::vector<PlayerControlFrame> makeRootPrefixFrames(uint64_t gameplayFrameCount)
 {
     return std::vector<PlayerControlFrame>(
@@ -143,7 +164,7 @@ bool SmbDfsSearch::FallingTranspositionKey::operator==(const FallingTranspositio
         && horizontalSpeed == other.horizontalSpeed && movementX == other.movementX
         && absoluteX == other.absoluteX && level == other.level
         && playerYScreen == other.playerYScreen && powerupState == other.powerupState
-        && world == other.world && enemyPresent == other.enemyPresent
+        && world == other.world && ramBytes == other.ramBytes && enemyPresent == other.enemyPresent
         && secondEnemyPresent == other.secondEnemyPresent;
 }
 
@@ -164,6 +185,9 @@ size_t SmbDfsSearch::FallingTranspositionKeyHash::operator()(
     hashCombine(seed, std::hash<uint8_t>{}(key.playerYScreen));
     hashCombine(seed, std::hash<uint8_t>{}(key.powerupState));
     hashCombine(seed, std::hash<uint8_t>{}(key.world));
+    for (const uint8_t byte : key.ramBytes) {
+        hashCombine(seed, std::hash<uint8_t>{}(byte));
+    }
     hashCombine(seed, std::hash<bool>{}(key.enemyPresent));
     hashCombine(seed, std::hash<bool>{}(key.secondEnemyPresent));
     return seed;
@@ -422,7 +446,8 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
         }
 
         const std::optional<FallingTranspositionKey> fallingTranspositionKey =
-            buildFallingTranspositionKey(state, evaluatorSummary);
+            buildFallingTranspositionKey(
+                state, stepResult.memorySnapshot.value(), evaluatorSummary);
         const bool prunedTransposition = fallingTranspositionKey.has_value()
             && isFallingTranspositionPruned(fallingTranspositionKey.value(), evaluatorSummary);
         const size_t childIndex = nodes_.size();
@@ -771,7 +796,9 @@ void SmbDfsSearch::completeWithTraceEvent(SmbDfsSearchTraceEventType eventType)
 }
 
 std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingTranspositionKey(
-    const NesSuperMarioBrosState& state, const SmbSearchEvaluatorSummary& evaluatorSummary) const
+    const NesSuperMarioBrosState& state,
+    const SmolnesRuntime::MemorySnapshot& memorySnapshot,
+    const SmbSearchEvaluatorSummary& evaluatorSummary) const
 {
     if (!options_.fallingTranspositionPruningEnabled) {
         return std::nullopt;
@@ -803,6 +830,7 @@ std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingT
         .playerYScreen = state.playerYScreen,
         .powerupState = static_cast<uint8_t>(state.powerupState),
         .world = state.world,
+        .ramBytes = buildFallingTranspositionRamBytes(memorySnapshot),
         .enemyPresent = state.enemyPresent,
         .secondEnemyPresent = state.secondEnemyPresent,
     };

--- a/apps/src/server/search/SmbDfsSearch.cpp
+++ b/apps/src/server/search/SmbDfsSearch.cpp
@@ -35,6 +35,29 @@ uint64_t encodeCurrentFrontier(const NesSuperMarioBrosState& state)
     return encodeSmbFrontier(stageIndex, state.absoluteX);
 }
 
+SmbSearchHorizontalDirection getHorizontalDirection(const NesSuperMarioBrosState& state)
+{
+    if (state.movementX > 0.0f) {
+        return SmbSearchHorizontalDirection::Right;
+    }
+    if (state.movementX < 0.0f) {
+        return SmbSearchHorizontalDirection::Left;
+    }
+    if (state.horizontalSpeedNormalized > 0.0) {
+        return SmbSearchHorizontalDirection::Right;
+    }
+    if (state.horizontalSpeedNormalized < 0.0) {
+        return SmbSearchHorizontalDirection::Left;
+    }
+    if (state.facingX > 0.0f) {
+        return SmbSearchHorizontalDirection::Right;
+    }
+    if (state.facingX < 0.0f) {
+        return SmbSearchHorizontalDirection::Left;
+    }
+    return SmbSearchHorizontalDirection::None;
+}
+
 std::vector<PlayerControlFrame> makeRootPrefixFrames(uint64_t gameplayFrameCount)
 {
     return std::vector<PlayerControlFrame>(
@@ -392,6 +415,7 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
             const SmbSearchActionOrdering actionOrdering = buildDfsActionOrder(
                 state.airborne,
                 state.verticalSpeedNormalized,
+                getHorizontalDirection(state),
                 action,
                 options_.groundedVerticalJumpPrioritizationEnabled);
             dfsStack_.push_back(
@@ -582,7 +606,11 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRootNode(
             .nodeIndex = 0u,
             .nextActionIndex = 0,
             .actionOrdering = buildDfsActionOrder(
-                false, 0.0, std::nullopt, options_.groundedVerticalJumpPrioritizationEnabled),
+                false,
+                0.0,
+                SmbSearchHorizontalDirection::None,
+                std::nullopt,
+                options_.groundedVerticalJumpPrioritizationEnabled),
         });
 
     bestLeafIndex_ = 0u;

--- a/apps/src/server/search/SmbDfsSearch.cpp
+++ b/apps/src/server/search/SmbDfsSearch.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 
 namespace DirtSim::Server::SearchSupport {
 
@@ -19,8 +20,21 @@ namespace {
 
 constexpr uint32_t kLevelsPerWorld = 4u;
 constexpr uint8_t kBelowScreenPrunePlayerYScreenThreshold = 224u;
+constexpr uint8_t kFallingTranspositionPlayerYScreenThreshold =
+    kBelowScreenPrunePlayerYScreenThreshold - 8u;
 constexpr uint8_t kVelocityPruneConsecutiveFrameThreshold = 2u;
 constexpr double kVelocityPruneHorizontalSpeedEpsilon = 0.05;
+
+int8_t encodeAxisSign(float value)
+{
+    if (value > 0.0f) {
+        return 1;
+    }
+    if (value < 0.0f) {
+        return -1;
+    }
+    return 0;
+}
 
 std::unique_ptr<NesGameAdapter> createSmbGameAdapter()
 {
@@ -33,6 +47,11 @@ uint64_t encodeCurrentFrontier(const NesSuperMarioBrosState& state)
     const uint32_t stageIndex =
         (static_cast<uint32_t>(state.world) * kLevelsPerWorld) + state.level;
     return encodeSmbFrontier(stageIndex, state.absoluteX);
+}
+
+void hashCombine(size_t& seed, size_t value)
+{
+    seed ^= value + 0x9E3779B97F4A7C15ull + (seed << 6u) + (seed >> 2u);
 }
 
 SmbSearchHorizontalDirection getHorizontalDirection(const NesSuperMarioBrosState& state)
@@ -56,6 +75,18 @@ SmbSearchHorizontalDirection getHorizontalDirection(const NesSuperMarioBrosState
         return SmbSearchHorizontalDirection::Left;
     }
     return SmbSearchHorizontalDirection::None;
+}
+
+int8_t quantizeHorizontalSpeed(double normalizedSpeed)
+{
+    const int roundedSpeed = static_cast<int>(std::lround(normalizedSpeed * 40.0));
+    return static_cast<int8_t>(std::clamp(roundedSpeed, -128, 127));
+}
+
+int16_t quantizeVerticalSpeed(double normalizedSpeed)
+{
+    const int roundedSpeed = static_cast<int>(std::lround(normalizedSpeed * 128.0));
+    return static_cast<int16_t>(std::clamp(roundedSpeed, -128, 128));
 }
 
 std::vector<PlayerControlFrame> makeRootPrefixFrames(uint64_t gameplayFrameCount)
@@ -88,6 +119,8 @@ Api::SearchProgressEvent toSearchProgressEvent(SmbDfsSearchTraceEventType eventT
             return Api::SearchProgressEvent::PrunedVelocityStuck;
         case SmbDfsSearchTraceEventType::PrunedBelowScreen:
             return Api::SearchProgressEvent::PrunedBelowScreen;
+        case SmbDfsSearchTraceEventType::PrunedTransposition:
+            return Api::SearchProgressEvent::PrunedTransposition;
         case SmbDfsSearchTraceEventType::RootInitialized:
             return Api::SearchProgressEvent::RootInitialized;
         case SmbDfsSearchTraceEventType::Stopped:
@@ -102,6 +135,41 @@ Api::SearchProgressEvent toSearchProgressEvent(SmbDfsSearchTraceEventType eventT
 
 SmbDfsSearch::SmbDfsSearch(SmbDfsSearchOptions options) : options_(options)
 {}
+
+bool SmbDfsSearch::FallingTranspositionKey::operator==(const FallingTranspositionKey& other) const
+{
+    return nearestEnemyDx == other.nearestEnemyDx && nearestEnemyDy == other.nearestEnemyDy
+        && secondNearestEnemyDx == other.secondNearestEnemyDx
+        && secondNearestEnemyDy == other.secondNearestEnemyDy
+        && verticalSpeed == other.verticalSpeed && facingX == other.facingX
+        && horizontalSpeed == other.horizontalSpeed && movementX == other.movementX
+        && absoluteX == other.absoluteX && level == other.level
+        && playerYScreen == other.playerYScreen && powerupState == other.powerupState
+        && world == other.world && enemyPresent == other.enemyPresent
+        && secondEnemyPresent == other.secondEnemyPresent;
+}
+
+size_t SmbDfsSearch::FallingTranspositionKeyHash::operator()(
+    const FallingTranspositionKey& key) const
+{
+    size_t seed = 0u;
+    hashCombine(seed, std::hash<int16_t>{}(key.nearestEnemyDx));
+    hashCombine(seed, std::hash<int16_t>{}(key.nearestEnemyDy));
+    hashCombine(seed, std::hash<int16_t>{}(key.secondNearestEnemyDx));
+    hashCombine(seed, std::hash<int16_t>{}(key.secondNearestEnemyDy));
+    hashCombine(seed, std::hash<int16_t>{}(key.verticalSpeed));
+    hashCombine(seed, std::hash<int8_t>{}(key.facingX));
+    hashCombine(seed, std::hash<int8_t>{}(key.horizontalSpeed));
+    hashCombine(seed, std::hash<int8_t>{}(key.movementX));
+    hashCombine(seed, std::hash<uint16_t>{}(key.absoluteX));
+    hashCombine(seed, std::hash<uint8_t>{}(key.level));
+    hashCombine(seed, std::hash<uint8_t>{}(key.playerYScreen));
+    hashCombine(seed, std::hash<uint8_t>{}(key.powerupState));
+    hashCombine(seed, std::hash<uint8_t>{}(key.world));
+    hashCombine(seed, std::hash<bool>{}(key.enemyPresent));
+    hashCombine(seed, std::hash<bool>{}(key.secondEnemyPresent));
+    return seed;
+}
 
 Result<std::monostate, std::string> SmbDfsSearch::startDfs()
 {
@@ -241,6 +309,7 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
         DfsFrame& dfsFrame = dfsStack_.back();
         if (dfsFrame.nextActionIndex >= dfsFrame.actionOrdering.count) {
             const SmbSearchNode& exhaustedNode = nodes_[dfsFrame.nodeIndex];
+            publishFallingTranspositionEntry(dfsFrame.nodeIndex);
             recordTrace(
                 SmbDfsSearchTraceEntry{
                     .eventType = SmbDfsSearchTraceEventType::Backtracked,
@@ -354,6 +423,10 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
             scenarioVideoFrame = driver_->copyRuntimeFrameSnapshot();
         }
 
+        const std::optional<FallingTranspositionKey> fallingTranspositionKey =
+            buildFallingTranspositionKey(state, evaluatorSummary);
+        const bool prunedTransposition = fallingTranspositionKey.has_value()
+            && isFallingTranspositionPruned(fallingTranspositionKey.value(), evaluatorSummary);
         const size_t childIndex = nodes_.size();
         nodes_.push_back(
             SmbSearchNode{
@@ -367,6 +440,7 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                 .gameplayFrame = evaluatorSummary.gameplayFrames,
                 .playerYScreen = state.playerYScreen,
             });
+        fallingTranspositionKeys_.push_back(fallingTranspositionKey);
         progress_.searchedNodeCount++;
         if (groundedVerticalJumpPriorityAction) {
             progress_.groundedVerticalJumpPriorityActionCount++;
@@ -392,10 +466,11 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
         const bool stalled =
             evaluatorSummary.gameplayFramesSinceProgress >= options_.stallFrameLimit;
         const SmbDfsSearchTraceEventType traceEvent = dead ? SmbDfsSearchTraceEventType::PrunedDead
-            : belowScreen   ? SmbDfsSearchTraceEventType::PrunedBelowScreen
-            : velocityStuck ? SmbDfsSearchTraceEventType::PrunedVelocityStuck
-            : stalled       ? SmbDfsSearchTraceEventType::PrunedStalled
-                            : SmbDfsSearchTraceEventType::ExpandedAlive;
+            : prunedTransposition ? SmbDfsSearchTraceEventType::PrunedTransposition
+            : belowScreen         ? SmbDfsSearchTraceEventType::PrunedBelowScreen
+            : velocityStuck       ? SmbDfsSearchTraceEventType::PrunedVelocityStuck
+            : stalled             ? SmbDfsSearchTraceEventType::PrunedStalled
+                                  : SmbDfsSearchTraceEventType::ExpandedAlive;
         recordTrace(
             SmbDfsSearchTraceEntry{
                 .eventType = traceEvent,
@@ -410,7 +485,7 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
             });
         progress_.lastSearchEvent = toSearchProgressEvent(traceEvent);
 
-        if (!dead && !belowScreen && !velocityStuck && !stalled) {
+        if (!dead && !prunedTransposition && !belowScreen && !velocityStuck && !stalled) {
             updateBestLeaf(childIndex);
             const SmbSearchActionOrdering actionOrdering = buildDfsActionOrder(
                 state.airborne,
@@ -426,6 +501,7 @@ SmbDfsSearchTickResult SmbDfsSearch::tick()
                 });
         }
         else {
+            publishFallingTranspositionEntry(childIndex);
             // Pruned node will never be loaded again. Release heavy data.
             releaseNodeHeavyData(childIndex);
         }
@@ -572,6 +648,8 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRuntime()
     rootPrefixFrames_.clear();
     nodes_.clear();
     dfsStack_.clear();
+    fallingTranspositionKeys_.clear();
+    fallingTranspositionTable_.clear();
     trace_.clear();
     bestLeafIndex_.reset();
     bestFrontier_ = 0;
@@ -601,6 +679,7 @@ Result<std::monostate, std::string> SmbDfsSearch::initializeRootNode(
             .currentFrontier = evaluatorSummary.bestFrontier,
             .gameplayFrame = evaluatorSummary.gameplayFrames,
         });
+    fallingTranspositionKeys_.push_back(std::nullopt);
     dfsStack_.push_back(
         DfsFrame{
             .nodeIndex = 0u,
@@ -691,6 +770,93 @@ void SmbDfsSearch::completeWithTraceEvent(SmbDfsSearchTraceEventType eventType)
                 ? nodes_[nodeIndex].evaluatorSummary.gameplayFramesSinceProgress
                 : 0u,
         });
+}
+
+std::optional<SmbDfsSearch::FallingTranspositionKey> SmbDfsSearch::buildFallingTranspositionKey(
+    const NesSuperMarioBrosState& state, const SmbSearchEvaluatorSummary& evaluatorSummary) const
+{
+    if (!options_.fallingTranspositionPruningEnabled) {
+        return std::nullopt;
+    }
+    if (state.phase != SmbPhase::Gameplay || state.lifeState != SmbLifeState::Alive) {
+        return std::nullopt;
+    }
+    if (!state.airborne || state.verticalSpeedNormalized < 0.0) {
+        return std::nullopt;
+    }
+    if (state.playerYScreen < kFallingTranspositionPlayerYScreenThreshold) {
+        return std::nullopt;
+    }
+    if (evaluatorSummary.gameplayFramesSinceProgress == 0u) {
+        return std::nullopt;
+    }
+
+    return FallingTranspositionKey{
+        .nearestEnemyDx = state.nearestEnemyDx,
+        .nearestEnemyDy = state.nearestEnemyDy,
+        .secondNearestEnemyDx = state.secondNearestEnemyDx,
+        .secondNearestEnemyDy = state.secondNearestEnemyDy,
+        .verticalSpeed = quantizeVerticalSpeed(state.verticalSpeedNormalized),
+        .facingX = encodeAxisSign(state.facingX),
+        .horizontalSpeed = quantizeHorizontalSpeed(state.horizontalSpeedNormalized),
+        .movementX = encodeAxisSign(state.movementX),
+        .absoluteX = state.absoluteX,
+        .level = state.level,
+        .playerYScreen = state.playerYScreen,
+        .powerupState = static_cast<uint8_t>(state.powerupState),
+        .world = state.world,
+        .enemyPresent = state.enemyPresent,
+        .secondEnemyPresent = state.secondEnemyPresent,
+    };
+}
+
+bool SmbDfsSearch::isFallingTranspositionPruned(
+    const FallingTranspositionKey& key, const SmbSearchEvaluatorSummary& evaluatorSummary) const
+{
+    const auto entryIt = fallingTranspositionTable_.find(key);
+    if (entryIt == fallingTranspositionTable_.end()) {
+        return false;
+    }
+
+    const FallingTranspositionEntry& entry = entryIt->second;
+    return entry.bestFrontier >= evaluatorSummary.bestFrontier
+        && entry.gameplayFrame <= evaluatorSummary.gameplayFrames
+        && entry.framesSinceProgress <= evaluatorSummary.gameplayFramesSinceProgress;
+}
+
+void SmbDfsSearch::publishFallingTranspositionEntry(size_t nodeIndex)
+{
+    if (nodeIndex >= nodes_.size() || nodeIndex >= fallingTranspositionKeys_.size()) {
+        return;
+    }
+
+    const std::optional<FallingTranspositionKey>& key = fallingTranspositionKeys_[nodeIndex];
+    if (!key.has_value()) {
+        return;
+    }
+
+    const SmbSearchNode& node = nodes_[nodeIndex];
+    const FallingTranspositionEntry entry{
+        .bestFrontier = node.evaluatorSummary.bestFrontier,
+        .framesSinceProgress = node.evaluatorSummary.gameplayFramesSinceProgress,
+        .gameplayFrame = node.evaluatorSummary.gameplayFrames,
+    };
+
+    const auto existingIt = fallingTranspositionTable_.find(key.value());
+    if (existingIt == fallingTranspositionTable_.end()) {
+        fallingTranspositionTable_.emplace(key.value(), entry);
+        return;
+    }
+
+    FallingTranspositionEntry& existing = existingIt->second;
+    if (entry.bestFrontier > existing.bestFrontier
+        || (entry.bestFrontier == existing.bestFrontier
+            && entry.gameplayFrame < existing.gameplayFrame)
+        || (entry.bestFrontier == existing.bestFrontier
+            && entry.gameplayFrame == existing.gameplayFrame
+            && entry.framesSinceProgress < existing.framesSinceProgress)) {
+        existing = entry;
+    }
 }
 
 void SmbDfsSearch::rebuildBestPlan()

--- a/apps/src/server/search/SmbDfsSearch.h
+++ b/apps/src/server/search/SmbDfsSearch.h
@@ -25,6 +25,8 @@ namespace Server::SearchSupport {
 
 struct SmbSearchRootFixture;
 
+constexpr uint8_t kDefaultFallingTranspositionPlayerYScreenThreshold = 192u;
+
 enum class SmbDfsSearchCompletionReason : uint8_t {
     Completed = 0,
     Stopped = 1,
@@ -37,6 +39,8 @@ struct SmbDfsSearchOptions {
     bool velocityPruningEnabled = true;
     bool belowScreenPruningEnabled = true;
     bool fallingTranspositionPruningEnabled = true;
+    uint8_t fallingTranspositionPlayerYScreenThreshold =
+        kDefaultFallingTranspositionPlayerYScreenThreshold;
     bool groundedVerticalJumpPrioritizationEnabled = true;
     std::optional<uint64_t> stopAfterBestFrontier = std::nullopt;
 };

--- a/apps/src/server/search/SmbDfsSearch.h
+++ b/apps/src/server/search/SmbDfsSearch.h
@@ -8,6 +8,7 @@
 #include "server/api/SearchProgress.h"
 #include "server/search/SmbSearchCore.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -26,6 +27,7 @@ namespace Server::SearchSupport {
 struct SmbSearchRootFixture;
 
 constexpr uint8_t kDefaultFallingTranspositionPlayerYScreenThreshold = 192u;
+constexpr size_t kFallingTranspositionRamByteCount = 63u;
 
 enum class SmbDfsSearchCompletionReason : uint8_t {
     Completed = 0,
@@ -132,6 +134,7 @@ private:
         uint8_t playerYScreen = 0;
         uint8_t powerupState = 0;
         uint8_t world = 0;
+        std::array<uint8_t, kFallingTranspositionRamByteCount> ramBytes{};
         bool enemyPresent = false;
         bool secondEnemyPresent = false;
 
@@ -153,6 +156,7 @@ private:
     void completeWithTraceEvent(SmbDfsSearchTraceEventType eventType);
     std::optional<FallingTranspositionKey> buildFallingTranspositionKey(
         const NesSuperMarioBrosState& state,
+        const SmolnesRuntime::MemorySnapshot& memorySnapshot,
         const SmbSearchEvaluatorSummary& evaluatorSummary) const;
     bool isFallingTranspositionPruned(
         const FallingTranspositionKey& key,

--- a/apps/src/server/search/SmbDfsSearch.h
+++ b/apps/src/server/search/SmbDfsSearch.h
@@ -13,11 +13,13 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace DirtSim {
 
 class NesSmolnesScenarioDriver;
+struct NesSuperMarioBrosState;
 
 namespace Server::SearchSupport {
 
@@ -34,6 +36,7 @@ struct SmbDfsSearchOptions {
     uint32_t stallFrameLimit = 120;
     bool velocityPruningEnabled = true;
     bool belowScreenPruningEnabled = true;
+    bool fallingTranspositionPruningEnabled = true;
     bool groundedVerticalJumpPrioritizationEnabled = true;
     std::optional<uint64_t> stopAfterBestFrontier = std::nullopt;
 };
@@ -58,6 +61,7 @@ enum class SmbDfsSearchTraceEventType : uint8_t {
     RootInitialized = 9,
     Stopped = 10,
     PrunedBelowScreen = 11,
+    PrunedTransposition = 12,
 };
 
 struct SmbDfsSearchTraceEntry {
@@ -104,6 +108,36 @@ private:
         SmbSearchActionOrdering actionOrdering = {};
     };
 
+    struct FallingTranspositionEntry {
+        uint64_t bestFrontier = 0;
+        uint64_t framesSinceProgress = 0;
+        uint64_t gameplayFrame = 0;
+    };
+
+    struct FallingTranspositionKey {
+        int16_t nearestEnemyDx = 0;
+        int16_t nearestEnemyDy = 0;
+        int16_t secondNearestEnemyDx = 0;
+        int16_t secondNearestEnemyDy = 0;
+        int16_t verticalSpeed = 0;
+        int8_t facingX = 0;
+        int8_t horizontalSpeed = 0;
+        int8_t movementX = 0;
+        uint16_t absoluteX = 0;
+        uint8_t level = 0;
+        uint8_t playerYScreen = 0;
+        uint8_t powerupState = 0;
+        uint8_t world = 0;
+        bool enemyPresent = false;
+        bool secondEnemyPresent = false;
+
+        bool operator==(const FallingTranspositionKey& other) const;
+    };
+
+    struct FallingTranspositionKeyHash {
+        size_t operator()(const FallingTranspositionKey& key) const;
+    };
+
     Result<std::monostate, std::string> initializeRuntime();
     Result<std::monostate, std::string> initializeRootNode(
         const SmolnesRuntime::Savestate& savestate,
@@ -113,6 +147,13 @@ private:
 
     void completeWithError(const std::string& errorMessage);
     void completeWithTraceEvent(SmbDfsSearchTraceEventType eventType);
+    std::optional<FallingTranspositionKey> buildFallingTranspositionKey(
+        const NesSuperMarioBrosState& state,
+        const SmbSearchEvaluatorSummary& evaluatorSummary) const;
+    bool isFallingTranspositionPruned(
+        const FallingTranspositionKey& key,
+        const SmbSearchEvaluatorSummary& evaluatorSummary) const;
+    void publishFallingTranspositionEntry(size_t nodeIndex);
     void rebuildBestPlan();
     void recordTrace(const SmbDfsSearchTraceEntry& entry);
     void releaseNodeHeavyData(size_t nodeIndex);
@@ -129,6 +170,12 @@ private:
     std::vector<PlayerControlFrame> rootPrefixFrames_;
     std::vector<SmbSearchNode> nodes_;
     std::vector<DfsFrame> dfsStack_;
+    std::vector<std::optional<FallingTranspositionKey>> fallingTranspositionKeys_;
+    std::unordered_map<
+        FallingTranspositionKey,
+        FallingTranspositionEntry,
+        FallingTranspositionKeyHash>
+        fallingTranspositionTable_;
     std::vector<SmbDfsSearchTraceEntry> trace_;
     std::optional<size_t> bestLeafIndex_ = std::nullopt;
     uint64_t bestFrontier_ = 0;

--- a/apps/src/server/search/SmbDfsSearch.h
+++ b/apps/src/server/search/SmbDfsSearch.h
@@ -26,8 +26,19 @@ namespace Server::SearchSupport {
 
 struct SmbSearchRootFixture;
 
-constexpr uint8_t kDefaultFallingTranspositionPlayerYScreenThreshold = 192u;
-constexpr size_t kFallingTranspositionRamByteCount = 63u;
+constexpr uint8_t kDefaultFallingTranspositionPlayerYScreenThreshold = 0u;
+constexpr size_t kClosedLossTranspositionRamByteCount = 63u;
+
+// Hidden movement, input, collision, scroll, and timer bytes used to keep TT probes exact.
+constexpr std::array<size_t, kClosedLossTranspositionRamByteCount>
+    kClosedLossTranspositionRamByteAddrs{
+        0x0000, 0x0003, 0x000A, 0x000B, 0x000E, 0x001D, 0x0057, 0x009F, 0x00B5, 0x00CE, 0x03AD,
+        0x03B8, 0x0400, 0x0416, 0x0433, 0x0490, 0x04AC, 0x04AD, 0x04AE, 0x04AF, 0x06D5, 0x06FC,
+        0x0700, 0x0701, 0x0702, 0x0704, 0x0705, 0x0709, 0x070A, 0x070C, 0x070D, 0x0712, 0x0714,
+        0x071A, 0x071B, 0x071C, 0x071D, 0x071E, 0x071F, 0x0722, 0x0723, 0x072C, 0x072F, 0x0739,
+        0x0747, 0x074A, 0x0752, 0x0753, 0x0755, 0x0775, 0x077F, 0x0781, 0x0782, 0x0783, 0x0784,
+        0x0785, 0x0786, 0x0789, 0x078A, 0x0791, 0x0795, 0x079E, 0x079F,
+    };
 
 enum class SmbDfsSearchCompletionReason : uint8_t {
     Completed = 0,
@@ -68,6 +79,14 @@ enum class SmbDfsSearchTraceEventType : uint8_t {
     Stopped = 10,
     PrunedBelowScreen = 11,
     PrunedTransposition = 12,
+    PrunedNonGameplay = 13,
+};
+
+enum class SmbDfsClosedLossBlockReason : uint8_t {
+    None = 0,
+    FreshProgress = 1,
+    NonGameplay = 2,
+    ChildNotClosedLoss = 3,
 };
 
 struct SmbDfsSearchTraceEntry {
@@ -80,6 +99,13 @@ struct SmbDfsSearchTraceEntry {
     double evaluationScore = 0.0;
     uint64_t framesSinceProgress = 0;
     bool groundedVerticalJumpPriorityAction = false;
+    bool closedLossCandidate = false;
+    bool closedLossProven = false;
+    bool closedLossApproximateTranspositionPruned = false;
+    uint8_t closedLossApproximateTranspositionRamDiffCount = 0u;
+    std::array<bool, kClosedLossTranspositionRamByteCount>
+        closedLossApproximateTranspositionRamDiffs{};
+    SmbDfsClosedLossBlockReason closedLossBlockReason = SmbDfsClosedLossBlockReason::None;
 };
 
 class SmbDfsSearch {
@@ -112,15 +138,22 @@ private:
         size_t nodeIndex = 0;
         uint8_t nextActionIndex = 0;
         SmbSearchActionOrdering actionOrdering = {};
+        bool closedLossCandidate = true;
+        SmbDfsClosedLossBlockReason closedLossBlockReason = SmbDfsClosedLossBlockReason::None;
     };
 
-    struct FallingTranspositionEntry {
+    struct ClosedLossTranspositionEntry {
         uint64_t bestFrontier = 0;
         uint64_t framesSinceProgress = 0;
         uint64_t gameplayFrame = 0;
     };
 
-    struct FallingTranspositionKey {
+    struct ClosedLossTranspositionShapeEntry {
+        ClosedLossTranspositionEntry proof = {};
+        std::array<uint8_t, kClosedLossTranspositionRamByteCount> ramBytes{};
+    };
+
+    struct ClosedLossTranspositionKey {
         int16_t nearestEnemyDx = 0;
         int16_t nearestEnemyDy = 0;
         int16_t secondNearestEnemyDx = 0;
@@ -134,15 +167,51 @@ private:
         uint8_t playerYScreen = 0;
         uint8_t powerupState = 0;
         uint8_t world = 0;
-        std::array<uint8_t, kFallingTranspositionRamByteCount> ramBytes{};
+        std::array<uint8_t, kClosedLossTranspositionRamByteCount> ramBytes{};
         bool enemyPresent = false;
         bool secondEnemyPresent = false;
 
-        bool operator==(const FallingTranspositionKey& other) const;
+        bool operator==(const ClosedLossTranspositionKey& other) const;
     };
 
-    struct FallingTranspositionKeyHash {
-        size_t operator()(const FallingTranspositionKey& key) const;
+    struct ClosedLossTranspositionKeyHash {
+        size_t operator()(const ClosedLossTranspositionKey& key) const;
+    };
+
+    struct ClosedLossTranspositionShapeKey {
+        int16_t nearestEnemyDx = 0;
+        int16_t nearestEnemyDy = 0;
+        int16_t secondNearestEnemyDx = 0;
+        int16_t secondNearestEnemyDy = 0;
+        int16_t verticalSpeed = 0;
+        int8_t facingX = 0;
+        int8_t horizontalSpeed = 0;
+        int8_t movementX = 0;
+        uint16_t absoluteX = 0;
+        uint8_t level = 0;
+        uint8_t playerYScreen = 0;
+        uint8_t powerupState = 0;
+        uint8_t world = 0;
+        bool enemyPresent = false;
+        bool secondEnemyPresent = false;
+
+        bool operator==(const ClosedLossTranspositionShapeKey& other) const;
+    };
+
+    struct ClosedLossTranspositionShapeKeyHash {
+        size_t operator()(const ClosedLossTranspositionShapeKey& key) const;
+    };
+
+    struct ClosedLossTranspositionShapeProbeResult {
+        bool pruned = false;
+        uint8_t ramDiffCount = 0u;
+        std::array<bool, kClosedLossTranspositionRamByteCount> ramDiffs{};
+    };
+
+    enum class SmbSearchNodeOutcome : uint8_t {
+        Open = 0,
+        ClosedLoss = 1,
+        NotClosedLoss = 2,
     };
 
     Result<std::monostate, std::string> initializeRuntime();
@@ -154,14 +223,25 @@ private:
 
     void completeWithError(const std::string& errorMessage);
     void completeWithTraceEvent(SmbDfsSearchTraceEventType eventType);
-    std::optional<FallingTranspositionKey> buildFallingTranspositionKey(
+    bool isClosedLossCandidate(size_t nodeIndex) const;
+    std::optional<ClosedLossTranspositionKey> buildClosedLossTranspositionKey(
         const NesSuperMarioBrosState& state,
-        const SmolnesRuntime::MemorySnapshot& memorySnapshot,
+        const SmolnesRuntime::MemorySnapshot& memorySnapshot) const;
+    ClosedLossTranspositionShapeKey buildClosedLossTranspositionShapeKey(
+        const ClosedLossTranspositionKey& key) const;
+    void noteChildOutcome(
+        DfsFrame& dfsFrame,
+        SmbSearchNodeOutcome childOutcome,
+        SmbDfsClosedLossBlockReason childBlockReason);
+    SmbDfsClosedLossBlockReason getInitialClosedLossBlockReason(size_t nodeIndex) const;
+    bool isClosedLossTranspositionPruned(
+        const ClosedLossTranspositionKey& key,
         const SmbSearchEvaluatorSummary& evaluatorSummary) const;
-    bool isFallingTranspositionPruned(
-        const FallingTranspositionKey& key,
+    ClosedLossTranspositionShapeProbeResult probeClosedLossTranspositionShape(
+        const ClosedLossTranspositionShapeKey& key,
+        const ClosedLossTranspositionKey& exactKey,
         const SmbSearchEvaluatorSummary& evaluatorSummary) const;
-    void publishFallingTranspositionEntry(size_t nodeIndex);
+    void publishClosedLossTranspositionEntry(size_t nodeIndex);
     void rebuildBestPlan();
     void recordTrace(const SmbDfsSearchTraceEntry& entry);
     void releaseNodeHeavyData(size_t nodeIndex);
@@ -178,12 +258,19 @@ private:
     std::vector<PlayerControlFrame> rootPrefixFrames_;
     std::vector<SmbSearchNode> nodes_;
     std::vector<DfsFrame> dfsStack_;
-    std::vector<std::optional<FallingTranspositionKey>> fallingTranspositionKeys_;
+    std::vector<SmbSearchNodeOutcome> nodeOutcomes_;
+    std::vector<SmbDfsClosedLossBlockReason> closedLossBlockReasons_;
+    std::vector<std::optional<ClosedLossTranspositionKey>> closedLossTranspositionKeys_;
     std::unordered_map<
-        FallingTranspositionKey,
-        FallingTranspositionEntry,
-        FallingTranspositionKeyHash>
-        fallingTranspositionTable_;
+        ClosedLossTranspositionKey,
+        ClosedLossTranspositionEntry,
+        ClosedLossTranspositionKeyHash>
+        closedLossTranspositionTable_;
+    std::unordered_map<
+        ClosedLossTranspositionShapeKey,
+        ClosedLossTranspositionShapeEntry,
+        ClosedLossTranspositionShapeKeyHash>
+        closedLossTranspositionShapeTable_;
     std::vector<SmbDfsSearchTraceEntry> trace_;
     std::optional<size_t> bestLeafIndex_ = std::nullopt;
     uint64_t bestFrontier_ = 0;

--- a/apps/src/server/search/SmbSearchCore.cpp
+++ b/apps/src/server/search/SmbSearchCore.cpp
@@ -193,6 +193,7 @@ SmbSearchEvaluatorSummary buildSmbSearchEvaluatorSummary(
 
     summary.bestFrontier = encodeSmbFrontier(*snapshot);
     summary.distanceRewardTotal = snapshot->distanceRewardTotal;
+    summary.endReason = snapshot->endReason;
     summary.evaluationScore = snapshot->totalReward;
     summary.gameplayFrames = snapshot->gameplayFrames;
     summary.gameplayFramesSinceProgress = snapshot->framesSinceProgress;

--- a/apps/src/server/search/SmbSearchCore.cpp
+++ b/apps/src/server/search/SmbSearchCore.cpp
@@ -47,11 +47,28 @@ bool isJumpButtonAction(SmbSearchLegalAction action)
     return false;
 }
 
+std::optional<SmbSearchLegalAction> makeDescendingRunJumpRescueAction(
+    SmbSearchHorizontalDirection horizontalDirection)
+{
+    switch (horizontalDirection) {
+        case SmbSearchHorizontalDirection::Left:
+            return SmbSearchLegalAction::LeftJumpRun;
+        case SmbSearchHorizontalDirection::Right:
+            return SmbSearchLegalAction::RightJumpRun;
+        case SmbSearchHorizontalDirection::None:
+            return std::nullopt;
+    }
+
+    DIRTSIM_ASSERT(false, "Unhandled SmbSearchHorizontalDirection");
+    return std::nullopt;
+}
+
 } // namespace
 
 SmbSearchActionOrdering buildDfsActionOrder(
     bool airborne,
     double verticalSpeedNormalized,
+    SmbSearchHorizontalDirection horizontalDirection,
     std::optional<SmbSearchLegalAction> actionFromParent,
     bool groundedVerticalJumpPrioritizationEnabled)
 {
@@ -72,14 +89,18 @@ SmbSearchActionOrdering buildDfsActionOrder(
         return false;
     };
 
+    auto placeAny = [&](SmbSearchLegalAction action) {
+        if (!isPlaced(action)) {
+            order[writePos++] = action;
+        }
+    };
+
     auto place = [&](SmbSearchLegalAction action) {
         if (descendingAirborne && isJumpButtonAction(action)) {
             return;
         }
 
-        if (!isPlaced(action)) {
-            order[writePos++] = action;
-        }
+        placeAny(action);
     };
 
     if (groundedMovingVertically) {
@@ -97,9 +118,16 @@ SmbSearchActionOrdering buildDfsActionOrder(
         place(actionFromParent.value());
     }
 
-    // While descending, A-button variants cannot recover height, so drop them entirely.
     for (const auto& action : defaultOrder) {
         place(action);
+    }
+
+    if (descendingAirborne) {
+        const std::optional<SmbSearchLegalAction> rescueAction =
+            makeDescendingRunJumpRescueAction(horizontalDirection);
+        if (rescueAction.has_value()) {
+            placeAny(rescueAction.value());
+        }
     }
 
     ordering.count = static_cast<uint8_t>(writePos);

--- a/apps/src/server/search/SmbSearchCore.h
+++ b/apps/src/server/search/SmbSearchCore.h
@@ -33,6 +33,12 @@ enum class SmbSearchLegalAction : uint8_t {
     DuckLeftJumpRun = 10,
 };
 
+enum class SmbSearchHorizontalDirection : uint8_t {
+    None = 0,
+    Left = 1,
+    Right = 2,
+};
+
 constexpr size_t kSmbSearchLegalActionCount = 11;
 using SmbSearchActionOrder = std::array<SmbSearchLegalAction, kSmbSearchLegalActionCount>;
 
@@ -70,6 +76,7 @@ struct SmbSearchNode {
 SmbSearchActionOrdering buildDfsActionOrder(
     bool airborne,
     double verticalSpeedNormalized,
+    SmbSearchHorizontalDirection horizontalDirection,
     std::optional<SmbSearchLegalAction> actionFromParent,
     bool groundedVerticalJumpPrioritizationEnabled);
 bool isSmbGameplayFrame(

--- a/apps/src/server/search/SmbSearchCore.h
+++ b/apps/src/server/search/SmbSearchCore.h
@@ -54,6 +54,7 @@ struct SmbSearchEvaluatorSummary {
     uint64_t gameplayFrames = 0;
     uint64_t gameplayFramesSinceProgress = 0;
     double distanceRewardTotal = 0.0;
+    SmbEpisodeEndReason endReason = SmbEpisodeEndReason::None;
     double evaluationScore = 0.0;
     double levelClearRewardTotal = 0.0;
     std::optional<uint8_t> gameState = std::nullopt;

--- a/apps/src/server/states/Idle.cpp
+++ b/apps/src/server/states/Idle.cpp
@@ -711,6 +711,8 @@ State::Any Idle::onEvent(const Api::PlanPlaybackStart::Cwc& cwc, StateMachine& d
 
     PlanPlayback nextState;
     nextState.planId = cwc.command.planId;
+    nextState.planPlaybackFrameDelayMs =
+        dsm.getUserSettings().searchSettings.planPlaybackFrameDelayMs;
     const auto startResult = nextState.execution.startPlayback(found.value());
     if (startResult.isError()) {
         cwc.sendResponse(

--- a/apps/src/server/states/PlanPlayback.cpp
+++ b/apps/src/server/states/PlanPlayback.cpp
@@ -4,6 +4,7 @@
 #include "core/network/BinaryProtocol.h"
 #include "server/StateMachine.h"
 #include "server/api/PlanPlaybackStopped.h"
+#include <thread>
 
 namespace DirtSim {
 namespace Server {
@@ -24,6 +25,18 @@ void broadcastPlanPlaybackStopped(
     dsm.broadcastEventData(Api::PlanPlaybackStopped::name(), Network::serialize_payload(stopped));
 }
 
+bool shouldWaitForPlaybackDelay(
+    uint32_t delayMs,
+    std::chrono::steady_clock::time_point lastTickTime,
+    std::chrono::steady_clock::time_point now)
+{
+    if (delayMs == 0u || lastTickTime == std::chrono::steady_clock::time_point{}) {
+        return false;
+    }
+
+    return now - lastTickTime < std::chrono::milliseconds(delayMs);
+}
+
 } // namespace
 
 void PlanPlayback::onEnter(StateMachine& dsm)
@@ -35,6 +48,7 @@ void PlanPlayback::onEnter(StateMachine& dsm)
         broadcastExecutionRender(dsm, execution);
         renderBroadcasted_ = true;
     }
+    lastPlaybackTickTime_ = {};
 }
 
 void PlanPlayback::onExit(StateMachine& /*dsm*/)
@@ -44,7 +58,15 @@ void PlanPlayback::onExit(StateMachine& /*dsm*/)
 
 std::optional<Any> PlanPlayback::tick(StateMachine& dsm)
 {
+    const auto now = std::chrono::steady_clock::now();
+    if (!execution.isCompleted()
+        && shouldWaitForPlaybackDelay(planPlaybackFrameDelayMs, lastPlaybackTickTime_, now)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        return std::nullopt;
+    }
+
     const auto tickResult = execution.tick();
+    lastPlaybackTickTime_ = now;
     if (execution.hasRenderableFrame() && (!renderBroadcasted_ || tickResult.frameAdvanced)) {
         dsm.updateCachedWorldData(execution.getWorldData());
         broadcastExecutionRender(dsm, execution);

--- a/apps/src/server/states/PlanPlayback.h
+++ b/apps/src/server/states/PlanPlayback.h
@@ -4,6 +4,8 @@
 #include "core/UUID.h"
 #include "server/Event.h"
 #include "server/search/SmbPlanExecution.h"
+#include <chrono>
+#include <cstdint>
 #include <optional>
 
 namespace DirtSim {
@@ -24,6 +26,8 @@ struct PlanPlayback {
 
     UUID planId{};
     SearchSupport::SmbPlanExecution execution;
+    uint32_t planPlaybackFrameDelayMs = 0;
+    std::chrono::steady_clock::time_point lastPlaybackTickTime_{};
     bool renderBroadcasted_ = false;
 };
 

--- a/apps/src/server/tests/SmbDfsSearch_test.cpp
+++ b/apps/src/server/tests/SmbDfsSearch_test.cpp
@@ -2487,8 +2487,8 @@ TEST(SmbDfsSearchTest, LegalActionOrderRightRunFirst)
 
 TEST(SmbDfsSearchTest, GroundedVerticalJumpPrioritizationMovesJumpActionsFirst)
 {
-    const SmbSearchActionOrdering enabledOrder =
-        buildDfsActionOrder(false, 0.03125, SmbSearchLegalAction::RightRun, true);
+    const SmbSearchActionOrdering enabledOrder = buildDfsActionOrder(
+        false, 0.03125, SmbSearchHorizontalDirection::Right, SmbSearchLegalAction::RightRun, true);
 
     EXPECT_TRUE(enabledOrder.groundedVerticalJumpPriorityApplied);
     EXPECT_EQ(enabledOrder.groundedVerticalJumpPriorityActionCount, 6u);
@@ -2501,15 +2501,19 @@ TEST(SmbDfsSearchTest, GroundedVerticalJumpPrioritizationMovesJumpActionsFirst)
     EXPECT_EQ(enabledOrder.actions[5], SmbSearchLegalAction::DuckLeftJumpRun);
     EXPECT_EQ(enabledOrder.actions[6], SmbSearchLegalAction::RightRun);
 
-    const SmbSearchActionOrdering disabledOrder =
-        buildDfsActionOrder(false, 0.03125, SmbSearchLegalAction::RightRun, false);
+    const SmbSearchActionOrdering disabledOrder = buildDfsActionOrder(
+        false, 0.03125, SmbSearchHorizontalDirection::Right, SmbSearchLegalAction::RightRun, false);
     EXPECT_FALSE(disabledOrder.groundedVerticalJumpPriorityApplied);
     EXPECT_EQ(disabledOrder.groundedVerticalJumpPriorityActionCount, 0u);
     ASSERT_GT(disabledOrder.count, 0u);
     EXPECT_EQ(disabledOrder.actions[0], SmbSearchLegalAction::RightRun);
 
-    const SmbSearchActionOrdering descendingAirborneOrder =
-        buildDfsActionOrder(true, 0.03125, SmbSearchLegalAction::RightJumpRun, true);
+    const SmbSearchActionOrdering descendingAirborneOrder = buildDfsActionOrder(
+        true,
+        0.03125,
+        SmbSearchHorizontalDirection::None,
+        SmbSearchLegalAction::RightJumpRun,
+        true);
     EXPECT_FALSE(descendingAirborneOrder.groundedVerticalJumpPriorityApplied);
     EXPECT_EQ(descendingAirborneOrder.groundedVerticalJumpPriorityActionCount, 0u);
     ASSERT_EQ(descendingAirborneOrder.count, 5u);
@@ -2518,4 +2522,31 @@ TEST(SmbDfsSearchTest, GroundedVerticalJumpPrioritizationMovesJumpActionsFirst)
     EXPECT_EQ(descendingAirborneOrder.actions[2], SmbSearchLegalAction::Neutral);
     EXPECT_EQ(descendingAirborneOrder.actions[3], SmbSearchLegalAction::LeftRun);
     EXPECT_EQ(descendingAirborneOrder.actions[4], SmbSearchLegalAction::Duck);
+}
+
+TEST(SmbDfsSearchTest, DescendingAirborneOrderAddsOneLateDirectionalJumpRescue)
+{
+    const SmbSearchActionOrdering rightOrder = buildDfsActionOrder(
+        true,
+        0.03125,
+        SmbSearchHorizontalDirection::Right,
+        SmbSearchLegalAction::RightJumpRun,
+        true);
+    ASSERT_EQ(rightOrder.count, 6u);
+    EXPECT_EQ(rightOrder.actions[0], SmbSearchLegalAction::RightRun);
+    EXPECT_EQ(rightOrder.actions[1], SmbSearchLegalAction::Right);
+    EXPECT_EQ(rightOrder.actions[2], SmbSearchLegalAction::Neutral);
+    EXPECT_EQ(rightOrder.actions[3], SmbSearchLegalAction::LeftRun);
+    EXPECT_EQ(rightOrder.actions[4], SmbSearchLegalAction::Duck);
+    EXPECT_EQ(rightOrder.actions[5], SmbSearchLegalAction::RightJumpRun);
+
+    const SmbSearchActionOrdering leftOrder = buildDfsActionOrder(
+        true, 0.03125, SmbSearchHorizontalDirection::Left, SmbSearchLegalAction::LeftRun, true);
+    ASSERT_EQ(leftOrder.count, 6u);
+    EXPECT_EQ(leftOrder.actions[0], SmbSearchLegalAction::LeftRun);
+    EXPECT_EQ(leftOrder.actions[1], SmbSearchLegalAction::RightRun);
+    EXPECT_EQ(leftOrder.actions[2], SmbSearchLegalAction::Right);
+    EXPECT_EQ(leftOrder.actions[3], SmbSearchLegalAction::Neutral);
+    EXPECT_EQ(leftOrder.actions[4], SmbSearchLegalAction::Duck);
+    EXPECT_EQ(leftOrder.actions[5], SmbSearchLegalAction::LeftJumpRun);
 }

--- a/apps/src/server/tests/SmbDfsSearch_test.cpp
+++ b/apps/src/server/tests/SmbDfsSearch_test.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <functional>
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -25,6 +26,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 using namespace DirtSim::Server::SearchSupport;
 using DirtSim::NesSuperMarioBrosRamExtractor;
@@ -138,6 +140,7 @@ bool isCreationEvent(SmbDfsSearchTraceEventType eventType)
         case SmbDfsSearchTraceEventType::PrunedVelocityStuck:
         case SmbDfsSearchTraceEventType::PrunedBelowScreen:
         case SmbDfsSearchTraceEventType::PrunedTransposition:
+        case SmbDfsSearchTraceEventType::PrunedNonGameplay:
         case SmbDfsSearchTraceEventType::RootInitialized:
             return true;
         case SmbDfsSearchTraceEventType::Backtracked:
@@ -177,10 +180,28 @@ std::string toString(SmbDfsSearchTraceEventType eventType)
             return "PrunedBelowScreen";
         case SmbDfsSearchTraceEventType::PrunedTransposition:
             return "PrunedTransposition";
+        case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+            return "PrunedNonGameplay";
         case SmbDfsSearchTraceEventType::RootInitialized:
             return "RootInitialized";
         case SmbDfsSearchTraceEventType::Stopped:
             return "Stopped";
+    }
+
+    return "Unknown";
+}
+
+std::string toString(SmbDfsClosedLossBlockReason blockReason)
+{
+    switch (blockReason) {
+        case SmbDfsClosedLossBlockReason::None:
+            return "None";
+        case SmbDfsClosedLossBlockReason::FreshProgress:
+            return "FreshProgress";
+        case SmbDfsClosedLossBlockReason::NonGameplay:
+            return "NonGameplay";
+        case SmbDfsClosedLossBlockReason::ChildNotClosedLoss:
+            return "ChildNotClosedLoss";
     }
 
     return "Unknown";
@@ -454,11 +475,22 @@ struct WindowStats {
     size_t prunedVelocityStuckCount = 0;
     size_t prunedBelowScreenCount = 0;
     size_t prunedTranspositionCount = 0;
+    size_t prunedNonGameplayCount = 0;
 };
 
 struct TraceEventStats {
     size_t backtrackedCount = 0u;
+    size_t backtrackedClosedLossCount = 0u;
+    size_t backtrackedClosedLossFreshProgressCount = 0u;
+    size_t backtrackedNotClosedLossCount = 0u;
+    size_t backtrackedBlockedChildNotClosedLossCount = 0u;
+    size_t backtrackedBlockedFreshProgressCount = 0u;
+    size_t backtrackedBlockedNonGameplayCount = 0u;
     size_t expandedAliveCount = 0u;
+    size_t openClosedLossCandidateCount = 0u;
+    size_t openClosedLossCandidateFreshProgressCount = 0u;
+    size_t openExpandedAliveCount = 0u;
+    size_t openFreshProgressCount = 0u;
     size_t prunedDeadCount = 0u;
     size_t prunedStalledCount = 0u;
     size_t prunedVelocityStuckCount = 0u;
@@ -468,6 +500,15 @@ struct TraceEventStats {
     size_t prunedBelowScreenFreshProgressCount = 0u;
     size_t prunedTranspositionCount = 0u;
     size_t prunedTranspositionAtBestFrontierCount = 0u;
+    size_t prunedTranspositionFreshProgressCount = 0u;
+    size_t prunedNonGameplayCount = 0u;
+    size_t approximateTranspositionAtBestFrontierCount = 0u;
+    size_t approximateTranspositionCount = 0u;
+    size_t approximateTranspositionFreshProgressCount = 0u;
+    size_t approximateTranspositionWithoutExactCount = 0u;
+    std::array<size_t, kClosedLossTranspositionRamByteCount>
+        approximateTranspositionWithoutExactRamDiffCounts{};
+    size_t approximateTranspositionWithoutExactRamDiffTotal = 0u;
     uint64_t maxFramesSinceProgress = 0u;
     uint64_t maxGameplayFrame = 0u;
     uint64_t prunedBelowScreenMaxFramesSinceProgress = 0u;
@@ -506,6 +547,9 @@ WindowStats computeWindowStats(
             case SmbDfsSearchTraceEventType::PrunedTransposition:
                 stats.prunedTranspositionCount++;
                 break;
+            case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+                stats.prunedNonGameplayCount++;
+                break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
             case SmbDfsSearchTraceEventType::CompletedMilestoneReached:
@@ -523,19 +567,65 @@ TraceEventStats computeTraceEventStats(
     const std::vector<SmbDfsSearchTraceEntry>& trace, uint64_t bestFrontier)
 {
     TraceEventStats stats;
+    std::unordered_map<size_t, SmbDfsSearchTraceEntry> expandedAliveEntries;
+    std::unordered_set<size_t> backtrackedNodes;
     for (const auto& entry : trace) {
         if (isCreationEvent(entry.eventType)) {
             stats.maxFramesSinceProgress =
                 std::max(stats.maxFramesSinceProgress, entry.framesSinceProgress);
             stats.maxGameplayFrame = std::max(stats.maxGameplayFrame, entry.gameplayFrame);
+            if (entry.closedLossApproximateTranspositionPruned) {
+                stats.approximateTranspositionCount++;
+                if (entry.eventType != SmbDfsSearchTraceEventType::PrunedTransposition) {
+                    stats.approximateTranspositionWithoutExactCount++;
+                    stats.approximateTranspositionWithoutExactRamDiffTotal +=
+                        entry.closedLossApproximateTranspositionRamDiffCount;
+                    for (size_t i = 0u; i < entry.closedLossApproximateTranspositionRamDiffs.size();
+                         ++i) {
+                        if (entry.closedLossApproximateTranspositionRamDiffs[i]) {
+                            stats.approximateTranspositionWithoutExactRamDiffCounts[i]++;
+                        }
+                    }
+                }
+                if (entry.framesSinceProgress == 0u) {
+                    stats.approximateTranspositionFreshProgressCount++;
+                }
+                if (entry.frontier == bestFrontier) {
+                    stats.approximateTranspositionAtBestFrontierCount++;
+                }
+            }
         }
 
         switch (entry.eventType) {
             case SmbDfsSearchTraceEventType::Backtracked:
                 stats.backtrackedCount++;
+                backtrackedNodes.insert(entry.nodeIndex);
+                if (entry.closedLossProven) {
+                    stats.backtrackedClosedLossCount++;
+                    if (entry.framesSinceProgress == 0u) {
+                        stats.backtrackedClosedLossFreshProgressCount++;
+                    }
+                    break;
+                }
+
+                stats.backtrackedNotClosedLossCount++;
+                switch (entry.closedLossBlockReason) {
+                    case SmbDfsClosedLossBlockReason::None:
+                        break;
+                    case SmbDfsClosedLossBlockReason::ChildNotClosedLoss:
+                        stats.backtrackedBlockedChildNotClosedLossCount++;
+                        break;
+                    case SmbDfsClosedLossBlockReason::FreshProgress:
+                        stats.backtrackedBlockedFreshProgressCount++;
+                        break;
+                    case SmbDfsClosedLossBlockReason::NonGameplay:
+                        stats.backtrackedBlockedNonGameplayCount++;
+                        break;
+                }
                 break;
             case SmbDfsSearchTraceEventType::ExpandedAlive:
                 stats.expandedAliveCount++;
+                expandedAliveEntries.emplace(entry.nodeIndex, entry);
                 break;
             case SmbDfsSearchTraceEventType::PrunedDead:
                 stats.prunedDeadCount++;
@@ -565,12 +655,18 @@ TraceEventStats computeTraceEventStats(
                 break;
             case SmbDfsSearchTraceEventType::PrunedTransposition:
                 stats.prunedTranspositionCount++;
+                if (entry.framesSinceProgress == 0u) {
+                    stats.prunedTranspositionFreshProgressCount++;
+                }
                 if (entry.frontier == bestFrontier) {
                     stats.prunedTranspositionAtBestFrontierCount++;
                 }
                 if (!stats.firstTranspositionPrune.has_value()) {
                     stats.firstTranspositionPrune = entry;
                 }
+                break;
+            case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+                stats.prunedNonGameplayCount++;
                 break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
@@ -582,7 +678,64 @@ TraceEventStats computeTraceEventStats(
         }
     }
 
+    for (const auto& [nodeIndex, entry] : expandedAliveEntries) {
+        if (backtrackedNodes.contains(nodeIndex)) {
+            continue;
+        }
+
+        stats.openExpandedAliveCount++;
+        if (entry.closedLossCandidate) {
+            stats.openClosedLossCandidateCount++;
+            if (entry.framesSinceProgress == 0u) {
+                stats.openClosedLossCandidateFreshProgressCount++;
+            }
+        }
+        else if (entry.closedLossBlockReason == SmbDfsClosedLossBlockReason::FreshProgress) {
+            stats.openFreshProgressCount++;
+        }
+    }
+
     return stats;
+}
+
+std::string formatRamDiffHistogram(
+    const std::array<size_t, kClosedLossTranspositionRamByteCount>& ramDiffCounts,
+    size_t maxPrintedEntries)
+{
+    std::vector<std::pair<size_t, size_t>> entries;
+    entries.reserve(ramDiffCounts.size());
+    for (size_t i = 0u; i < ramDiffCounts.size(); ++i) {
+        if (ramDiffCounts[i] == 0u) {
+            continue;
+        }
+
+        entries.emplace_back(i, ramDiffCounts[i]);
+    }
+
+    std::sort(entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.second != rhs.second) {
+            return lhs.second > rhs.second;
+        }
+        return kClosedLossTranspositionRamByteAddrs[lhs.first]
+            < kClosedLossTranspositionRamByteAddrs[rhs.first];
+    });
+
+    if (entries.size() > maxPrintedEntries) {
+        entries.resize(maxPrintedEntries);
+    }
+
+    std::ostringstream stream;
+    for (size_t i = 0u; i < entries.size(); ++i) {
+        if (i > 0u) {
+            stream << "|";
+        }
+
+        stream << "0x" << std::uppercase << std::hex << std::setw(4) << std::setfill('0')
+               << kClosedLossTranspositionRamByteAddrs[entries[i].first] << std::dec
+               << std::setfill(' ') << ":" << entries[i].second;
+    }
+
+    return stream.str();
 }
 
 Result<SmbSearchReplayResult, std::string> replayHoldRight(
@@ -685,6 +838,13 @@ bool writeTraceJsonl(
             { "action",
               entry.action.has_value() ? nlohmann::json(toString(entry.action.value()))
                                        : nlohmann::json(nullptr) },
+            { "closedLossBlockReason", toString(entry.closedLossBlockReason) },
+            { "closedLossApproximateTranspositionPruned",
+              entry.closedLossApproximateTranspositionPruned },
+            { "closedLossApproximateTranspositionRamDiffCount",
+              entry.closedLossApproximateTranspositionRamDiffCount },
+            { "closedLossCandidate", entry.closedLossCandidate },
+            { "closedLossProven", entry.closedLossProven },
             { "creationEvent", isCreationEvent(entry.eventType) },
             { "evaluationScore", entry.evaluationScore },
             { "eventType", toString(entry.eventType) },
@@ -877,6 +1037,13 @@ nlohmann::json makeTraceEntryJson(size_t traceIndex, const SmbDfsSearchTraceEntr
           entry.action.has_value() ? nlohmann::json(toString(entry.action.value()))
                                    : nlohmann::json(nullptr) },
         { "bestFrontier", entry.frontier },
+        { "closedLossBlockReason", toString(entry.closedLossBlockReason) },
+        { "closedLossApproximateTranspositionPruned",
+          entry.closedLossApproximateTranspositionPruned },
+        { "closedLossApproximateTranspositionRamDiffCount",
+          entry.closedLossApproximateTranspositionRamDiffCount },
+        { "closedLossCandidate", entry.closedLossCandidate },
+        { "closedLossProven", entry.closedLossProven },
         { "eventType", toString(entry.eventType) },
         { "framesSinceProgress", entry.framesSinceProgress },
         { "frontierAbsoluteX", decodeSmbAbsoluteX(entry.frontier) },
@@ -1028,6 +1195,7 @@ std::string buildDivergenceHistogramReport(
         size_t prunedVelocityStuckCount = 0u;
         size_t prunedBelowScreenCount = 0u;
         size_t prunedTranspositionCount = 0u;
+        size_t prunedNonGameplayCount = 0u;
         size_t survivingCount = 0u;
         uint64_t bestFrontier = 0u;
     };
@@ -1068,6 +1236,9 @@ std::string buildDivergenceHistogramReport(
             case SmbDfsSearchTraceEventType::PrunedTransposition:
                 bucket.prunedTranspositionCount++;
                 break;
+            case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+                bucket.prunedNonGameplayCount++;
+                break;
             case SmbDfsSearchTraceEventType::Backtracked:
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
@@ -1088,7 +1259,8 @@ std::string buildDivergenceHistogramReport(
                << " prunedStalled=" << bucket.prunedStalledCount
                << " prunedVelocityStuck=" << bucket.prunedVelocityStuckCount
                << " prunedBelowScreen=" << bucket.prunedBelowScreenCount
-               << " prunedTransposition=" << bucket.prunedTranspositionCount << "\n";
+               << " prunedTransposition=" << bucket.prunedTranspositionCount
+               << " prunedNonGameplay=" << bucket.prunedNonGameplayCount << "\n";
     }
 
     return stream.str();
@@ -1280,12 +1452,14 @@ Result<std::optional<ReplayStallInfo>, std::string> findFirstReplayStall(
 
 void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
 {
+    TraceEventStats stats = computeTraceEventStats(trace, 0u);
     size_t expandedCount = 0u;
     size_t prunedDeadCount = 0u;
     size_t prunedStalledCount = 0u;
     size_t prunedVelocityStuckCount = 0u;
     size_t prunedBelowScreenCount = 0u;
     size_t prunedTranspositionCount = 0u;
+    size_t prunedNonGameplayCount = 0u;
     size_t backtrackedCount = 0u;
     size_t groundedVerticalJumpPriorityActionCount = 0u;
     for (const auto& entry : trace) {
@@ -1315,6 +1489,9 @@ void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
             case SmbDfsSearchTraceEventType::PrunedTransposition:
                 prunedTranspositionCount++;
                 break;
+            case SmbDfsSearchTraceEventType::PrunedNonGameplay:
+                prunedNonGameplayCount++;
+                break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
             case SmbDfsSearchTraceEventType::CompletedMilestoneReached:
@@ -1330,8 +1507,24 @@ void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
               << " prunedVelocityStuck=" << prunedVelocityStuckCount
               << " prunedBelowScreen=" << prunedBelowScreenCount
               << " prunedTransposition=" << prunedTranspositionCount
+              << " prunedNonGameplay=" << prunedNonGameplayCount
               << " groundedVerticalJumpPriorityAction=" << groundedVerticalJumpPriorityActionCount
-              << " backtracked=" << backtrackedCount << "\n";
+              << " backtracked=" << backtrackedCount
+              << " backtrackedClosedLoss=" << stats.backtrackedClosedLossCount
+              << " backtrackedClosedLossFreshProgress="
+              << stats.backtrackedClosedLossFreshProgressCount
+              << " backtrackedNotClosedLoss=" << stats.backtrackedNotClosedLossCount
+              << " blockedFreshProgress=" << stats.backtrackedBlockedFreshProgressCount
+              << " blockedNonGameplay=" << stats.backtrackedBlockedNonGameplayCount
+              << " blockedChildNotClosedLoss=" << stats.backtrackedBlockedChildNotClosedLossCount
+              << " openExpanded=" << stats.openExpandedAliveCount
+              << " openClosedLossCandidates=" << stats.openClosedLossCandidateCount
+              << " openClosedLossCandidateFreshProgress="
+              << stats.openClosedLossCandidateFreshProgressCount
+              << " approximateTransposition=" << stats.approximateTranspositionCount
+              << " approximateTranspositionWithoutExact="
+              << stats.approximateTranspositionWithoutExactCount
+              << " openFreshProgress=" << stats.openFreshProgressCount << "\n";
 }
 
 Result<std::monostate, std::string> runSearchToCompletion(
@@ -1437,6 +1630,18 @@ void expectTraceEq(const SmbDfsSearchTraceEntry& actual, const SmbDfsSearchTrace
     EXPECT_EQ(actual.framesSinceProgress, expected.framesSinceProgress);
     EXPECT_EQ(
         actual.groundedVerticalJumpPriorityAction, expected.groundedVerticalJumpPriorityAction);
+    EXPECT_EQ(actual.closedLossCandidate, expected.closedLossCandidate);
+    EXPECT_EQ(actual.closedLossProven, expected.closedLossProven);
+    EXPECT_EQ(
+        actual.closedLossApproximateTranspositionPruned,
+        expected.closedLossApproximateTranspositionPruned);
+    EXPECT_EQ(
+        actual.closedLossApproximateTranspositionRamDiffCount,
+        expected.closedLossApproximateTranspositionRamDiffCount);
+    EXPECT_EQ(
+        actual.closedLossApproximateTranspositionRamDiffs,
+        expected.closedLossApproximateTranspositionRamDiffs);
+    EXPECT_EQ(actual.closedLossBlockReason, expected.closedLossBlockReason);
 }
 
 void expectPlanFramesEq(
@@ -1682,7 +1887,8 @@ TEST(SmbDfsSearchTest, PrunesAndBacktracksHazardBranches)
                 || entry.eventType == SmbDfsSearchTraceEventType::PrunedStalled
                 || entry.eventType == SmbDfsSearchTraceEventType::PrunedVelocityStuck
                 || entry.eventType == SmbDfsSearchTraceEventType::PrunedBelowScreen
-                || entry.eventType == SmbDfsSearchTraceEventType::PrunedTransposition;
+                || entry.eventType == SmbDfsSearchTraceEventType::PrunedTransposition
+                || entry.eventType == SmbDfsSearchTraceEventType::PrunedNonGameplay;
             sawBacktrack |= entry.eventType == SmbDfsSearchTraceEventType::Backtracked;
         }
 
@@ -1790,6 +1996,7 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
     size_t prunedStalledCount = 0;
     size_t prunedBelowScreenCount = 0;
     size_t prunedTranspositionCount = 0;
+    size_t prunedNonGameplayCount = 0;
     size_t backtrackedCount = 0;
     for (const auto& entry : search.getTrace()) {
         if (entry.eventType == SmbDfsSearchTraceEventType::ExpandedAlive) {
@@ -1810,6 +2017,9 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
         else if (entry.eventType == SmbDfsSearchTraceEventType::PrunedTransposition) {
             prunedTranspositionCount++;
         }
+        else if (entry.eventType == SmbDfsSearchTraceEventType::PrunedNonGameplay) {
+            prunedNonGameplayCount++;
+        }
         else if (entry.eventType == SmbDfsSearchTraceEventType::Backtracked) {
             backtrackedCount++;
         }
@@ -1818,6 +2028,7 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
               << " prunedStalled=" << prunedStalledCount
               << " prunedBelowScreen=" << prunedBelowScreenCount
               << " prunedTransposition=" << prunedTranspositionCount
+              << " prunedNonGameplay=" << prunedNonGameplayCount
               << " backtracked=" << backtrackedCount << "\n";
 
     ASSERT_TRUE(search.hasPersistablePlan());
@@ -2041,8 +2252,16 @@ TEST(SmbDfsSearchTest, DISABLED_ReportFirstPitTranspositionThresholdSweep)
 
     std::cout << "budget,threshold,searched,trace,bestFrontier,planFrames,expanded,prunedDead,"
                  "prunedBelowScreen,prunedTransposition,prunedVelocityStuck,backtracked,"
+                 "backtrackedClosedLoss,backtrackedClosedLossFreshProgress,"
+                 "backtrackedNotClosedLoss,blockedFreshProgress,blockedNonGameplay,"
+                 "blockedChildNotClosedLoss,openExpanded,openClosedLossCandidates,"
+                 "openClosedLossCandidateFreshProgress,openFreshProgress,"
                  "belowAtBestFrontier,belowAtBestFrontierFreshProgress,belowFreshProgress,"
                  "belowMaxFramesSinceProgress,transpositionAtBestFrontier,"
+                 "transpositionFreshProgress,approxTransposition,"
+                 "approxTranspositionWithoutExact,approxTranspositionFreshProgress,"
+                 "approxTranspositionAtBestFrontier,"
+                 "approxWithoutExactRamDiffTotal,approxWithoutExactRamDiffTop,"
                  "maxGameplayFrame,maxFramesSinceProgress,firstTranspositionFrame,"
                  "firstTranspositionFrontier,firstTranspositionFramesSinceProgress,"
                  "firstBelowScreenFrame,firstBelowScreenFrontier,elapsedMs\n";
@@ -2088,6 +2307,8 @@ TEST(SmbDfsSearchTest, DISABLED_ReportFirstPitTranspositionThresholdSweep)
             const uint64_t firstBelowScreenFrontier = stats.firstBelowScreenPrune.has_value()
                 ? stats.firstBelowScreenPrune->frontier
                 : 0u;
+            const std::string approximateRamDiffTop = formatRamDiffHistogram(
+                stats.approximateTranspositionWithoutExactRamDiffCounts, 12u);
 
             std::cout << budget << "," << static_cast<uint32_t>(threshold) << ","
                       << search.getProgress().searchedNodeCount << "," << search.getTrace().size()
@@ -2095,16 +2316,31 @@ TEST(SmbDfsSearchTest, DISABLED_ReportFirstPitTranspositionThresholdSweep)
                       << search.getPlan().frames.size() << "," << stats.expandedAliveCount << ","
                       << stats.prunedDeadCount << "," << stats.prunedBelowScreenCount << ","
                       << stats.prunedTranspositionCount << "," << stats.prunedVelocityStuckCount
-                      << "," << stats.backtrackedCount << ","
+                      << "," << stats.backtrackedCount << "," << stats.backtrackedClosedLossCount
+                      << "," << stats.backtrackedClosedLossFreshProgressCount << ","
+                      << stats.backtrackedNotClosedLossCount << ","
+                      << stats.backtrackedBlockedFreshProgressCount << ","
+                      << stats.backtrackedBlockedNonGameplayCount << ","
+                      << stats.backtrackedBlockedChildNotClosedLossCount << ","
+                      << stats.openExpandedAliveCount << "," << stats.openClosedLossCandidateCount
+                      << "," << stats.openClosedLossCandidateFreshProgressCount << ","
+                      << stats.openFreshProgressCount << ","
                       << stats.prunedBelowScreenAtBestFrontierCount << ","
                       << stats.prunedBelowScreenAtBestFrontierFreshProgressCount << ","
                       << stats.prunedBelowScreenFreshProgressCount << ","
                       << stats.prunedBelowScreenMaxFramesSinceProgress << ","
                       << stats.prunedTranspositionAtBestFrontierCount << ","
-                      << stats.maxGameplayFrame << "," << stats.maxFramesSinceProgress << ","
-                      << firstTranspositionFrame << "," << firstTranspositionFrontier << ","
-                      << firstTranspositionFramesSinceProgress << "," << firstBelowScreenFrame
-                      << "," << firstBelowScreenFrontier << "," << elapsedMs << "\n";
+                      << stats.prunedTranspositionFreshProgressCount << ","
+                      << stats.approximateTranspositionCount << ","
+                      << stats.approximateTranspositionWithoutExactCount << ","
+                      << stats.approximateTranspositionFreshProgressCount << ","
+                      << stats.approximateTranspositionAtBestFrontierCount << ","
+                      << stats.approximateTranspositionWithoutExactRamDiffTotal << ","
+                      << approximateRamDiffTop << "," << stats.maxGameplayFrame << ","
+                      << stats.maxFramesSinceProgress << "," << firstTranspositionFrame << ","
+                      << firstTranspositionFrontier << "," << firstTranspositionFramesSinceProgress
+                      << "," << firstBelowScreenFrame << "," << firstBelowScreenFrontier << ","
+                      << elapsedMs << "\n";
         }
     }
 }
@@ -2696,7 +2932,7 @@ TEST(SmbDfsSearchTest, BelowScreenPruningProducesDedicatedTraceEvent)
     }
 }
 
-TEST(SmbDfsSearchTest, FallingTranspositionPruningProducesDedicatedTraceEvent)
+TEST(SmbDfsSearchTest, ClosedLossTranspositionPruningProducesDedicatedTraceEvent)
 {
     REQUIRE_SMB_ROM_OR_SKIP();
 
@@ -2740,10 +2976,12 @@ TEST(SmbDfsSearchTest, FallingTranspositionPruningProducesDedicatedTraceEvent)
         DirtSim::Api::SearchProgressEvent::PrunedTransposition);
     EXPECT_GT(firstTranspositionPrune->nodeIndex, 0u);
     EXPECT_GT(firstTranspositionPrune->gameplayFrame, 0u);
-    EXPECT_GT(firstTranspositionPrune->framesSinceProgress, 0u);
-    std::cout << "First falling transposition prune at node " << firstTranspositionPrune->nodeIndex
-              << " frame " << firstTranspositionPrune->gameplayFrame << " frontier "
-              << firstTranspositionPrune->frontier << "\n";
+    EXPECT_TRUE(firstTranspositionPrune->closedLossApproximateTranspositionPruned);
+    std::cout << "First closed-loss transposition prune at node "
+              << firstTranspositionPrune->nodeIndex << " frame "
+              << firstTranspositionPrune->gameplayFrame << " frontier "
+              << firstTranspositionPrune->frontier << " framesSinceProgress "
+              << firstTranspositionPrune->framesSinceProgress << "\n";
 }
 
 TEST(SmbDfsSearchTest, LegalActionOrderRightRunFirst)

--- a/apps/src/server/tests/SmbDfsSearch_test.cpp
+++ b/apps/src/server/tests/SmbDfsSearch_test.cpp
@@ -111,6 +111,7 @@ bool isCreationEvent(SmbDfsSearchTraceEventType eventType)
         case SmbDfsSearchTraceEventType::PrunedStalled:
         case SmbDfsSearchTraceEventType::PrunedVelocityStuck:
         case SmbDfsSearchTraceEventType::PrunedBelowScreen:
+        case SmbDfsSearchTraceEventType::PrunedTransposition:
         case SmbDfsSearchTraceEventType::RootInitialized:
             return true;
         case SmbDfsSearchTraceEventType::Backtracked:
@@ -148,6 +149,8 @@ std::string toString(SmbDfsSearchTraceEventType eventType)
             return "PrunedVelocityStuck";
         case SmbDfsSearchTraceEventType::PrunedBelowScreen:
             return "PrunedBelowScreen";
+        case SmbDfsSearchTraceEventType::PrunedTransposition:
+            return "PrunedTransposition";
         case SmbDfsSearchTraceEventType::RootInitialized:
             return "RootInitialized";
         case SmbDfsSearchTraceEventType::Stopped:
@@ -424,6 +427,7 @@ struct WindowStats {
     size_t prunedStalledCount = 0;
     size_t prunedVelocityStuckCount = 0;
     size_t prunedBelowScreenCount = 0;
+    size_t prunedTranspositionCount = 0;
 };
 
 WindowStats computeWindowStats(
@@ -453,6 +457,9 @@ WindowStats computeWindowStats(
                 break;
             case SmbDfsSearchTraceEventType::PrunedBelowScreen:
                 stats.prunedBelowScreenCount++;
+                break;
+            case SmbDfsSearchTraceEventType::PrunedTransposition:
+                stats.prunedTranspositionCount++;
                 break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
@@ -909,6 +916,7 @@ std::string buildDivergenceHistogramReport(
         size_t prunedStalledCount = 0u;
         size_t prunedVelocityStuckCount = 0u;
         size_t prunedBelowScreenCount = 0u;
+        size_t prunedTranspositionCount = 0u;
         size_t survivingCount = 0u;
         uint64_t bestFrontier = 0u;
     };
@@ -946,6 +954,9 @@ std::string buildDivergenceHistogramReport(
             case SmbDfsSearchTraceEventType::PrunedBelowScreen:
                 bucket.prunedBelowScreenCount++;
                 break;
+            case SmbDfsSearchTraceEventType::PrunedTransposition:
+                bucket.prunedTranspositionCount++;
+                break;
             case SmbDfsSearchTraceEventType::Backtracked:
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
@@ -965,7 +976,8 @@ std::string buildDivergenceHistogramReport(
                << " prunedDead=" << bucket.prunedDeadCount
                << " prunedStalled=" << bucket.prunedStalledCount
                << " prunedVelocityStuck=" << bucket.prunedVelocityStuckCount
-               << " prunedBelowScreen=" << bucket.prunedBelowScreenCount << "\n";
+               << " prunedBelowScreen=" << bucket.prunedBelowScreenCount
+               << " prunedTransposition=" << bucket.prunedTranspositionCount << "\n";
     }
 
     return stream.str();
@@ -1162,6 +1174,7 @@ void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
     size_t prunedStalledCount = 0u;
     size_t prunedVelocityStuckCount = 0u;
     size_t prunedBelowScreenCount = 0u;
+    size_t prunedTranspositionCount = 0u;
     size_t backtrackedCount = 0u;
     size_t groundedVerticalJumpPriorityActionCount = 0u;
     for (const auto& entry : trace) {
@@ -1188,6 +1201,9 @@ void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
             case SmbDfsSearchTraceEventType::PrunedBelowScreen:
                 prunedBelowScreenCount++;
                 break;
+            case SmbDfsSearchTraceEventType::PrunedTransposition:
+                prunedTranspositionCount++;
+                break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
             case SmbDfsSearchTraceEventType::CompletedMilestoneReached:
@@ -1202,6 +1218,7 @@ void printTraceSummary(const std::vector<SmbDfsSearchTraceEntry>& trace)
               << " prunedStalled=" << prunedStalledCount
               << " prunedVelocityStuck=" << prunedVelocityStuckCount
               << " prunedBelowScreen=" << prunedBelowScreenCount
+              << " prunedTransposition=" << prunedTranspositionCount
               << " groundedVerticalJumpPriorityAction=" << groundedVerticalJumpPriorityActionCount
               << " backtracked=" << backtrackedCount << "\n";
 }
@@ -1553,7 +1570,8 @@ TEST(SmbDfsSearchTest, PrunesAndBacktracksHazardBranches)
             sawPrune |= entry.eventType == SmbDfsSearchTraceEventType::PrunedDead
                 || entry.eventType == SmbDfsSearchTraceEventType::PrunedStalled
                 || entry.eventType == SmbDfsSearchTraceEventType::PrunedVelocityStuck
-                || entry.eventType == SmbDfsSearchTraceEventType::PrunedBelowScreen;
+                || entry.eventType == SmbDfsSearchTraceEventType::PrunedBelowScreen
+                || entry.eventType == SmbDfsSearchTraceEventType::PrunedTransposition;
             sawBacktrack |= entry.eventType == SmbDfsSearchTraceEventType::Backtracked;
         }
 
@@ -1660,6 +1678,7 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
     size_t prunedDeadCount = 0;
     size_t prunedStalledCount = 0;
     size_t prunedBelowScreenCount = 0;
+    size_t prunedTranspositionCount = 0;
     size_t backtrackedCount = 0;
     for (const auto& entry : search.getTrace()) {
         if (entry.eventType == SmbDfsSearchTraceEventType::ExpandedAlive) {
@@ -1677,6 +1696,9 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
         else if (entry.eventType == SmbDfsSearchTraceEventType::PrunedBelowScreen) {
             prunedBelowScreenCount++;
         }
+        else if (entry.eventType == SmbDfsSearchTraceEventType::PrunedTransposition) {
+            prunedTranspositionCount++;
+        }
         else if (entry.eventType == SmbDfsSearchTraceEventType::Backtracked) {
             backtrackedCount++;
         }
@@ -1684,6 +1706,7 @@ TEST(SmbDfsSearchTest, FindsPlanToFirstGap)
     std::cout << "Trace: expanded=" << expandedCount << " prunedDead=" << prunedDeadCount
               << " prunedStalled=" << prunedStalledCount
               << " prunedBelowScreen=" << prunedBelowScreenCount
+              << " prunedTransposition=" << prunedTranspositionCount
               << " backtracked=" << backtrackedCount << "\n";
 
     ASSERT_TRUE(search.hasPersistablePlan());
@@ -2476,6 +2499,56 @@ TEST(SmbDfsSearchTest, BelowScreenPruningProducesDedicatedTraceEvent)
                   << " playerYScreen=" << static_cast<uint32_t>(state.playerYScreen)
                   << " lifeState=" << static_cast<uint32_t>(state.lifeState) << "\n";
     }
+}
+
+TEST(SmbDfsSearchTest, FallingTranspositionPruningProducesDedicatedTraceEvent)
+{
+    REQUIRE_SMB_ROM_OR_SKIP();
+
+    SmbSearchHarness harness;
+    const auto fixtureResult = harness.captureFixture(SmbSearchRootFixtureId::FlatGroundSanity);
+    ASSERT_FALSE(fixtureResult.isError()) << fixtureResult.errorValue();
+
+    SmbDfsSearch search(
+        SmbDfsSearchOptions{
+            .maxSearchedNodeCount = 1500u,
+            .stallFrameLimit = 120u,
+            .velocityPruningEnabled = true,
+            .belowScreenPruningEnabled = true,
+            .fallingTranspositionPruningEnabled = true,
+        });
+    const auto startResult = search.startFromFixture(fixtureResult.value());
+    ASSERT_FALSE(startResult.isError()) << startResult.errorValue();
+
+    std::optional<SmbDfsSearchTraceEntry> firstTranspositionPrune;
+    size_t traceCursor = 0u;
+    for (size_t tickIndex = 0; tickIndex < 1200u && !search.isCompleted(); ++tickIndex) {
+        const auto tickResult = search.tick();
+        ASSERT_FALSE(tickResult.error.has_value()) << tickResult.error.value();
+
+        const auto& trace = search.getTrace();
+        for (; traceCursor < trace.size(); ++traceCursor) {
+            if (trace[traceCursor].eventType == SmbDfsSearchTraceEventType::PrunedTransposition) {
+                firstTranspositionPrune = trace[traceCursor];
+                break;
+            }
+        }
+
+        if (firstTranspositionPrune.has_value()) {
+            break;
+        }
+    }
+
+    ASSERT_TRUE(firstTranspositionPrune.has_value());
+    EXPECT_EQ(
+        search.getProgress().lastSearchEvent,
+        DirtSim::Api::SearchProgressEvent::PrunedTransposition);
+    EXPECT_GT(firstTranspositionPrune->nodeIndex, 0u);
+    EXPECT_GT(firstTranspositionPrune->gameplayFrame, 0u);
+    EXPECT_GT(firstTranspositionPrune->framesSinceProgress, 0u);
+    std::cout << "First falling transposition prune at node " << firstTranspositionPrune->nodeIndex
+              << " frame " << firstTranspositionPrune->gameplayFrame << " frontier "
+              << firstTranspositionPrune->frontier << "\n";
 }
 
 TEST(SmbDfsSearchTest, LegalActionOrderRightRunFirst)

--- a/apps/src/server/tests/SmbDfsSearch_test.cpp
+++ b/apps/src/server/tests/SmbDfsSearch_test.cpp
@@ -10,8 +10,10 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -44,6 +46,30 @@ struct NodePathStats {
 };
 
 using NodePathStatsMap = std::unordered_map<size_t, NodePathStats>;
+
+std::vector<uint32_t> parseUint32ListEnv(
+    const char* variableName, const std::vector<uint32_t>& defaultValues)
+{
+    const char* rawValue = std::getenv(variableName);
+    if (rawValue == nullptr || rawValue[0] == '\0') {
+        return defaultValues;
+    }
+
+    std::vector<uint32_t> values;
+    std::stringstream stream(rawValue);
+    std::string token;
+    while (std::getline(stream, token, ',')) {
+        std::stringstream tokenStream(token);
+        uint32_t value = 0u;
+        tokenStream >> value;
+        if (tokenStream.fail()) {
+            return defaultValues;
+        }
+        values.push_back(value);
+    }
+
+    return values.empty() ? defaultValues : values;
+}
 
 // PNG screenshot helpers (from NesSuperMarioBrosRamProbe_test.cpp).
 
@@ -430,6 +456,25 @@ struct WindowStats {
     size_t prunedTranspositionCount = 0;
 };
 
+struct TraceEventStats {
+    size_t backtrackedCount = 0u;
+    size_t expandedAliveCount = 0u;
+    size_t prunedDeadCount = 0u;
+    size_t prunedStalledCount = 0u;
+    size_t prunedVelocityStuckCount = 0u;
+    size_t prunedBelowScreenCount = 0u;
+    size_t prunedBelowScreenAtBestFrontierCount = 0u;
+    size_t prunedBelowScreenAtBestFrontierFreshProgressCount = 0u;
+    size_t prunedBelowScreenFreshProgressCount = 0u;
+    size_t prunedTranspositionCount = 0u;
+    size_t prunedTranspositionAtBestFrontierCount = 0u;
+    uint64_t maxFramesSinceProgress = 0u;
+    uint64_t maxGameplayFrame = 0u;
+    uint64_t prunedBelowScreenMaxFramesSinceProgress = 0u;
+    std::optional<SmbDfsSearchTraceEntry> firstBelowScreenPrune = std::nullopt;
+    std::optional<SmbDfsSearchTraceEntry> firstTranspositionPrune = std::nullopt;
+};
+
 WindowStats computeWindowStats(
     const std::vector<SmbDfsSearchTraceEntry>& trace, uint64_t minFrontier, uint64_t maxFrontier)
 {
@@ -460,6 +505,72 @@ WindowStats computeWindowStats(
                 break;
             case SmbDfsSearchTraceEventType::PrunedTransposition:
                 stats.prunedTranspositionCount++;
+                break;
+            case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
+            case SmbDfsSearchTraceEventType::CompletedExhausted:
+            case SmbDfsSearchTraceEventType::CompletedMilestoneReached:
+            case SmbDfsSearchTraceEventType::Error:
+            case SmbDfsSearchTraceEventType::RootInitialized:
+            case SmbDfsSearchTraceEventType::Stopped:
+                break;
+        }
+    }
+
+    return stats;
+}
+
+TraceEventStats computeTraceEventStats(
+    const std::vector<SmbDfsSearchTraceEntry>& trace, uint64_t bestFrontier)
+{
+    TraceEventStats stats;
+    for (const auto& entry : trace) {
+        if (isCreationEvent(entry.eventType)) {
+            stats.maxFramesSinceProgress =
+                std::max(stats.maxFramesSinceProgress, entry.framesSinceProgress);
+            stats.maxGameplayFrame = std::max(stats.maxGameplayFrame, entry.gameplayFrame);
+        }
+
+        switch (entry.eventType) {
+            case SmbDfsSearchTraceEventType::Backtracked:
+                stats.backtrackedCount++;
+                break;
+            case SmbDfsSearchTraceEventType::ExpandedAlive:
+                stats.expandedAliveCount++;
+                break;
+            case SmbDfsSearchTraceEventType::PrunedDead:
+                stats.prunedDeadCount++;
+                break;
+            case SmbDfsSearchTraceEventType::PrunedStalled:
+                stats.prunedStalledCount++;
+                break;
+            case SmbDfsSearchTraceEventType::PrunedVelocityStuck:
+                stats.prunedVelocityStuckCount++;
+                break;
+            case SmbDfsSearchTraceEventType::PrunedBelowScreen:
+                stats.prunedBelowScreenCount++;
+                stats.prunedBelowScreenMaxFramesSinceProgress = std::max(
+                    stats.prunedBelowScreenMaxFramesSinceProgress, entry.framesSinceProgress);
+                if (entry.framesSinceProgress == 0u) {
+                    stats.prunedBelowScreenFreshProgressCount++;
+                }
+                if (entry.frontier == bestFrontier) {
+                    stats.prunedBelowScreenAtBestFrontierCount++;
+                    if (entry.framesSinceProgress == 0u) {
+                        stats.prunedBelowScreenAtBestFrontierFreshProgressCount++;
+                    }
+                }
+                if (!stats.firstBelowScreenPrune.has_value()) {
+                    stats.firstBelowScreenPrune = entry;
+                }
+                break;
+            case SmbDfsSearchTraceEventType::PrunedTransposition:
+                stats.prunedTranspositionCount++;
+                if (entry.frontier == bestFrontier) {
+                    stats.prunedTranspositionAtBestFrontierCount++;
+                }
+                if (!stats.firstTranspositionPrune.has_value()) {
+                    stats.firstTranspositionPrune = entry;
+                }
                 break;
             case SmbDfsSearchTraceEventType::CompletedBudgetExceeded:
             case SmbDfsSearchTraceEventType::CompletedExhausted:
@@ -1912,6 +2023,90 @@ TEST(SmbDfsSearchTest, DISABLED_ReportFirstPitSearch)
     const auto bestLeafScreenshot = screenshotDir / "dfs_pit_best_leaf.png";
     writeScreenshotIfAvailable(
         search.getScenarioVideoFrame(), bestLeafScreenshot, "Pit best leaf screenshot");
+}
+
+TEST(SmbDfsSearchTest, DISABLED_ReportFirstPitTranspositionThresholdSweep)
+{
+    REQUIRE_SMB_ROM_OR_SKIP();
+
+    const std::vector<uint32_t> budgetValues =
+        parseUint32ListEnv("SMB_DFS_PIT_SWEEP_BUDGETS", { 10'000u });
+    const std::vector<uint32_t> thresholdValues =
+        parseUint32ListEnv("SMB_DFS_PIT_SWEEP_THRESHOLDS", { 216u, 208u, 200u, 192u });
+
+    printDiagnosticProgress("Capturing FlatGroundSanity fixture");
+    SmbSearchHarness harness;
+    const auto fixtureResult = harness.captureFixture(SmbSearchRootFixtureId::FlatGroundSanity);
+    ASSERT_FALSE(fixtureResult.isError()) << fixtureResult.errorValue();
+
+    std::cout << "budget,threshold,searched,trace,bestFrontier,planFrames,expanded,prunedDead,"
+                 "prunedBelowScreen,prunedTransposition,prunedVelocityStuck,backtracked,"
+                 "belowAtBestFrontier,belowAtBestFrontierFreshProgress,belowFreshProgress,"
+                 "belowMaxFramesSinceProgress,transpositionAtBestFrontier,"
+                 "maxGameplayFrame,maxFramesSinceProgress,firstTranspositionFrame,"
+                 "firstTranspositionFrontier,firstTranspositionFramesSinceProgress,"
+                 "firstBelowScreenFrame,firstBelowScreenFrontier,elapsedMs\n";
+    for (const uint32_t budget : budgetValues) {
+        for (const uint32_t thresholdValue : thresholdValues) {
+            ASSERT_LE(thresholdValue, 255u);
+
+            const uint8_t threshold = static_cast<uint8_t>(thresholdValue);
+            SmbDfsSearch search(
+                SmbDfsSearchOptions{
+                    .maxSearchedNodeCount = budget,
+                    .stallFrameLimit = 120u,
+                    .velocityPruningEnabled = true,
+                    .belowScreenPruningEnabled = true,
+                    .fallingTranspositionPruningEnabled = true,
+                    .fallingTranspositionPlayerYScreenThreshold = threshold,
+                });
+            const auto startResult = search.startFromFixture(fixtureResult.value());
+            ASSERT_FALSE(startResult.isError()) << startResult.errorValue();
+
+            const auto startTime = std::chrono::steady_clock::now();
+            const auto runResult = runSearchToCompletion(search, static_cast<size_t>(budget) * 3u);
+            const auto endTime = std::chrono::steady_clock::now();
+            ASSERT_FALSE(runResult.isError()) << runResult.errorValue();
+
+            const TraceEventStats stats =
+                computeTraceEventStats(search.getTrace(), search.getProgress().bestFrontier);
+            const auto elapsedMs =
+                std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+            const uint64_t firstTranspositionFrame = stats.firstTranspositionPrune.has_value()
+                ? stats.firstTranspositionPrune->gameplayFrame
+                : 0u;
+            const uint64_t firstTranspositionFrontier = stats.firstTranspositionPrune.has_value()
+                ? stats.firstTranspositionPrune->frontier
+                : 0u;
+            const uint64_t firstTranspositionFramesSinceProgress =
+                stats.firstTranspositionPrune.has_value()
+                ? stats.firstTranspositionPrune->framesSinceProgress
+                : 0u;
+            const uint64_t firstBelowScreenFrame = stats.firstBelowScreenPrune.has_value()
+                ? stats.firstBelowScreenPrune->gameplayFrame
+                : 0u;
+            const uint64_t firstBelowScreenFrontier = stats.firstBelowScreenPrune.has_value()
+                ? stats.firstBelowScreenPrune->frontier
+                : 0u;
+
+            std::cout << budget << "," << static_cast<uint32_t>(threshold) << ","
+                      << search.getProgress().searchedNodeCount << "," << search.getTrace().size()
+                      << "," << search.getProgress().bestFrontier << ","
+                      << search.getPlan().frames.size() << "," << stats.expandedAliveCount << ","
+                      << stats.prunedDeadCount << "," << stats.prunedBelowScreenCount << ","
+                      << stats.prunedTranspositionCount << "," << stats.prunedVelocityStuckCount
+                      << "," << stats.backtrackedCount << ","
+                      << stats.prunedBelowScreenAtBestFrontierCount << ","
+                      << stats.prunedBelowScreenAtBestFrontierFreshProgressCount << ","
+                      << stats.prunedBelowScreenFreshProgressCount << ","
+                      << stats.prunedBelowScreenMaxFramesSinceProgress << ","
+                      << stats.prunedTranspositionAtBestFrontierCount << ","
+                      << stats.maxGameplayFrame << "," << stats.maxFramesSinceProgress << ","
+                      << firstTranspositionFrame << "," << firstTranspositionFrontier << ","
+                      << firstTranspositionFramesSinceProgress << "," << firstBelowScreenFrame
+                      << "," << firstBelowScreenFrontier << "," << elapsedMs << "\n";
+        }
+    }
 }
 
 TEST(SmbDfsSearchTest, DISABLED_ReportFirstPipeSearch)

--- a/apps/src/server/tests/UserSettings_test.cpp
+++ b/apps/src/server/tests/UserSettings_test.cpp
@@ -57,6 +57,7 @@ TEST(UserSettingsTest, MissingFileLoadsDefaultsAndWritesFile)
     EXPECT_DOUBLE_EQ(inMemory.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(inMemory.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(inMemory.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(inMemory.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_EQ(inMemory.volumePercent, 20);
     EXPECT_EQ(inMemory.defaultScenario, Scenario::EnumType::Sandbox);
     EXPECT_EQ(inMemory.startMenuIdleTimeoutMs, 60000);
@@ -69,6 +70,7 @@ TEST(UserSettingsTest, MissingFileLoadsDefaultsAndWritesFile)
     EXPECT_DOUBLE_EQ(fromDisk.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(fromDisk.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(fromDisk.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(fromDisk.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_EQ(fromDisk.volumePercent, 20);
     EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Sandbox);
     EXPECT_EQ(fromDisk.startMenuIdleTimeoutMs, 60000);
@@ -159,6 +161,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_DOUBLE_EQ(inMemory.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(inMemory.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(inMemory.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(inMemory.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_TRUE(inMemory.searchSettings.belowScreenPruningEnabled);
     EXPECT_TRUE(inMemory.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_TRUE(inMemory.searchSettings.velocityPruningEnabled);
@@ -175,6 +178,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_DOUBLE_EQ(fromDisk.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(fromDisk.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(fromDisk.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(fromDisk.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_TRUE(fromDisk.searchSettings.belowScreenPruningEnabled);
     EXPECT_TRUE(fromDisk.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_TRUE(fromDisk.searchSettings.velocityPruningEnabled);
@@ -196,6 +200,7 @@ TEST(UserSettingsTest, LoadingLegacySettingsBackfillsDefaultsAndStripsUnknownFie
     EXPECT_TRUE(canonicalJson["searchSettings"].contains("belowScreenPruningEnabled"));
     EXPECT_TRUE(
         canonicalJson["searchSettings"].contains("groundedVerticalJumpPrioritizationEnabled"));
+    EXPECT_TRUE(canonicalJson["searchSettings"].contains("planPlaybackFrameDelayMs"));
     EXPECT_TRUE(canonicalJson.contains("trainingResumePolicy"));
     EXPECT_TRUE(canonicalJson.contains("treeGerminationScenarioConfig"));
     EXPECT_TRUE(canonicalJson["nesSessionSettings"].contains("frameDelayMs"));
@@ -229,6 +234,7 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     requestedSettings.searchSettings = SearchSettings{
         .maxSearchedNodeCount = 0u,
         .stallFrameLimit = 999u,
+        .planPlaybackFrameDelayMs = 999999u,
         .velocityPruningEnabled = false,
         .belowScreenPruningEnabled = false,
         .groundedVerticalJumpPrioritizationEnabled = false,
@@ -268,6 +274,9 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(
         response.value().settings.searchSettings.stallFrameLimit,
         SearchSettings::StallFrameLimitMax);
+    EXPECT_EQ(
+        response.value().settings.searchSettings.planPlaybackFrameDelayMs,
+        SearchSettings::PlanPlaybackFrameDelayMsMax);
     EXPECT_FALSE(response.value().settings.searchSettings.belowScreenPruningEnabled);
     EXPECT_FALSE(
         response.value().settings.searchSettings.groundedVerticalJumpPrioritizationEnabled);
@@ -292,6 +301,9 @@ TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
     EXPECT_EQ(
         fromDisk.searchSettings.maxSearchedNodeCount, SearchSettings::MaxSearchedNodeCountMin);
     EXPECT_EQ(fromDisk.searchSettings.stallFrameLimit, SearchSettings::StallFrameLimitMax);
+    EXPECT_EQ(
+        fromDisk.searchSettings.planPlaybackFrameDelayMs,
+        SearchSettings::PlanPlaybackFrameDelayMsMax);
     EXPECT_FALSE(fromDisk.searchSettings.belowScreenPruningEnabled);
     EXPECT_FALSE(fromDisk.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_FALSE(fromDisk.searchSettings.velocityPruningEnabled);
@@ -318,6 +330,7 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
     changedSettings.searchSettings = SearchSettings{
         .maxSearchedNodeCount = 10000u,
         .stallFrameLimit = 60u,
+        .planPlaybackFrameDelayMs = 17u,
         .velocityPruningEnabled = false,
         .belowScreenPruningEnabled = false,
         .groundedVerticalJumpPrioritizationEnabled = false,
@@ -350,6 +363,7 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
     EXPECT_DOUBLE_EQ(response.value().settings.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(response.value().settings.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(response.value().settings.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(response.value().settings.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_TRUE(response.value().settings.searchSettings.belowScreenPruningEnabled);
     EXPECT_TRUE(response.value().settings.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_TRUE(response.value().settings.searchSettings.velocityPruningEnabled);
@@ -365,6 +379,7 @@ TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
     EXPECT_DOUBLE_EQ(fromDisk.nesSessionSettings.frameDelayMs, 0.0);
     EXPECT_EQ(fromDisk.searchSettings.maxSearchedNodeCount, 5000u);
     EXPECT_EQ(fromDisk.searchSettings.stallFrameLimit, 30u);
+    EXPECT_EQ(fromDisk.searchSettings.planPlaybackFrameDelayMs, 0u);
     EXPECT_TRUE(fromDisk.searchSettings.belowScreenPruningEnabled);
     EXPECT_TRUE(fromDisk.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_TRUE(fromDisk.searchSettings.velocityPruningEnabled);
@@ -385,6 +400,7 @@ TEST(UserSettingsTest, UserSettingsPatchMergesAndPersists)
     baseSettings.searchSettings = SearchSettings{
         .maxSearchedNodeCount = 8000u,
         .stallFrameLimit = 50u,
+        .planPlaybackFrameDelayMs = 16u,
         .velocityPruningEnabled = true,
         .belowScreenPruningEnabled = true,
         .groundedVerticalJumpPrioritizationEnabled = true,
@@ -413,6 +429,7 @@ TEST(UserSettingsTest, UserSettingsPatchMergesAndPersists)
     patchCommand.searchSettings = SearchSettings{
         .maxSearchedNodeCount = 999999u,
         .stallFrameLimit = 999u,
+        .planPlaybackFrameDelayMs = 999999u,
         .velocityPruningEnabled = false,
         .belowScreenPruningEnabled = false,
         .groundedVerticalJumpPrioritizationEnabled = false,
@@ -437,6 +454,9 @@ TEST(UserSettingsTest, UserSettingsPatchMergesAndPersists)
     EXPECT_EQ(
         inMemory.searchSettings.maxSearchedNodeCount, SearchSettings::MaxSearchedNodeCountMax);
     EXPECT_EQ(inMemory.searchSettings.stallFrameLimit, SearchSettings::StallFrameLimitMax);
+    EXPECT_EQ(
+        inMemory.searchSettings.planPlaybackFrameDelayMs,
+        SearchSettings::PlanPlaybackFrameDelayMsMax);
     EXPECT_FALSE(inMemory.searchSettings.belowScreenPruningEnabled);
     EXPECT_FALSE(inMemory.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_FALSE(inMemory.searchSettings.velocityPruningEnabled);
@@ -456,6 +476,9 @@ TEST(UserSettingsTest, UserSettingsPatchMergesAndPersists)
     EXPECT_EQ(
         fromDisk.searchSettings.maxSearchedNodeCount, SearchSettings::MaxSearchedNodeCountMax);
     EXPECT_EQ(fromDisk.searchSettings.stallFrameLimit, SearchSettings::StallFrameLimitMax);
+    EXPECT_EQ(
+        fromDisk.searchSettings.planPlaybackFrameDelayMs,
+        SearchSettings::PlanPlaybackFrameDelayMsMax);
     EXPECT_FALSE(fromDisk.searchSettings.belowScreenPruningEnabled);
     EXPECT_FALSE(fromDisk.searchSettings.groundedVerticalJumpPrioritizationEnabled);
     EXPECT_FALSE(fromDisk.searchSettings.velocityPruningEnabled);

--- a/apps/src/ui/controls/SearchSettingsPanel.cpp
+++ b/apps/src/ui/controls/SearchSettingsPanel.cpp
@@ -30,6 +30,10 @@ SearchSettings clampSearchSettings(const SearchSettings& settings)
             static_cast<int32_t>(settings.stallFrameLimit),
             SearchSettings::StallFrameLimitMin,
             SearchSettings::StallFrameLimitMax),
+        .planPlaybackFrameDelayMs = clampStepperValue(
+            static_cast<int32_t>(settings.planPlaybackFrameDelayMs),
+            0u,
+            SearchSettings::PlanPlaybackFrameDelayMsMax),
         .velocityPruningEnabled = settings.velocityPruningEnabled,
         .belowScreenPruningEnabled = settings.belowScreenPruningEnabled,
         .groundedVerticalJumpPrioritizationEnabled =
@@ -65,6 +69,11 @@ void SearchSettingsPanel::applySettings(const DirtSim::UserSettings& settings)
         LVGLBuilder::ActionStepperBuilder::setValue(
             stallFrameLimitStepper_,
             static_cast<int32_t>(settings_.searchSettings.stallFrameLimit));
+    }
+    if (planPlaybackFrameDelayStepper_) {
+        LVGLBuilder::ActionStepperBuilder::setValue(
+            planPlaybackFrameDelayStepper_,
+            static_cast<int32_t>(settings_.searchSettings.planPlaybackFrameDelayMs));
     }
     if (velocityPruningSwitch_) {
         if (settings_.searchSettings.velocityPruningEnabled) {
@@ -128,6 +137,16 @@ void SearchSettingsPanel::createControls()
             .value(static_cast<int32_t>(settings_.searchSettings.stallFrameLimit))
             .width(kPanelControlWidth)
             .callback(onStallFrameLimitChanged, this)
+            .buildOrLog();
+
+    planPlaybackFrameDelayStepper_ =
+        LVGLBuilder::actionStepper(container_)
+            .label("Plan Playback Delay (ms)")
+            .range(0, static_cast<int32_t>(SearchSettings::PlanPlaybackFrameDelayMsMax))
+            .step(1)
+            .value(static_cast<int32_t>(settings_.searchSettings.planPlaybackFrameDelayMs))
+            .width(kPanelControlWidth)
+            .callback(onPlanPlaybackFrameDelayChanged, this)
             .buildOrLog();
 
     velocityPruningSwitch_ = LVGLBuilder::labeledSwitch(container_)
@@ -196,6 +215,21 @@ void SearchSettingsPanel::onStallFrameLimitChanged(lv_event_t* e)
         LVGLBuilder::ActionStepperBuilder::getValue(self->stallFrameLimitStepper_),
         SearchSettings::StallFrameLimitMin,
         SearchSettings::StallFrameLimitMax);
+    self->patchCurrentSettings();
+}
+
+void SearchSettingsPanel::onPlanPlaybackFrameDelayChanged(lv_event_t* e)
+{
+    auto* self = static_cast<SearchSettingsPanel*>(lv_event_get_user_data(e));
+    DIRTSIM_ASSERT(self, "SearchSettingsPanel plan-playback-delay callback requires panel");
+    if (self->updatingUi_) {
+        return;
+    }
+
+    self->settings_.searchSettings.planPlaybackFrameDelayMs = clampStepperValue(
+        LVGLBuilder::ActionStepperBuilder::getValue(self->planPlaybackFrameDelayStepper_),
+        0u,
+        SearchSettings::PlanPlaybackFrameDelayMsMax);
     self->patchCurrentSettings();
 }
 

--- a/apps/src/ui/controls/SearchSettingsPanel.h
+++ b/apps/src/ui/controls/SearchSettingsPanel.h
@@ -21,6 +21,7 @@ private:
     void patchCurrentSettings();
 
     static void onMaxSearchedNodeCountChanged(lv_event_t* e);
+    static void onPlanPlaybackFrameDelayChanged(lv_event_t* e);
     static void onStallFrameLimitChanged(lv_event_t* e);
     static void onVelocityPruningChanged(lv_event_t* e);
     static void onBelowScreenPruningChanged(lv_event_t* e);
@@ -28,6 +29,7 @@ private:
 
     lv_obj_t* container_ = nullptr;
     lv_obj_t* maxSearchedNodeCountStepper_ = nullptr;
+    lv_obj_t* planPlaybackFrameDelayStepper_ = nullptr;
     lv_obj_t* stallFrameLimitStepper_ = nullptr;
     lv_obj_t* velocityPruningSwitch_ = nullptr;
     lv_obj_t* belowScreenPruningSwitch_ = nullptr;

--- a/apps/src/ui/state-machine/states/SearchActive.cpp
+++ b/apps/src/ui/state-machine/states/SearchActive.cpp
@@ -53,6 +53,8 @@ const char* searchProgressEventText(Api::SearchProgressEvent event)
             return "Pruned velocity";
         case Api::SearchProgressEvent::PrunedBelowScreen:
             return "Pruned below";
+        case Api::SearchProgressEvent::PrunedTransposition:
+            return "Pruned transposition";
         case Api::SearchProgressEvent::CompletedBudgetExceeded:
             return "Budget hit";
         case Api::SearchProgressEvent::CompletedExhausted:

--- a/apps/src/ui/state-machine/states/SearchActive.cpp
+++ b/apps/src/ui/state-machine/states/SearchActive.cpp
@@ -55,6 +55,8 @@ const char* searchProgressEventText(Api::SearchProgressEvent event)
             return "Pruned below";
         case Api::SearchProgressEvent::PrunedTransposition:
             return "Pruned transposition";
+        case Api::SearchProgressEvent::PrunedNonGameplay:
+            return "Pruned mode";
         case Api::SearchProgressEvent::CompletedBudgetExceeded:
             return "Budget hit";
         case Api::SearchProgressEvent::CompletedExhausted:

--- a/apps/src/ui/state-machine/tests/StateTraining_test.cpp
+++ b/apps/src/ui/state-machine/tests/StateTraining_test.cpp
@@ -712,6 +712,7 @@ TEST(StateTrainingTest, SearchSettingsPanelPreservesPruningSwitchesWhenPersistin
     };
     settingsOkay.settings.searchSettings.maxSearchedNodeCount = 12000u;
     settingsOkay.settings.searchSettings.stallFrameLimit = 45u;
+    settingsOkay.settings.searchSettings.planPlaybackFrameDelayMs = 17u;
     settingsOkay.settings.searchSettings.velocityPruningEnabled = false;
     settingsOkay.settings.searchSettings.belowScreenPruningEnabled = false;
     settingsOkay.settings.searchSettings.groundedVerticalJumpPrioritizationEnabled = false;
@@ -737,6 +738,9 @@ TEST(StateTrainingTest, SearchSettingsPanelPreservesPruningSwitchesWhenPersistin
     EXPECT_EQ(
         sentCommand.searchSettings->stallFrameLimit,
         settingsOkay.settings.searchSettings.stallFrameLimit);
+    EXPECT_EQ(
+        sentCommand.searchSettings->planPlaybackFrameDelayMs,
+        settingsOkay.settings.searchSettings.planPlaybackFrameDelayMs);
     EXPECT_FALSE(sentCommand.searchSettings->velocityPruningEnabled);
     EXPECT_FALSE(sentCommand.searchSettings->belowScreenPruningEnabled);
     EXPECT_FALSE(sentCommand.searchSettings->groundedVerticalJumpPrioritizationEnabled);
@@ -746,6 +750,9 @@ TEST(StateTrainingTest, SearchSettingsPanelPreservesPruningSwitchesWhenPersistin
         localSettings.maxSearchedNodeCount,
         settingsOkay.settings.searchSettings.maxSearchedNodeCount);
     EXPECT_EQ(localSettings.stallFrameLimit, settingsOkay.settings.searchSettings.stallFrameLimit);
+    EXPECT_EQ(
+        localSettings.planPlaybackFrameDelayMs,
+        settingsOkay.settings.searchSettings.planPlaybackFrameDelayMs);
     EXPECT_FALSE(localSettings.velocityPruningEnabled);
     EXPECT_FALSE(localSettings.belowScreenPruningEnabled);
     EXPECT_FALSE(localSettings.groundedVerticalJumpPrioritizationEnabled);

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,7 +279,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -644,7 +643,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",


### PR DESCRIPTION
## Summary
- add late descending jump rescue ordering for SMB DFS
- add scoped falling and closed-loss transposition pruning with RAM/motion signatures
- add SMB motion diagnostics, sweep coverage, and search/playback settings for live testing

## Notes
- branch includes the pushed plan playback frame delay setting
- branch also includes the package-lock change from commit `3ee51131 lock`

## Validation
- not run during PR creation